### PR TITLE
Delayed asProxy, VTree.apply to copy with more modifiers

### DIFF
--- a/src/main/scala/outwatch/dom/Tags.scala
+++ b/src/main/scala/outwatch/dom/Tags.scala
@@ -12,69 +12,69 @@
 
 package outwatch.dom
 
-import outwatch.dom.helpers.DomUtils
-
 /** Trait that contains all tags, so they can be mixed in to other objects if needed.
   */
 trait Tags {
-  private def tag: (String) => (Seq[VDomModifier]) => VNode = DomUtils.hyperscriptHelper
+  import VDomModifier.VTree
+
+  private def tag(nodeType: String)(args: Seq[VDomModifier]): VTree = VTree(nodeType, args.toVector)
 
   /** Represents a hyperlink, linking to another resource.
     *
     *  MDN
     */
-  def a          (args: VDomModifier*): VNode = tag("a")(args)
+  def a          (args: VDomModifier*): VTree = tag("a")(args)
 
   /** An abbreviation or acronym; the expansion of the abbreviation can be
     * represented in the title attribute.
     *
     *  MDN
     */
-  def abbr       (args: VDomModifier*): VNode = tag("abbr")(args)
+  def abbr       (args: VDomModifier*): VTree = tag("abbr")(args)
 
   /** Defines a section containing contact information.
     *
     *  MDN
     */
-  def address    (args: VDomModifier*): VNode = tag("address")(args)
+  def address    (args: VDomModifier*): VTree = tag("address")(args)
 
   /** In conjunction with map, defines an image map
     *
     *  MDN
     */
-  def area       (args: VDomModifier*): VNode = tag("area")(args)
+  def area       (args: VDomModifier*): VTree = tag("area")(args)
 
   /** Defines self-contained content that could exist independently of the rest
     * of the content.
     *
     *  MDN
     */
-  def article    (args: VDomModifier*): VNode = tag("article")(args)
+  def article    (args: VDomModifier*): VTree = tag("article")(args)
 
   /** Defines some content loosely related to the page content. If it is removed,
     * the remaining content still makes sense.
     *
     *  MDN
     */
-  def aside      (args: VDomModifier*): VNode = tag("aside")(args)
+  def aside      (args: VDomModifier*): VTree = tag("aside")(args)
 
   /** Represents a sound or an audio stream.
     *
     *  MDN
     */
-  def audio      (args: VDomModifier*): VNode = tag("audio")(args)
+  def audio      (args: VDomModifier*): VTree = tag("audio")(args)
 
   /** Bold text.
     *
     *  MDN
     */
-  def b          (args: VDomModifier*): VNode = tag("b")(args)
+  def b          (args: VDomModifier*): VTree = tag("b")(args)
 
   /** Defines the base URL for relative URLs in the page.
     *
     *  MDN
     */
-  def base       (args: VDomModifier*): VNode = tag("base")(args)
+  def base       (args: VDomModifier*): VTree = tag("base")(args)
 
   /** Represents text that must be isolated from its surrounding for bidirectional
     * text formatting. It allows embedding a span of text with a different, or
@@ -82,278 +82,278 @@ trait Tags {
     *
     *  MDN
     */
-  def bdi        (args: VDomModifier*): VNode = tag("bdi")(args)
+  def bdi        (args: VDomModifier*): VTree = tag("bdi")(args)
 
   /** Represents the directionality of its children, in order to explicitly
     * override the Unicode bidirectional algorithm.
     *
     *  MDN
     */
-  def bdo        (args: VDomModifier*): VNode = tag("bdo")(args)
+  def bdo        (args: VDomModifier*): VTree = tag("bdo")(args)
 
   /** Represents a content that is quoted from another source.
     *
     *  MDN
     */
-  def blockquote (args: VDomModifier*): VNode = tag("blockquote")(args)
+  def blockquote (args: VDomModifier*): VTree = tag("blockquote")(args)
 
   /** Represents the content of an HTML document. There is only one body
     *   element in a document.
     *
     *  MDN
     */
-  def body       (args: VDomModifier*): VNode = tag("body")(args)
+  def body       (args: VDomModifier*): VTree = tag("body")(args)
 
   /** Represents a line break.
     *
     *  MDN
     */
-  def br         (args: VDomModifier*): VNode = tag("br")(args)
+  def br         (args: VDomModifier*): VTree = tag("br")(args)
 
   /** A button
     *
     *  MDN
     */
-  def button     (args: VDomModifier*): VNode = tag("button")(args)
+  def button     (args: VDomModifier*): VTree = tag("button")(args)
 
   /** Represents a bitmap area that scripts can use to render graphics like graphs,
     * games or any visual images on the fly.
     *
     *  MDN
     */
-  def canvas     (args: VDomModifier*): VNode = tag("canvas")(args)
+  def canvas     (args: VDomModifier*): VTree = tag("canvas")(args)
 
   /** The title of a table.
     *
     *  MDN
     */
-  def caption    (args: VDomModifier*): VNode = tag("caption")(args)
+  def caption    (args: VDomModifier*): VTree = tag("caption")(args)
 
   /** Represents the title of a work being cited.
     *
     *  MDN
     */
-  def cite       (args: VDomModifier*): VNode = tag("cite")(args)
+  def cite       (args: VDomModifier*): VTree = tag("cite")(args)
 
   /** Represents computer code.
     *
     *  MDN
     */
-  def code       (args: VDomModifier*): VNode = tag("code")(args)
+  def code       (args: VDomModifier*): VTree = tag("code")(args)
 
   /** A single column.
     *
     *  MDN
     */
-  def col        (args: VDomModifier*): VNode = tag("col")(args)
+  def col        (args: VDomModifier*): VTree = tag("col")(args)
 
   /** A set of columns.
     *
     *  MDN
     */
-  def colgroup   (args: VDomModifier*): VNode = tag("colgroup")(args)
+  def colgroup   (args: VDomModifier*): VTree = tag("colgroup")(args)
 
   /** Links a given content with a machine-readable translation.
     * If the content is time- or date-related, the `<time>` element must be used.
     *
     * MDN
     */
-  def dataElement(args: VDomModifier*): VNode = tag("data")(args)
+  def dataElement(args: VDomModifier*): VTree = tag("data")(args)
 
   /** A set of predefined options for other controls.
     *
     *  MDN
     */
-  def datalist   (args: VDomModifier*): VNode = tag("datalist")(args)
+  def datalist   (args: VDomModifier*): VTree = tag("datalist")(args)
 
   /** Represents the definition of the terms immediately listed before it.
     *
     * MDN
     */
-  def dd         (args: VDomModifier*): VNode = tag("dd")(args)
+  def dd         (args: VDomModifier*): VTree = tag("dd")(args)
 
   /** Defines a removal from the document.
     *
     * MDN
     */
-  def del        (args: VDomModifier*): VNode = tag("del")(args)
+  def del        (args: VDomModifier*): VTree = tag("del")(args)
 
   /** A widget from which the user can obtain additional information
     * or controls.
     *
     * MDN
     */
-  def details    (args: VDomModifier*): VNode = tag("details")(args)
+  def details    (args: VDomModifier*): VTree = tag("details")(args)
 
   /** Represents a term whose definition is contained in its nearest ancestor
     * content.
     *
     * MDN
     */
-  def dfn        (args: VDomModifier*): VNode = tag("dfn")(args)
+  def dfn        (args: VDomModifier*): VTree = tag("dfn")(args)
 
   /** Represents a dialog box or other interactive component, such as an inspector
     * or window.
     *
     * MDN
     */
-  def dialog     (args: VDomModifier*): VNode = tag("dialog")(args)
+  def dialog     (args: VDomModifier*): VTree = tag("dialog")(args)
 
   /** Represents a generic container with no special meaning.
     *
     * MDN
     */
-  def div        (args: VDomModifier*): VNode = tag("div")(args)
+  def div        (args: VDomModifier*): VTree = tag("div")(args)
 
   /** Defines a definition list; a list of terms and their associated definitions.
     *
     * MDN
     */
-  def dl         (args: VDomModifier*): VNode = tag("dl")(args)
+  def dl         (args: VDomModifier*): VTree = tag("dl")(args)
 
   /** Represents a term defined by the next dd
     *
     * MDN
     */
-  def dt         (args: VDomModifier*): VNode = tag("dt")(args)
+  def dt         (args: VDomModifier*): VTree = tag("dt")(args)
 
   /** Represents emphasized text.
     *
     * MDN
     */
-  def em         (args: VDomModifier*): VNode = tag("em")(args)
+  def em         (args: VDomModifier*): VTree = tag("em")(args)
 
   /** Represents a integration point for an external, often non-HTML, application
     * or interactive content.
     *
     * MDN
     */
-  def embed      (args: VDomModifier*): VNode = tag("embed")(args)
+  def embed      (args: VDomModifier*): VTree = tag("embed")(args)
 
   /** A set of fields.
     *
     * MDN
     */
-  def fieldset   (args: VDomModifier*): VNode = tag("fieldset")(args)
+  def fieldset   (args: VDomModifier*): VTree = tag("fieldset")(args)
 
   /** Represents the legend of a figure.
     *
     * MDN
     */
-  def figcaption (args: VDomModifier*): VNode = tag("figcaption")(args)
+  def figcaption (args: VDomModifier*): VTree = tag("figcaption")(args)
 
   /** Represents a figure illustrated as part of the document.
     *
     * MDN
     */
-  def figure     (args: VDomModifier*): VNode = tag("figure")(args)
+  def figure     (args: VDomModifier*): VTree = tag("figure")(args)
 
   /** Defines the footer for a page or section. It often contains a copyright
     * notice, some links to legal information, or addresses to give feedback.
     *
     * MDN
     */
-  def footer     (args: VDomModifier*): VNode = tag("footer")(args)
+  def footer     (args: VDomModifier*): VTree = tag("footer")(args)
 
   /** Represents a form, consisting of controls, that can be submitted to a
     * server for processing.
     *
     * MDN
     */
-  def form       (args: VDomModifier*): VNode = tag("form")(args)
+  def form       (args: VDomModifier*): VTree = tag("form")(args)
 
   /** Heading level 1
     *
     * MDN
     */
-  def h1         (args: VDomModifier*): VNode = tag("h1")(args)
+  def h1         (args: VDomModifier*): VTree = tag("h1")(args)
 
   /** Heading level 2
     *
     * MDN
     */
-  def h2         (args: VDomModifier*): VNode = tag("h2")(args)
+  def h2         (args: VDomModifier*): VTree = tag("h2")(args)
 
   /** Heading level 3
     *
     * MDN
     */
-  def h3         (args: VDomModifier*): VNode = tag("h3")(args)
+  def h3         (args: VDomModifier*): VTree = tag("h3")(args)
 
   /** Heading level 4
     *
     * MDN
     */
-  def h4         (args: VDomModifier*): VNode = tag("h4")(args)
+  def h4         (args: VDomModifier*): VTree = tag("h4")(args)
 
   /** Heading level 5
     *
     * MDN
     */
-  def h5         (args: VDomModifier*): VNode = tag("h5")(args)
+  def h5         (args: VDomModifier*): VTree = tag("h5")(args)
 
   /** Heading level 6
     *
     * MDN
     */
-  def h6         (args: VDomModifier*): VNode = tag("h6")(args)
+  def h6         (args: VDomModifier*): VTree = tag("h6")(args)
 
   /** Represents a collection of metadata about the document, including links to,
     * or definitions of, scripts and style sheets.
     *
     * MDN
     */
-  def head       (args: VDomModifier*): VNode = tag("head")(args)
+  def head       (args: VDomModifier*): VTree = tag("head")(args)
 
   /** Defines the header of a page or section. It often contains a logo, the
     * title of the Web site, and a navigational table of content.
     *
     * MDN
     */
-  def header     (args: VDomModifier*): VNode = tag("header")(args)
+  def header     (args: VDomModifier*): VTree = tag("header")(args)
 
   /** Represents a thematic break between paragraphs of a section or article or
     * any longer content.
     *
     * MDN
     */
-  def hr         (args: VDomModifier*): VNode = tag("hr")(args)
+  def hr         (args: VDomModifier*): VTree = tag("hr")(args)
 
   /** Italicized text.
     *
     * MDN
     */
-  def i          (args: VDomModifier*): VNode = tag("i")(args)
+  def i          (args: VDomModifier*): VTree = tag("i")(args)
 
   /** Represents a nested browsing context, that is an embedded HTML document.
     *
     * MDN
     */
-  def iframe     (args: VDomModifier*): VNode = tag("iframe")(args)
+  def iframe     (args: VDomModifier*): VTree = tag("iframe")(args)
 
   /** Represents an image.
     *
     * MDN
     */
-  def img        (args: VDomModifier*): VNode = tag("img")(args)
+  def img        (args: VDomModifier*): VTree = tag("img")(args)
 
   /** A typed data field allowing the user to input data.
     *
     * MDN
     */
-  def input      (args: VDomModifier*): VNode = tag("input")(args)
+  def input      (args: VDomModifier*): VTree = tag("input")(args)
 
   /** Defines an addition to the document.
     *
     * MDN
     */
-  def ins        (args: VDomModifier*): VNode = tag("ins")(args)
+  def ins        (args: VDomModifier*): VTree = tag("ins")(args)
 
   /** Represents user input, often from a keyboard, but not necessarily.
     *
     * MDN
     */
-  def kbd        (args: VDomModifier*): VNode = tag("kbd")(args)
+  def kbd        (args: VDomModifier*): VTree = tag("kbd")(args)
 
   /** A key-pair generator control.
     *
@@ -367,57 +367,57 @@ trait Tags {
       |compatibility table at the bottom of this page to guide your decision.
       |Be aware that this feature may cease to work at any time.
     """.stripMargin, "0.9.0")
-  def keygen     (args: VDomModifier*): VNode = tag("keygen")(args)
+  def keygen     (args: VDomModifier*): VTree = tag("keygen")(args)
 
   /** The caption of a single field
     *
     * MDN
     */
-  def label      (args: VDomModifier*): VNode = tag("label")(args)
+  def label      (args: VDomModifier*): VTree = tag("label")(args)
 
   /** The caption for a fieldset.
     *
     * MDN
     */
-  def legend     (args: VDomModifier*): VNode = tag("legend")(args)
+  def legend     (args: VDomModifier*): VTree = tag("legend")(args)
 
   /** Defines an item of an list.
     *
     * MDN
     */
-  def li         (args: VDomModifier*): VNode = tag("li")(args)
+  def li         (args: VDomModifier*): VTree = tag("li")(args)
 
   /** Used to link JavaScript and external CSS with the current HTML document.
     *
     * MDN
     */
-  def link       (args: VDomModifier*): VNode = tag("link")(args)
+  def link       (args: VDomModifier*): VTree = tag("link")(args)
 
   /** Defines the main or important content in the document. There is only one
     * main element in the document.
     *
     * MDN
     */
-  def main       (args: VDomModifier*): VNode = tag("main")(args)
+  def main       (args: VDomModifier*): VTree = tag("main")(args)
 
   /** In conjunction with area, defines an image map.
     *
     * MDN
     */
-  def map        (args: VDomModifier*): VNode = tag("map")(args)
+  def map        (args: VDomModifier*): VTree = tag("map")(args)
 
   /** Represents text highlighted for reference purposes, that is for its
     * relevance in another context.
     *
     * MDN
     */
-  def mark       (args: VDomModifier*): VNode = tag("mark")(args)
+  def mark       (args: VDomModifier*): VTree = tag("mark")(args)
 
   /** Defines a mathematical formula.
     *
     * MDN
     */
-  def math       (args: VDomModifier*): VNode = tag("math")(args)
+  def math       (args: VDomModifier*): VTree = tag("math")(args)
 
   /** Represents a group of commands that a user can perform or activate.
     * This includes both list menus, which might appear across the top of
@@ -426,7 +426,7 @@ trait Tags {
     *
     * MDN
     */
-  def menu       (args: VDomModifier*): VNode = tag("menu")(args)
+  def menu       (args: VDomModifier*): VTree = tag("menu")(args)
 
   /** Represents a command that a user is able to invoke through a popup menu.
     * This includes context menus, as well as menus that might be attached to
@@ -442,96 +442,96 @@ trait Tags {
     *
     * MDN
     */
-  def menuitem   (args: VDomModifier*): VNode = tag("menuitem")(args)
+  def menuitem   (args: VDomModifier*): VTree = tag("menuitem")(args)
 
   /** Defines metadata that can't be defined using another HTML element.
     *
     * MDN
     */
-  def meta       (args: VDomModifier*): VNode = tag("meta")(args)
+  def meta       (args: VDomModifier*): VTree = tag("meta")(args)
 
   /** A scalar measurement within a known range.
     *
     * MDN
     */
-  def meter      (args: VDomModifier*): VNode = tag("meter")(args)
+  def meter      (args: VDomModifier*): VTree = tag("meter")(args)
 
   /** Represents a section of a page that links to other pages or to parts within
     * the page: a section with navigation links.
     *
     * MDN
     */
-  def nav        (args: VDomModifier*): VNode = tag("nav")(args)
+  def nav        (args: VDomModifier*): VTree = tag("nav")(args)
 
   /** Defines alternative content to display when the browser doesn't support
     * scripting.
     *
     * MDN
     */
-  def noscript   (args: VDomModifier*): VNode = tag("noscript")(args)
+  def noscript   (args: VDomModifier*): VTree = tag("noscript")(args)
 
   /** Represents an external resource, which is treated as an image, an HTML
     * sub-document, or an external resource to be processed by a plug-in.
     *
     * MDN
     */
-  def `object`   (args: VDomModifier*): VNode = tag("object")(args)
+  def `object`   (args: VDomModifier*): VTree = tag("object")(args)
 
   /** Defines an ordered list of items.
     *
     * MDN
     */
-  def ol         (args: VDomModifier*): VNode = tag("ol")(args)
+  def ol         (args: VDomModifier*): VTree = tag("ol")(args)
 
   /** A set of options, logically grouped.
     *
     * MDN
     */
-  def optgroup   (args: VDomModifier*): VNode = tag("optgroup")(args)
+  def optgroup   (args: VDomModifier*): VTree = tag("optgroup")(args)
 
   /**
     * An option in a select element.
     *
     *  MDN
     */
-  def option     (args: VDomModifier*): VNode = tag("option")(args)
+  def option     (args: VDomModifier*): VTree = tag("option")(args)
 
   /** The result of a calculation
     *
     * MDN
     */
-  def output     (args: VDomModifier*): VNode = tag("output")(args)
+  def output     (args: VDomModifier*): VTree = tag("output")(args)
 
   /** Defines a portion that should be displayed as a paragraph.
     *
     * MDN
     */
-  def p          (args: VDomModifier*): VNode = tag("p")(args)
+  def p          (args: VDomModifier*): VTree = tag("p")(args)
 
   /** Defines parameters for use by plug-ins invoked by object elements.
     *
     * MDN
     */
-  def param      (args: VDomModifier*): VNode = tag("param")(args)
+  def param      (args: VDomModifier*): VTree = tag("param")(args)
 
   /** Indicates that its content is preformatted and that this format must be
     * preserved.
     *
     * MDN
     */
-  def pre        (args: VDomModifier*): VNode = tag("pre")(args)
+  def pre        (args: VDomModifier*): VTree = tag("pre")(args)
 
   /** A progress completion bar
     *
     * MDN
     */
-  def progress   (args: VDomModifier*): VNode = tag("progress")(args)
+  def progress   (args: VDomModifier*): VTree = tag("progress")(args)
 
   /** An inline quotation.
     *
     * MDN
     */
-  def q          (args: VDomModifier*): VNode = tag("q")(args)
+  def q          (args: VDomModifier*): VTree = tag("q")(args)
 
   /** Represents parenthesis around a ruby annotation, used to display the
     * annotation in an alternate way by browsers not supporting the standard
@@ -539,7 +539,7 @@ trait Tags {
     *
     * MDN
     */
-  def rp         (args: VDomModifier*): VNode = tag("rp")(args)
+  def rp         (args: VDomModifier*): VTree = tag("rp")(args)
 
   /** Represents content to be marked with ruby annotations, short runs of text
     * presented alongside the text. This is often used in conjunction with East
@@ -548,66 +548,66 @@ trait Tags {
     *
     * MDN
     */
-  def ruby         (args: VDomModifier*): VNode = tag("ruby")(args)
+  def ruby         (args: VDomModifier*): VTree = tag("ruby")(args)
 
   /** Represents the text of a ruby annotation.
     *
     * MDN
     */
-  def rt         (args: VDomModifier*): VNode = tag("rt")(args)
+  def rt         (args: VDomModifier*): VTree = tag("rt")(args)
 
   /** Strikethrough element, used for that is no longer accurate or relevant.
     *
     * MDN
     */
-  def s          (args: VDomModifier*): VNode = tag("s")(args)
+  def s          (args: VDomModifier*): VTree = tag("s")(args)
 
   /** Represents sample output of a program or a computer.
     *
     * MDN
     */
-  def samp       (args: VDomModifier*): VNode = tag("samp")(args)
+  def samp       (args: VDomModifier*): VTree = tag("samp")(args)
 
   /** Defines either an internal script or a link to an external script. The
     * script language is JavaScript.
     *
     * MDN
     */
-  def script     (args: VDomModifier*): VNode = tag("script")(args)
+  def script     (args: VDomModifier*): VTree = tag("script")(args)
 
   /** Represents a generic section of a document, i.e., a thematic grouping of
     * content, typically with a heading.
     *
     * MDN
     */
-  def section    (args: VDomModifier*): VNode = tag("section")(args)
+  def section    (args: VDomModifier*): VTree = tag("section")(args)
 
   /** A control that allows the user to select one of a set of options.
     *
     * MDN
     */
-  def select     (args: VDomModifier*): VNode = tag("select")(args)
+  def select     (args: VDomModifier*): VTree = tag("select")(args)
 
   /** Represents a placeholder inside a web component that you can fill with
     * your own markup, with the effect of composing different DOM trees together.
     *
     * MDN
     */
-  def slot       (args: VDomModifier*): VNode = tag("slot")(args)
+  def slot       (args: VDomModifier*): VTree = tag("slot")(args)
 
   /** Represents a side comment; text like a disclaimer or copyright, which is not
     * essential to the comprehension of the document.
     *
     * MDN
     */
-  def small      (args: VDomModifier*): VNode = tag("small")(args)
+  def small      (args: VDomModifier*): VTree = tag("small")(args)
 
   /** Allows the authors to specify alternate media resources for media elements
     * like video or audio
     *
     * MDN
     */
-  def source     (args: VDomModifier*): VNode = tag("source")(args)
+  def source     (args: VDomModifier*): VTree = tag("source")(args)
 
   /** Represents text with no specific meaning. This has to be used when no other
     * text-semantic element conveys an adequate meaning, which, in this case, is
@@ -615,86 +615,86 @@ trait Tags {
     *
     * MDN
     */
-  def span       (args: VDomModifier*): VNode = tag("span")(args)
+  def span       (args: VDomModifier*): VTree = tag("span")(args)
 
   /** Represents especially important text.
     *
     * MDN
     */
-  def strong     (args: VDomModifier*): VNode = tag("strong")(args)
+  def strong     (args: VDomModifier*): VTree = tag("strong")(args)
 
   /** Used to write inline CSS.
     *
     * MDN
     */
-  def style      (args: VDomModifier*): VNode = tag("style")(args)
+  def style      (args: VDomModifier*): VTree = tag("style")(args)
 
   /** Subscript tag
     *
     * MDN
     */
-  def sub        (args: VDomModifier*): VNode = tag("sub")(args)
+  def sub        (args: VDomModifier*): VTree = tag("sub")(args)
 
   /** A summary, caption, or legend for a given details.
     *
     * MDN
     */
-  def summary    (args: VDomModifier*): VNode = tag("summary")(args)
+  def summary    (args: VDomModifier*): VTree = tag("summary")(args)
 
   /** Superscript tag.
     *
     * MDN
     */
-  def sup        (args: VDomModifier*): VNode = tag("sup")(args)
+  def sup        (args: VDomModifier*): VTree = tag("sup")(args)
 
   /** Represents data with more than one dimension.
     *
     * MDN
     */
-  def table      (args: VDomModifier*): VNode = tag("table")(args)
+  def table      (args: VDomModifier*): VTree = tag("table")(args)
 
   /** The table body.
     *
     * MDN
     */
-  def tbody      (args: VDomModifier*): VNode = tag("tbody")(args)
+  def tbody      (args: VDomModifier*): VTree = tag("tbody")(args)
 
   /** A single cell in a table.
     *
     * MDN
     */
-  def td         (args: VDomModifier*): VNode = tag("td")(args)
+  def td         (args: VDomModifier*): VTree = tag("td")(args)
 
   /** A multiline text edit control.
     *
     * MDN
     */
-  def textarea   (args: VDomModifier*): VNode = tag("textarea")(args)
+  def textarea   (args: VDomModifier*): VTree = tag("textarea")(args)
 
   /** The table footer.
     *
     * MDN
     */
-  def tfoot      (args: VDomModifier*): VNode = tag("tfoot")(args)
+  def tfoot      (args: VDomModifier*): VTree = tag("tfoot")(args)
 
   /** A header cell in a table.
     *
     * MDN
     */
-  def th         (args: VDomModifier*): VNode = tag("th")(args)
+  def th         (args: VDomModifier*): VTree = tag("th")(args)
 
   /** The table headers.
     *
     * MDN
     */
-  def thead      (args: VDomModifier*): VNode = tag("thead")(args)
+  def thead      (args: VDomModifier*): VTree = tag("thead")(args)
 
   /** Represents a date and time value; the machine-readable equivalent can be
     * represented in the datetime attribetu
     *
     * MDN
     */
-  def time       (args: VDomModifier*): VNode = tag("time")(args)
+  def time       (args: VDomModifier*): VTree = tag("time")(args)
 
   /** Defines the title of the document, shown in a browser's title bar or on the
     * page's tab. It can only contain text and any contained tags are not
@@ -702,46 +702,46 @@ trait Tags {
     *
     * MDN
     */
-  def title      (args: VDomModifier*): VNode = tag("title")(args)
+  def title      (args: VDomModifier*): VTree = tag("title")(args)
 
   /** A single row in a table.
     *
     * MDN
     */
-  def tr         (args: VDomModifier*): VNode = tag("tr")(args)
+  def tr         (args: VDomModifier*): VTree = tag("tr")(args)
 
   /** Allows authors to specify timed text track for media elements like video or
     * audio
     *
     * MDN
     */
-  def track      (args: VDomModifier*): VNode = tag("track")(args)
+  def track      (args: VDomModifier*): VTree = tag("track")(args)
 
   /** Underlined text.
     *
     * MDN
     */
-  def u          (args: VDomModifier*): VNode = tag("u")(args)
+  def u          (args: VDomModifier*): VTree = tag("u")(args)
 
   /** Defines an unordered list of items.
     *
     * MDN
     */
-  def ul         (args: VDomModifier*): VNode = tag("ul")(args)
+  def ul         (args: VDomModifier*): VTree = tag("ul")(args)
 
   /** Represents a video, and its associated audio files and captions, with the
     * necessary interface to play it.
     *
     * MDN
     */
-  def video      (args: VDomModifier*): VNode = tag("video")(args)
+  def video      (args: VDomModifier*): VTree = tag("video")(args)
 
   /** Represents a line break opportunity, that is a suggested point for wrapping
     * text in order to improve readability of text split on several lines.
     *
     * MDN
     */
-  def wbr        (args: VDomModifier*): VNode = tag("wbr")(args)
+  def wbr        (args: VDomModifier*): VTree = tag("wbr")(args)
 }
 
 object Tags extends Tags

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -18,7 +18,7 @@ sealed trait Property extends VDomModifier
 
 sealed trait Receiver extends VDomModifier
 
-sealed trait VNode extends VDomModifier {
+sealed trait VNode extends Any with VDomModifier {
   def asProxy: VNodeProxy
 }
 
@@ -51,7 +51,7 @@ final case object EmptyVDomModifier extends VDomModifier
 
 
 object VDomModifier {
-  final implicit class StringNode(string: String) extends VNode {
+  final implicit class StringNode(val string: String) extends AnyVal with VNode {
     def asProxy = VNodeProxy.fromString(string)
   }
 

--- a/src/main/scala/snabbdom/h.scala
+++ b/src/main/scala/snabbdom/h.scala
@@ -110,7 +110,7 @@ object DataObject {
     )
   }
 
-  implicit class DataObjectExt(obj: DataObject) {
+  implicit class DataObjectExt(val obj: DataObject) extends AnyVal {
 
     def withUpdatedAttributes(attributes: Seq[Attribute]): DataObject = {
       import scala.scalajs.js.JSConverters._

--- a/src/test/scala/outwatch/AttributeSpec.scala
+++ b/src/test/scala/outwatch/AttributeSpec.scala
@@ -7,15 +7,17 @@ class AttributeSpec extends UnitSpec {
   "data attribute" should "correctly render only data" in {
     val node = input(data := "bar").asProxy
 
-    node.data.attrs.iterator.contains("data" -> "bar") shouldBe true
-    node.data.attrs.size shouldBe 1
+    node.data.attrs.toList should contain theSameElementsAs List(
+      "data" -> "bar"
+    )
   }
 
   it should "correctly render expanded data with dynamic content" in {
     val node = input(data.foo := "bar").asProxy
 
-    node.data.attrs.iterator.contains("data-foo" -> "bar") shouldBe true
-    node.data.attrs.size shouldBe 1
+    node.data.attrs.toList should contain theSameElementsAs List(
+      "data-foo" -> "bar"
+    )
   }
 
   "optional attributes" should "correctly render" in {
@@ -24,14 +26,59 @@ class AttributeSpec extends UnitSpec {
       data.bar :=? Option.empty[String]
     ).asProxy
 
-    node.data.attrs.iterator.contains("data-foo" -> "bar") shouldBe true
-    node.data.attrs.size shouldBe 1
+    node.data.attrs.toList should contain theSameElementsAs List(
+      "data-foo" -> "bar"
+    )
   }
 
-  "data attribute" should "correctly render style" in {
+  "apply on vtree" should "correctly merge attributes" in {
+    val node = input(
+      data := "bar",
+      data.gurke := "franz"
+    )(
+      data := "buh",
+      data.tomate := "gisela"
+    ).asProxy
+
+    node.data.attrs.toList should contain theSameElementsAs List(
+      "data" -> "buh",
+      "data-gurke" -> "franz",
+      "data-tomate" -> "gisela"
+    )
+  }
+
+  it should "correctly merge styles" in {
+    val node = input(
+      Style("color", "red"),
+      Style("font-size", "5px")
+    )(
+      Style("color", "blue"),
+      Style("border", "1px solid black")
+    ).asProxy
+
+    node.data.style.toList should contain theSameElementsAs List(
+      ("color", "blue"),
+      ("font-size", "5px"),
+      ("border", "1px solid black")
+    )
+  }
+
+  it should "correctly merge keys" in {
+    val node = input( dom.key := "bumm")( dom.key := "klapp").asProxy
+    node.data.key.toList should contain theSameElementsAs List("klapp")
+
+    val node2 = input()( dom.key := "klapp").asProxy
+    node2.data.key.toList should contain theSameElementsAs List("klapp")
+
+    val node3 = input( dom.key := "bumm")().asProxy
+    node3.data.key.toList should contain theSameElementsAs List("bumm")
+  }
+
+  "style attribute" should "render correctly" in {
     val node = input(Style("color", "red")).asProxy
 
-    node.data.style.iterator.contains("color" -> "red") shouldBe true
-    node.data.style.size shouldBe 1
+    node.data.style.toList should contain theSameElementsAs List(
+      "color" -> "red"
+    )
   }
 }

--- a/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -3,7 +3,7 @@ package outwatch
 import org.scalajs.dom._
 import org.scalatest.BeforeAndAfterEach
 import outwatch.dom._
-import rxscalajs.Observable
+import rxscalajs.{Observable, Subject}
 
 class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
 
@@ -32,6 +32,24 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
 
   }
 
+  "Insertion hooks" should "be called correctly on merged nodes" in {
+    var switch = false
+    val sink = Sink.create((_: Element) => switch = true)
+    var switch2 = false
+    val sink2 = Sink.create((_: Element) => switch2 = true)
+
+    val node = div(insert --> sink)(insert --> sink2)
+
+    switch shouldBe false
+    switch2 shouldBe false
+
+    OutWatch.render("#app", node)
+
+    switch shouldBe true
+    switch2 shouldBe true
+
+  }
+
   "Destruction hooks" should "be called correctly" in {
 
     var switch = false
@@ -44,6 +62,24 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
     OutWatch.render("#app", node)
 
     switch shouldBe true
+
+  }
+  "Destruction hooks" should "be called correctly on merged nodes" in {
+
+    var switch = false
+    val sink = Sink.create((_: Element) => switch = true)
+    var switch2 = false
+    val sink2 = Sink.create((_: Element) => switch2 = true)
+
+    val node = div(child <-- Observable.of(span(destroy --> sink)(destroy --> sink2), "Hasdasd"))
+
+    switch shouldBe false
+    switch2 shouldBe false
+
+    OutWatch.render("#app", node)
+
+    switch shouldBe true
+    switch2 shouldBe true
 
   }
 
@@ -60,6 +96,24 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
 
     switch shouldBe true
 
+  }
+
+  "Update hooks" should "be called correctly on merged nodes" in {
+    var switch1 = false
+    val sink1 = Sink.create((_: (Element, Element)) => switch1 = true)
+    var switch2 = false
+    val sink2 = Sink.create((_: (Element, Element)) => switch2 = true)
+
+    val message = Subject[String]()
+    val node = div(child <-- message, update --> sink1)(update --> sink2)
+
+    OutWatch.render("#app", node)
+    switch1 shouldBe false
+    switch2 shouldBe false
+    
+    message.next("wursi")
+    switch1 shouldBe true
+    switch2 shouldBe true
   }
 
 }


### PR DESCRIPTION
also fixes overwriting of StreamReceivers:
e.g.
```scala
div(data <-- a, data <-- b) // only uses stream b instead of both
div(children <-- a, children <-- b) // only uses last stream b instead of first
```

It makes sense to merge this PR before the referential transparency one, because constructing `VNode` is not a side-effect anymore.