### PR TITLE
Namespaces for tags and attributes

### DIFF
--- a/src/main/scala/outwatch/dom/Handlers.scala
+++ b/src/main/scala/outwatch/dom/Handlers.scala
@@ -23,3 +23,5 @@ trait Handlers {
     Sink.createHandler[T](defaultValues: _*)
   }
 }
+
+object Handlers extends Handlers

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -4,8 +4,7 @@ package object dom extends Handlers
 {
   object all extends Tags with Attributes
 
-  object < extends Tags
+  object T extends Tags
 
-  object ^ extends Attributes
-
+  object A extends Attributes
 }

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -1,3 +1,13 @@
 package outwatch
 
-package object dom extends Attributes with Tags with Handlers
+package object dom extends Handlers
+{
+  object all extends Tags with Attributes
+
+  object <^ {
+    object < extends Tags
+    object ^ extends Attributes
+  }
+
+  object Handlers extends Handlers
+}

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -8,6 +8,4 @@ package object dom extends Handlers
     object < extends Tags
     object ^ extends Attributes
   }
-
-  object Handlers extends Handlers
 }

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -4,8 +4,8 @@ package object dom extends Handlers
 {
   object all extends Tags with Attributes
 
-  object <^ {
-    object < extends Tags
-    object ^ extends Attributes
-  }
+  object < extends Tags
+
+  object ^ extends Attributes
+
 }

--- a/src/test/scala/outwatch/AttributeSpec.scala
+++ b/src/test/scala/outwatch/AttributeSpec.scala
@@ -1,6 +1,6 @@
 package outwatch
 
-import outwatch.dom._
+import outwatch.dom.all._
 
 class AttributeSpec extends UnitSpec {
 

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -102,7 +102,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   }
 
   it should "be able to set the value of a text field" in {
-    import outwatch.dom.<^.{< => tag, ^}
+    import outwatch.dom.{< => tag, ^}
 
     val values = Subject[String]
 
@@ -244,7 +244,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
     OutWatch.render("#app", node)
 
     val inputEvt = document.createEvent("HTMLEvents")
-    inputEvt.initEvent("input", false, true)
+    inputEvt initEvent("input", false, true)
 
 
     document.getElementById("input").dispatchEvent(inputEvt)

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -102,11 +102,10 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   }
 
   it should "be able to set the value of a text field" in {
-    import outwatch.dom.{< => tag, ^}
 
     val values = Subject[String]
 
-    val vtree = tag.input(^.id:= "input", ^.value <-- values)
+    val vtree = T.input(A.id:= "input", A.value <-- values)
 
     OutWatch.render("#app", vtree)
 

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -5,6 +5,7 @@ import org.scalajs.dom.raw.{HTMLInputElement, MouseEvent}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.prop.PropertyChecks
 import rxscalajs.Subject
+import outwatch.dom._
 
 class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks {
 
@@ -19,7 +20,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   }
 
   "EventStreams" should "emit and receive events correctly" in {
-    import outwatch.dom._
+    import outwatch.dom.all._
     val observable = createMouseHandler()
     val buttonDisabled = observable.mapTo(true).startWith(false)
     val vtree = div(id :="click", click --> observable,
@@ -39,36 +40,35 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   }
 
   it should "be converted to a generic emitter correctly" in {
-    import outwatch.dom._
+    import outwatch.dom.all._
 
+    val observable = createStringHandler()
 
-        val observable = createStringHandler()
+    val message = "ad"
+    val vtree = div(id := "click", click(message) --> observable,
+      span(id := "child", child <-- observable)
+    )
 
-        val message = "ad"
-        val vtree = div(id := "click", click(message) --> observable,
-          span(id := "child", child <-- observable)
-        )
+    OutWatch.render("#app", vtree)
 
-        OutWatch.render("#app", vtree)
+    document.getElementById("child").innerHTML shouldBe ""
 
-        document.getElementById("child").innerHTML shouldBe ""
+    val event = document.createEvent("Events")
+    event.initEvent("click", canBubbleArg = true, cancelableArg = false)
+    document.getElementById("click").dispatchEvent(event)
 
-        val event = document.createEvent("Events")
-        event.initEvent("click", canBubbleArg = true, cancelableArg = false)
-        document.getElementById("click").dispatchEvent(event)
+    document.getElementById("child").innerHTML shouldBe message
 
-        document.getElementById("child").innerHTML shouldBe message
+    //dispatch another event
+    document.getElementById("click").dispatchEvent(event)
 
-        //dispatch another event
-        document.getElementById("click").dispatchEvent(event)
-
-        document.getElementById("child").innerHTML shouldBe message
+    document.getElementById("child").innerHTML shouldBe message
 
 
   }
 
   it should "be converted to a generic stream emitter correctly" in {
-    import outwatch.dom._
+    import outwatch.dom.all._
     val stream = createStringHandler()
     val messages = createStringHandler()
     val vtree = div(id :="click", click(messages) --> stream,
@@ -102,11 +102,11 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   }
 
   it should "be able to set the value of a text field" in {
-    import outwatch.dom._
+    import outwatch.dom.<^.{< => tag, ^}
 
     val values = Subject[String]
 
-    val vtree = input(id:= "input", outwatch.dom.value <-- values)
+    val vtree = tag.input(^.id:= "input", ^.value <-- values)
 
     OutWatch.render("#app", vtree)
 
@@ -130,7 +130,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   }
 
   it should "be bindable to a list of children" in {
-    import outwatch.dom._
+    import outwatch.dom.all._
 
 
     val state = Subject[Seq[VNode]]
@@ -177,7 +177,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   }
 
   it should "be able to handle two events of the same type" in {
-    import outwatch.dom._
+    import outwatch.dom.all._
 
 
     val first = createStringHandler()
@@ -205,7 +205,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   }
 
   it should "be able to be transformed by a function in place" in {
-    import outwatch.dom._
+    import outwatch.dom.all._
 
     val stream = createHandler[(MouseEvent, Int)]()
 
@@ -230,7 +230,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   }
 
   it should "be able to be transformed from strings" in {
-    import outwatch.dom._
+    import outwatch.dom.all._
 
     val stream = createHandler[Int]()
 
@@ -253,7 +253,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   }
 
   it should "be able to toggle attributes with a boolean observer" in {
-    import outwatch.dom._
+    import outwatch.dom.all._
     import outwatch.util.SyntaxSugar._
 
     val stream = createBoolHandler()

--- a/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -3,6 +3,7 @@ package outwatch
 import org.scalajs.dom._
 import org.scalatest.BeforeAndAfterEach
 import outwatch.dom._
+import outwatch.dom.all._
 import rxscalajs.Observable
 
 class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -223,11 +223,10 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
   }
 
   it should "change the value of a textfield" in {
-    import outwatch.dom.^
 
     val messages = Subject[String]
     val vtree = div(
-      input(^.value <-- messages, id := "input")
+      input(A.value <-- messages, id := "input")
     )
 
     val node = document.createElement("div")

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -4,6 +4,7 @@ import org.scalajs.dom.raw.HTMLInputElement
 import org.scalatest.BeforeAndAfterEach
 import rxscalajs.{Observable, Subject}
 import snabbdom.{DataObject, h}
+import outwatch.dom.all._
 import outwatch.dom._
 import outwatch.dom.helpers._
 
@@ -222,11 +223,11 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
   }
 
   it should "change the value of a textfield" in {
-
+    import outwatch.dom.<^.^
 
     val messages = Subject[String]
     val vtree = div(
-      input(outwatch.dom.value <-- messages, id := "input")
+      input(^.value <-- messages, id := "input")
     )
 
     val node = document.createElement("div")

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -223,7 +223,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
   }
 
   it should "change the value of a textfield" in {
-    import outwatch.dom.<^.^
+    import outwatch.dom.^
 
     val messages = Subject[String]
     val vtree = div(

--- a/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -3,8 +3,8 @@ package outwatch
 import org.scalajs.dom._
 import org.scalajs.dom.raw.HTMLInputElement
 import org.scalatest.BeforeAndAfterEach
-import rxscalajs.{Observable, Subject}
 import outwatch.dom.helpers.DomUtils
+import outwatch.dom._
 
 class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
   override def afterEach(): Unit = {
@@ -16,7 +16,7 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
   }
 
   "A simple counter application" should "work as intended" in {
-    import outwatch.dom._
+    import outwatch.dom.all._
 
     val handlePlus = createMouseHandler()
     val plusOne$ = handlePlus.mapTo(1)
@@ -56,7 +56,7 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
   }
 
   "A simple name application" should "work as intended" in {
-    import outwatch.dom._
+    import outwatch.dom.all._
 
     val nameHandler = createStringHandler()
 
@@ -75,7 +75,7 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
 
 
     val evt = document.createEvent("HTMLEvents")
-    evt.initEvent("input", false, true)
+    evt.initEvent("input", canBubbleArg = false, cancelableArg = true)
     val name = "Luka"
 
     document.getElementById("input").asInstanceOf[HTMLInputElement].value = name
@@ -92,7 +92,7 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
   }
 
   "A todo application" should "work with components" in {
-    import outwatch.dom._
+    import outwatch.dom.all._
 
     def TodoComponent(title: String, deleteStream: Sink[String]) =
       li(
@@ -158,10 +158,10 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
     DomUtils.render(root, vtree)
 
     val inputEvt = document.createEvent("HTMLEvents")
-    inputEvt.initEvent("input", false, true)
+    inputEvt.initEvent("input", canBubbleArg = false, cancelableArg = true)
 
     val clickEvt = document.createEvent("Events")
-    clickEvt.initEvent("click", true, true)
+    clickEvt.initEvent("click", canBubbleArg = true, cancelableArg = true)
 
     val inputElement = document.getElementById("input").asInstanceOf[HTMLInputElement]
     val submitButton = document.getElementById("submit")

--- a/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -29,14 +29,13 @@ class SnabbdomSpec extends UnitSpec {
   }
 
   it should "correctly patch nodes with keys" in {
-    import outwatch.dom.{< => tag, _}
 
     val clicks = createHandler[Int](1)
     val nodes = clicks.map { i =>
-      tag.div(
-        ^.key := s"key-$i",
-        tag.span(^.click(if (i == 1) 2 else 1) --> clicks,  s"This is number $i", ^.id := "btn"),
-        tag.input(^.id := "input")
+      T.div(
+        A.key := s"key-$i",
+        T.span(A.click(if (i == 1) 2 else 1) --> clicks,  s"This is number $i", A.id := "btn"),
+        T.input(A.id := "input")
       )
     }
 
@@ -44,7 +43,7 @@ class SnabbdomSpec extends UnitSpec {
     node.id = "app"
     document.body.appendChild(node)
 
-    OutWatch.render("#app", tag.div(^.child <-- nodes))
+    OutWatch.render("#app", T.div(A.child <-- nodes))
 
     val inputEvt = document.createEvent("HTMLEvents")
     inputEvt.initEvent("input", false, true)

--- a/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -29,7 +29,7 @@ class SnabbdomSpec extends UnitSpec {
   }
 
   it should "correctly patch nodes with keys" in {
-    import outwatch.dom.<^.{< => tag, _}
+    import outwatch.dom.{< => tag, _}
 
     val clicks = createHandler[Int](1)
     val nodes = clicks.map { i =>

--- a/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -6,6 +6,8 @@ import scalajs.js
 import org.scalajs.dom.document
 import org.scalajs.dom.raw.HTMLInputElement
 
+import outwatch.dom._
+
 class SnabbdomSpec extends UnitSpec {
   "The Snabbdom Facade" should "correctly patch the DOM" in {
     val message = "Hello World"
@@ -27,14 +29,14 @@ class SnabbdomSpec extends UnitSpec {
   }
 
   it should "correctly patch nodes with keys" in {
-    import outwatch.dom._
+    import outwatch.dom.<^.{< => tag, _}
 
     val clicks = createHandler[Int](1)
     val nodes = clicks.map { i =>
-      div(
-        dom.key := s"key-$i",
-        span(click(if (i == 1) 2 else 1) --> clicks,  s"This is number $i", id := "btn"),
-        input(id := "input")
+      tag.div(
+        ^.key := s"key-$i",
+        tag.span(^.click(if (i == 1) 2 else 1) --> clicks,  s"This is number $i", ^.id := "btn"),
+        tag.input(^.id := "input")
       )
     }
 
@@ -42,7 +44,7 @@ class SnabbdomSpec extends UnitSpec {
     node.id = "app"
     document.body.appendChild(node)
 
-    OutWatch.render("#app", div(child <-- nodes))
+    OutWatch.render("#app", tag.div(^.child <-- nodes))
 
     val inputEvt = document.createEvent("HTMLEvents")
     inputEvt.initEvent("input", false, true)


### PR DESCRIPTION
An attempt at fixing #32.

Tags and attributes are imported namespaced by default with ```import outwatch.dom._``` and globally with ```import outwatch.dom.all._```.

Note, this will break most client code, it will require adding ```import outwatch.dom.all._``` to keep the same code working.