### PR TITLE
handle boolean attributes with snabbdom

### DIFF
--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -1,6 +1,7 @@
 package outwatch.dom
 
 import org.scalajs.dom._
+import scala.scalajs.js.|
 import rxscalajs.{Observable, Observer}
 import snabbdom.{DataObject, VNodeProxy, h}
 
@@ -28,14 +29,13 @@ final case class NumberEventEmitter(eventType: String, sink: Observer[Double]) e
 
 sealed trait Attribute extends Property{
   val title: String
-  val value: String
 }
 
 object Attribute {
-  def apply(title: String, value: String) = Attr(title, value)
+  def apply(title: String, value: String | Boolean) = Attr(title, value)
 }
 
-final case class Attr(title: String, value: String) extends Attribute
+final case class Attr(title: String, value: String | Boolean) extends Attribute
 final case class Prop(title: String, value: String) extends Attribute
 final case class Style(title: String, value: String) extends Attribute
 final case class InsertHook(sink: Observer[Element]) extends Property

--- a/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -32,8 +32,7 @@ final class AttributeBuilder[T](val attributeName: String) extends AnyVal with V
   def :=(value: T) = Attribute(attributeName, value.toString)
 
   def <--(valueStream: Observable[T]) = {
-    val attributeStream = valueStream.map(n => Attribute(attributeName, n.toString))
-    AttributeStreamReceiver(attributeName, attributeStream)
+    AttributeStreamReceiver(attributeName, valueStream.map(:=))
   }
 }
 
@@ -41,8 +40,7 @@ final class PropertyBuilder[T](val attributeName: String) extends AnyVal with Va
   def :=(value: T) = Prop(attributeName, value.toString)
 
   def <--(valueStream: Observable[T]) = {
-    val attributeStream = valueStream.map(n => Prop(attributeName, n.toString))
-    AttributeStreamReceiver(attributeName, attributeStream)
+    AttributeStreamReceiver(attributeName, valueStream.map(:=))
   }
 }
 
@@ -54,26 +52,20 @@ final class DynamicAttributeBuilder[T](parts: List[String]) extends Dynamic with
   def :=(value: T) = Attribute(name, value.toString)
 
   def <--(valueStream: Observable[T]) = {
-    val attributeStream = valueStream.map(:=)
-    AttributeStreamReceiver(name, attributeStream)
+    AttributeStreamReceiver(name, valueStream.map(:=))
   }
 }
 
 final class BoolAttributeBuilder(val attributeName: String) extends AnyVal with ValueBuilder[Boolean] {
-  def :=(value: Boolean) = Attribute(attributeName, toEmptyIfFalse(value))
+  def :=(value: Boolean) = Attribute(attributeName, value)
 
   def <--(valueStream: Observable[Boolean]) = {
-    AttributeStreamReceiver(attributeName, valueStream.map(b => {
-      Attribute(attributeName, toEmptyIfFalse(b))
-    }))
+    AttributeStreamReceiver(attributeName, valueStream.map(:=))
   }
-
-  private def toEmptyIfFalse(b: Boolean) = if (b) b.toString else ""
 }
 
 object BoolAttributeBuilder {
-  implicit def toAttribute(builder: BoolAttributeBuilder): Attribute =
-    Attribute(builder.attributeName, "_")
+  implicit def toAttribute(builder: BoolAttributeBuilder): Attribute = builder := true
 }
 
 object KeyBuilder {

--- a/src/main/scala/snabbdom/VDomProxy.scala
+++ b/src/main/scala/snabbdom/VDomProxy.scala
@@ -2,6 +2,7 @@ package snabbdom
 
 import org.scalajs.dom._
 import org.scalajs.dom.raw.HTMLInputElement
+import scala.scalajs.js.|
 import outwatch.dom._
 import outwatch.dom.{Attr, Prop}
 import rxscalajs.Observer
@@ -12,8 +13,8 @@ object VDomProxy {
 
   import js.JSConverters._
 
-  def attrsToSnabbDom(attributes: Seq[Attribute]): (js.Dictionary[String], js.Dictionary[String], js.Dictionary[String]) = {
-    val attrsDict = js.Dictionary[String]()
+  def attrsToSnabbDom(attributes: Seq[Attribute]): (js.Dictionary[String | Boolean], js.Dictionary[String], js.Dictionary[String]) = {
+    val attrsDict = js.Dictionary[String | Boolean]()
     val propsDict = js.Dictionary[String]()
     val styleDict = js.Dictionary[String]()
 

--- a/src/main/scala/snabbdom/h.scala
+++ b/src/main/scala/snabbdom/h.scala
@@ -50,7 +50,7 @@ object Hooks {
 
 @ScalaJSDefined
 trait DataObject extends js.Object {
-  val attrs: js.Dictionary[String]
+  val attrs: js.Dictionary[String | Boolean]
   val props: js.Dictionary[String]
   val style: js.Dictionary[String]
   val on: js.Dictionary[js.Function1[Event, Unit]]
@@ -60,12 +60,12 @@ trait DataObject extends js.Object {
 
 object DataObject {
 
-  def apply(attrs: js.Dictionary[String],
+  def apply(attrs: js.Dictionary[String | Boolean],
             on: js.Dictionary[js.Function1[Event, Unit]]
            ): DataObject = apply(attrs, js.Dictionary.empty, js.Dictionary.empty, on, Hooks(), js.undefined)
 
 
-  def apply(attrs: js.Dictionary[String],
+  def apply(attrs: js.Dictionary[String | Boolean],
             props: js.Dictionary[String],
             style: js.Dictionary[String],
             on: js.Dictionary[js.Function1[Event, Unit]],
@@ -81,7 +81,7 @@ object DataObject {
     val _key = key
 
     new DataObject {
-      val attrs: js.Dictionary[String] = _attrs
+      val attrs: js.Dictionary[String | Boolean] = _attrs
       val props: js.Dictionary[String] = _props
       val style: js.Dictionary[String] = _style
       val on: js.Dictionary[js.Function1[Event, Unit]] = _on
@@ -90,7 +90,7 @@ object DataObject {
     }
   }
 
-  def create(attrs: js.Dictionary[String],
+  def create(attrs: js.Dictionary[String | Boolean],
              props: js.Dictionary[String],
              style: js.Dictionary[String],
              on: js.Dictionary[js.Function1[Event, Unit]],

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -28,13 +28,13 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
 
 
     OutWatch.render("#app", vtree)
-    document.getElementById("btn").getAttribute("disabled") shouldBe ""
+    document.getElementById("btn").hasAttribute("disabled") shouldBe false
 
     val event = document.createEvent("Events")
     event.initEvent("click", canBubbleArg = true, cancelableArg = false)
     document.getElementById("click").dispatchEvent(event)
 
-    document.getElementById("btn").getAttribute("disabled") shouldBe "true"
+    document.getElementById("btn").getAttribute("disabled") shouldBe ""
   }
 
   it should "be converted to a generic emitter correctly" in {

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -12,7 +12,7 @@ import snabbdom.{DataObject, h}
 import scala.collection.immutable.Seq
 import scala.language.reflectiveCalls
 import scala.scalajs.js
-import scala.scalajs.js.JSON
+import scala.scalajs.js.{JSON, |}
 
 class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
 
@@ -246,6 +246,26 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     )
 
     JSON.stringify(vtree.asProxy) shouldBe JSON.stringify(fixture.proxy)
+
+  }
+
+  it should "construct VTrees with boolean attributes" in {
+    import outwatch.dom._
+
+    def boolBuilder(name: String) = new BoolAttributeBuilder(name)
+    def anyBuilder(name: String) = new AttributeBuilder[Boolean](name)
+    val vtree = div(
+      boolBuilder("a"),
+      boolBuilder("b") := true,
+      boolBuilder("c") := false,
+      anyBuilder("d") := true,
+      anyBuilder("e") := false
+    )
+
+    val attrs = js.Dictionary[String | Boolean]("a" -> true, "b" -> true, "c" -> false, "d" -> "true", "e" -> "false")
+    val expected = h("div", DataObject(attrs, js.Dictionary()), js.Array[Any]())
+
+    JSON.stringify(vtree.asProxy) shouldBe JSON.stringify(expected)
 
   }
 

--- a/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -3,6 +3,7 @@ package outwatch
 import snabbdom.{DataObject, h, patch}
 
 import scalajs.js
+import scalajs.js.|
 import org.scalajs.dom.document
 import org.scalajs.dom.raw.HTMLInputElement
 
@@ -60,4 +61,17 @@ class SnabbdomSpec extends UnitSpec {
     inputElement().value shouldBe ""
   }
 
+  it should "correctly handle boolean attributes" in {
+    val message = "Hello World"
+    val attributes = js.Dictionary[String | Boolean]("bool1" -> true, "bool0" -> false, "string1" -> "true", "string0" -> "false")
+    val vNode = h("span#msg", DataObject(attributes, js.Dictionary()), message)
+
+    val node = document.createElement("div")
+    document.body.appendChild(node)
+
+    patch(node, vNode)
+
+    val expected = s"""<span id="msg" bool1="" string1="true" string0="false">$message</span>"""
+    document.getElementById("msg").outerHTML shouldBe expected
+  }
 }


### PR DESCRIPTION
The current behaviour of how we handle boolean attributes seems to be broken. We are rendering `false as ""` and `true as "true"`. Quoting from the [HTML5 spec](https://www.w3.org/TR/html5/infrastructure.html#boolean-attributes): "A number of attributes are boolean attributes. The presence of a boolean attribute on an element represents the true value, and the absence of the attribute represents the false value."

The handling of boolean attributes was changed in the release `0.7.0` of snabbdom: https://github.com/snabbdom/snabbdom/releases/tag/v0.7.0. Previously it relied on an internal list of boolean attributes and would handle it depending on the attribute name. Now it relies on the type of the value, i.e., if the value is strictly equal to true/false, it will be handled as a boolean attribute. If true, the attribute is set with value "" and if false, the attribute is not set.

Therefore I have changed the `Attr` type to have a value of either String or Boolean, so that snabbdom can handle it downstream. The BoolAttributeBuilder just passes the boolean value to the Attribute.

I am not entirely sure about the change I did [here with the builder](https://github.com/OutWatch/outwatch/blob/master/src/main/scala/outwatch/dom/helpers/Builder.scala#L76). What was the `"_"` used for?

Furthermore, this means, we have to take care which attributes are boolean attributes and which are enumeration (for example [draggable](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/draggable) is not a boolean attribute, but an enumeration of true|false).

This might also fix https://github.com/OutWatch/outwatch/issues/34, however we cannot automatically infer whether a dynamic `data`-attribute is boolean (e.g. you could achieve it with `new BoolAttributeBuilder("data-close")`).