### PR TITLE
Some refactorings in Sink

### DIFF
--- a/src/main/scala/outwatch/dom/Handlers.scala
+++ b/src/main/scala/outwatch/dom/Handlers.scala
@@ -19,7 +19,7 @@ trait Handlers {
   def createBoolHandler(defaultValues: Boolean*) = createHandler[Boolean](defaultValues: _*)
   def createNumberHandler(defaultValues: Double*) = createHandler[Double](defaultValues: _*)
 
-  def createHandler[T](defaultValues: T*): Observable[T] with Sink[T] = {
+  def createHandler[T](defaultValues: T*): Handler[T] = {
     Sink.createHandler[T](defaultValues: _*)
   }
 }

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -1,3 +1,9 @@
 package outwatch
 
-package object dom extends Attributes with Tags with Handlers
+import rxscalajs.Observable
+
+package object dom extends Attributes with Tags with Handlers {
+
+  type Handler[T] = Observable[T] with Sink[T]
+
+}

--- a/src/main/scala/outwatch/util/Store.scala
+++ b/src/main/scala/outwatch/util/Store.scala
@@ -1,15 +1,16 @@
 package outwatch.util
 
 import outwatch.Sink
-import outwatch.dom.createHandler
+import outwatch.dom.{Handler, createHandler}
 import rxscalajs.Observable
 import rxscalajs.subscription.Subscription
 
 import scala.language.implicitConversions
 
 final case class Store[State, Action](initialState: State, reducer: (State, Action) => State) {
-  val sink: Observable[Action] with Sink[Action] = createHandler[Action]()
-  val source: Observable[State] = sink
+  private val handler: Handler[Action] = createHandler[Action]()
+  val sink: Sink[Action] = handler
+  val source: Observable[State] = handler
     .scan(initialState)(reducer)
     .startWith(initialState)
 

--- a/src/main/scala/outwatch/util/WebSocket.scala
+++ b/src/main/scala/outwatch/util/WebSocket.scala
@@ -20,7 +20,7 @@ final case class WebSocket private(url: String) {
     () => ws.close()
   })
 
-  lazy val sink = Sink.create[String](s => ws.send(s))
+  lazy val sink = Sink.create[String](s => ws.send(s), _ => (), () => ws.close())
 
 }
 


### PR DESCRIPTION
A few refactorings in ```Sink```, made a code a bit more DRY, added ```onError``` and ```onComplete``` arguments to ```Sink.create```.