### PR TITLE
Fix Snabbdom patching issue

### DIFF
--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -45,8 +45,7 @@ object VDomModifier {
 
   final case class VTree(nodeType: String,
                    children: Seq[VNode],
-                   attributeObject: DataObject,
-                   changables: Observable[(Seq[Attribute], Seq[VNode])]
+                   attributeObject: DataObject
                   ) extends VNode {
 
 

--- a/src/main/scala/snabbdom/VDomProxy.scala
+++ b/src/main/scala/snabbdom/VDomProxy.scala
@@ -3,8 +3,8 @@ package snabbdom
 import org.scalajs.dom._
 import org.scalajs.dom.raw.HTMLInputElement
 import outwatch.dom._
-import outwatch.dom.helpers._
 import rxscalajs.Observer
+
 import scala.scalajs.js
 
 
@@ -13,9 +13,7 @@ object VDomProxy {
   import js.JSConverters._
 
   def attrsToSnabbDom(attributes: Seq[Attribute]): js.Dictionary[String] = {
-    attributes.map(attr => attr.title -> attr.value)
-      .toMap
-      .toJSDictionary
+    js.Dictionary(attributes.map(attr => attr.title -> attr.value): _*)
   }
 
 

--- a/src/main/scala/snabbdom/h.scala
+++ b/src/main/scala/snabbdom/h.scala
@@ -77,7 +77,7 @@ object DataObject {
       val attrs: Dictionary[String] = _attrs
       val on: Dictionary[js.Function1[Event, Unit]] = _on
       val hook: Hooks = _hook
-      val key: UndefOr[|[String, Int]] = _key
+      val key: UndefOr[String | Int] = _key
     }
   }
 

--- a/src/main/scala/snabbdom/h.scala
+++ b/src/main/scala/snabbdom/h.scala
@@ -4,7 +4,7 @@ import org.scalajs.dom._
 import org.scalajs.dom.raw.HTMLInputElement
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSImport
+import scala.scalajs.js.annotation.{JSImport, ScalaJSDefined}
 import scala.scalajs.js.|
 
 @js.native
@@ -24,52 +24,63 @@ object h {
   }
 }
 
-@js.native
+
+@ScalaJSDefined
 trait DataObject extends js.Object {
-  val attrs: js.Dictionary[String] = js.native
-  val on: js.Dictionary[js.Function1[Event ,Unit]] = js.native
-  val hook: js.Dynamic = js.native
+  val attrs: js.Dictionary[String]
+  val on: js.Dictionary[js.Function1[Event ,Unit]]
+  val hook: js.Dynamic
+  val key: js.UndefOr[String]
 }
 
 object DataObject {
-  def apply(attrs: js.Dictionary[String], on: js.Dictionary[js.Function1[Event,Unit]]): DataObject = {
-    js.Dynamic.literal(attrs = attrs, on = on, hook = js.Dynamic.literal()).asInstanceOf[DataObject]
+  def apply(_attrs: js.Dictionary[String],
+            _on: js.Dictionary[js.Function1[Event, Unit]]
+           ): DataObject = {
+    new DataObject {
+      val attrs = _attrs
+      val on = _on
+      val hook = js.Dynamic.literal()
+      val key = js.undefined
+    }
   }
 
-  def createWithHooks(attrs: js.Dictionary[String],
-                      on: js.Dictionary[js.Function1[Event,Unit]],
-                      insert: js.Function1[VNodeProxy,Unit],
-                      destroy: js.Function1[VNodeProxy,Unit],
+
+  def createWithHooks(_attrs: js.Dictionary[String],
+                      _on: js.Dictionary[js.Function1[Event, Unit]],
+                      insert: js.Function1[VNodeProxy, Unit],
+                      destroy: js.Function1[VNodeProxy, Unit],
                       update: js.Function2[VNodeProxy, VNodeProxy, Unit],
-                      key: js.UndefOr[String]): DataObject = {
-
-
-    js.Dynamic.literal(
-      attrs = attrs,
-      on = on,
-      hook = js.Dynamic.literal(insert = insert, destroy = destroy, update = update),
-      key = key
-    ).asInstanceOf[DataObject]
+                      _key: js.UndefOr[String]
+                     ): DataObject = {
+    new DataObject {
+      val attrs = _attrs
+      val on = _on
+      val hook = js.Dynamic.literal(insert = insert, destroy = destroy, update = update)
+      val key = _key
+    }
   }
 
-  def createWithValue(attrs: js.Dictionary[String],
-                      on: js.Dictionary[js.Function1[Event,Unit]],
-                      insert: js.Function1[VNodeProxy,Unit],
-                      destroy: js.Function1[VNodeProxy,Unit],
+
+  def createWithValue(_attrs: js.Dictionary[String],
+                      _on: js.Dictionary[js.Function1[Event, Unit]],
+                      insert: js.Function1[VNodeProxy, Unit],
+                      destroy: js.Function1[VNodeProxy, Unit],
                       update: js.Function2[VNodeProxy, VNodeProxy, Unit],
-                      key: js.UndefOr[String]): DataObject = {
+                      _key: js.UndefOr[String]
+                     ): DataObject = {
 
     val uHook: js.Function2[VNodeProxy, VNodeProxy, Unit] = (old: VNodeProxy, node: VNodeProxy) => {
       update(old, node)
       updateHook(old, node)
     }
 
-    js.Dynamic.literal(
-      attrs = attrs,
-      on = on,
-      hook = js.Dynamic.literal(insert = insert, destroy = destroy, update = uHook),
-      key = key
-    ).asInstanceOf[DataObject]
+    new DataObject {
+      val attrs = _attrs
+      val on = _on
+      val hook = js.Dynamic.literal(insert = insert, destroy = destroy, update = uHook)
+      val key = _key
+    }
   }
 
   lazy val updateHook: js.Function2[VNodeProxy, VNodeProxy, Unit] = (old: VNodeProxy, node: VNodeProxy) => {
@@ -84,8 +95,14 @@ object DataObject {
   def updateAttributes(obj: DataObject, attrs: Seq[(String, String)]): DataObject = {
     import scala.scalajs.js.JSConverters._
 
-    val newProps = (obj.attrs ++ attrs).toJSDictionary
-    js.Dynamic.literal(attrs = newProps, on = obj.on, hook = obj.hook).asInstanceOf[DataObject]
+    val newAttrs = (obj.attrs ++ attrs).toJSDictionary
+
+    new DataObject {
+      val attrs = newAttrs
+      val on = obj.on
+      val hook = obj.hook
+      val key = obj.key
+    }
   }
 }
 
@@ -96,7 +113,9 @@ object patch {
     SnabbdomAttributes.default,
     SnabbdomProps.default
   ))
-  def apply(firstNode: org.scalajs.dom.raw.Element | VNodeProxy, vNode: VNodeProxy) = p(firstNode,vNode)
+  def apply(firstNode: VNodeProxy, vNode: VNodeProxy) = p(firstNode,vNode)
+
+  def apply(firstNode: org.scalajs.dom.raw.Element, vNode: VNodeProxy) = p(firstNode,vNode)
 }
 
 @js.native

--- a/src/main/scala/snabbdom/h.scala
+++ b/src/main/scala/snabbdom/h.scala
@@ -58,9 +58,14 @@ trait DataObject extends js.Object {
 object DataObject {
 
   def apply(attrs: js.Dictionary[String],
+            on: js.Dictionary[js.Function1[Event, Unit]]
+           ): DataObject = apply(attrs, on, Hooks(), js.undefined)
+
+
+  def apply(attrs: js.Dictionary[String],
             on: js.Dictionary[js.Function1[Event, Unit]],
-            hook: Hooks = Hooks(),
-            key: js.UndefOr[String | Int] = js.undefined
+            hook: Hooks,
+            key: js.UndefOr[String | Int]
            ): DataObject = {
 
     val _attrs = attrs
@@ -98,13 +103,7 @@ object DataObject {
       import scala.scalajs.js.JSConverters._
 
       val newAttrs = (obj.attrs ++ attrs).toJSDictionary
-
-      DataObject(
-        attrs = newAttrs,
-        on = obj.on,
-        hook = obj.hook,
-        key = obj.key
-      )
+      DataObject(attrs = newAttrs, on = obj.on, hook = obj.hook, key = obj.key)
     }
   }
 }

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -183,6 +183,44 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
 
   }
 
+  it should "be replaced if they contain changeables" in {
+
+    def page(num: Int): VNode = {
+      val pageNum = createHandler[Int](num)
+
+      div( id := "page",
+        num match {
+          case 1 =>
+            div(child <-- pageNum)
+          case 2 =>
+            div(child <-- pageNum)
+        }
+      )
+    }
+
+    val pageHandler =  Subject[Int]
+
+    val vtree = div(
+      div(child <-- pageHandler.map(page))
+    )
+
+    val node = document.createElement("div")
+    document.body.appendChild(node)
+
+    DomUtils.render(node, vtree)
+
+    pageHandler.next(1)
+
+    val domNode = document.getElementById("page")
+
+    domNode.textContent shouldBe "1"
+
+    pageHandler.next(2)
+
+    domNode.textContent shouldBe "2"
+
+  }
+
   "The HTML DSL" should "construct VTrees properly" in {
     import outwatch.dom._
 

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -1,17 +1,18 @@
 package outwatch
 
 import org.scalajs.dom.raw.HTMLInputElement
+import org.scalajs.dom.{Event, KeyboardEvent, document}
 import org.scalatest.BeforeAndAfterEach
-import rxscalajs.{Observable, Subject}
-import snabbdom.{DataObject, h}
+import outwatch.dom.VDomModifier.VTree
 import outwatch.dom._
 import outwatch.dom.helpers._
+import rxscalajs.{Observable, Subject}
+import snabbdom.{DataObject, h}
 
 import scala.collection.immutable.Seq
+import scala.language.reflectiveCalls
 import scala.scalajs.js
 import scala.scalajs.js.JSON
-import org.scalajs.dom.{Event, KeyboardEvent, document}
-import outwatch.dom.VDomModifier.VTree
 
 class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
 

--- a/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -3,8 +3,9 @@ package outwatch
 import org.scalajs.dom._
 import org.scalajs.dom.raw.HTMLInputElement
 import org.scalatest.BeforeAndAfterEach
-import rxscalajs.{Observable, Subject}
 import outwatch.dom.helpers.DomUtils
+
+import scala.language.reflectiveCalls
 
 class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
   override def afterEach(): Unit = {


### PR DESCRIPTION
This PR fixes issue #38.

The patch assigns a key to a VNode's data object that contains changeables and doesn't already have a key in order to force Snabbdom to destroy/re-create it when patched with new changeables. It also fixes the ```DataObject.updateAttributes``` method by passing the key to the newly constructed ```DataObject```.

I've also been doing some refactoring, most notably turned DataObject and Hooks in the Snabbdom facade into ```@ScalaJSDefined``` traits for extra type safety (this would have prevented the ```DataObject.updateAttributes``` bug for example).