### PR TITLE
VNode-apply + referential transparent api

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,11 @@ crossScalaVersions := Seq("2.11.11", "2.12.3")
 
 
 libraryDependencies ++= Seq(
-  "com.github.lukajcb" %%% "rxscala-js" % "0.14.0",
-  "org.scalatest" %%% "scalatest" % "3.0.1" % "test",
-  "org.scalacheck" %%% "scalacheck" % "1.13.4" % "test"
+  "com.github.lukajcb" %%% "rxscala-js" % "0.15.0",
+  "org.typelevel" %%% "cats-core" % "0.9.0",
+  "org.typelevel" %%% "cats-effect" % "0.3",
+  "org.scalatest" %%% "scalatest" % "3.0.1" % Test,
+  "org.scalacheck" %%% "scalacheck" % "1.13.4" % Test
 )
 
 npmDependencies in Compile ++= Seq(
@@ -37,8 +39,10 @@ scalacOptions ++=
   "-Ypartial-unification" ::
   "-Yno-adapted-args" ::
   "-Ywarn-infer-any" ::
+  "-Ywarn-value-discard" ::
   "-Ywarn-nullary-override" ::
   "-Ywarn-nullary-unit" ::
+  "-P:scalajs:sjsDefinedByDefault" ::
   Nil
 
 scalacOptions ++= {
@@ -85,5 +89,7 @@ pomExtra :=
     </developer>
   </developers>
 
+
+scalaJSUseMainModuleInitializer := true
 
 pomIncludeRepository := { _ => false }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.7.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.8.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0-M1")

--- a/src/main/scala/outwatch/Sink.scala
+++ b/src/main/scala/outwatch/Sink.scala
@@ -1,8 +1,9 @@
 package outwatch
 
+import cats.effect.IO
 import outwatch.dom.Handler
 import rxscalajs.facade.SubjectFacade
-import rxscalajs.subscription.AnonymousSubscription
+import rxscalajs.subscription.Subscription
 import rxscalajs.{Observable, Observer, Subject}
 
 import scala.scalajs.js
@@ -15,7 +16,7 @@ sealed trait Sink[-T] extends Any {
     * Using this method is inherently impure and can cause memory leaks, if subscription
     * isn't handled correctly. For more guaranteed safety, use Sink.redirect() instead.
     */
-  def <--(observable: Observable[T]): AnonymousSubscription = {
+  def <--(observable: Observable[T]): IO[Subscription] = IO {
     observable.subscribe(observer)
   }
 
@@ -63,15 +64,15 @@ object Sink {
     * @tparam T the type parameter of the consumed elements.
     * @return a Sink that consumes elements of type T.
     */
-  def create[T](onNext: T => Unit,
-    onError: js.Any => Unit = _ => (),
-    onComplete: () => Unit = () => ()
+  def create[T](onNext: T => IO[Unit],
+    onError: js.Any => IO[Unit] = _ => IO.pure(()),
+    onComplete: () => IO[Unit] = () => IO.pure(())
   ): Sink[T] = {
     val sink = ObserverSink(
       new Observer[T] {
-        override def next(t: T): Unit = onNext(t)
-        override def error(err: js.Any): Unit = onError(err)
-        override def complete(): Unit = onComplete()
+        override def next(t: T): Unit = onNext(t).unsafeRunSync()
+        override def error(err: js.Any): Unit = onError(err).unsafeRunSync()
+        override def complete(): Unit = onComplete().unsafeRunSync()
       }
     )
     sink
@@ -87,13 +88,14 @@ object Sink {
     * @tparam T the type parameter of the elements
     * @return the newly created Handler.
     */
-  def createHandler[T](seeds: T*): Handler[T] = {
+  def createHandler[T](seeds: T*): IO[Handler[T]] = {
     val handler = new SubjectSink[T]
+
     if (seeds.nonEmpty) {
-      ObservableSink[T](handler, handler.startWithMany(seeds: _*))
+      IO(ObservableSink[T](handler, handler.startWithMany(seeds: _*)))
     }
     else {
-      handler
+      IO(handler)
     }
   }
 
@@ -120,7 +122,7 @@ object Sink {
     * @return the resulting sink, that will forward the values
     */
   def redirect[T,R](sink: Sink[T])(project: Observable[R] => Observable[T]): Sink[R] = {
-    val forward = Sink.createHandler[R]()
+    val forward = Sink.createHandler[R]().unsafeRunSync() //TODO shouldnt this method return IO[Sink]
 
     completionObservable(sink)
       .fold(project(forward))(completed => project(forward).takeUntil(completed))
@@ -142,8 +144,8 @@ object Sink {
     * @return the two resulting sinks, that will forward the values
     */
   def redirect2[T,U,R](sink: Sink[T])(project: (Observable[R], Observable[U]) => Observable[T]): (Sink[R], Sink[U]) = {
-    val r = Sink.createHandler[R]()
-    val u = Sink.createHandler[U]()
+    val r = Sink.createHandler[R]().unsafeRunSync()
+    val u = Sink.createHandler[U]().unsafeRunSync()
 
     completionObservable(sink)
       .fold(project(r, u))(completed => project(r, u).takeUntil(completed))
@@ -168,9 +170,9 @@ object Sink {
   def redirect3[T,U,V,R](sink: Sink[T])
                        (project: (Observable[R], Observable[U], Observable[V]) => Observable[T])
                        :(Sink[R], Sink[U], Sink[V]) = {
-    val r = Sink.createHandler[R]()
-    val u = Sink.createHandler[U]()
-    val v = Sink.createHandler[V]()
+    val r = Sink.createHandler[R]().unsafeRunSync()
+    val u = Sink.createHandler[U]().unsafeRunSync()
+    val v = Sink.createHandler[V]().unsafeRunSync()
 
     completionObservable(sink)
       .fold(project(r, u, v))(completed => project(r, u, v).takeUntil(completed))

--- a/src/main/scala/outwatch/dom/Handlers.scala
+++ b/src/main/scala/outwatch/dom/Handlers.scala
@@ -4,6 +4,7 @@ import org.scalajs.dom.MouseEvent
 import org.scalajs.dom.raw.{ClipboardEvent, DragEvent, KeyboardEvent}
 import outwatch.Sink
 import outwatch.dom.helpers.InputEvent
+import cats.effect.IO
 
 /**
   * Trait containing event handlers, so they can be mixed in to other objects if needed.
@@ -18,7 +19,7 @@ trait Handlers {
   def createBoolHandler(defaultValues: Boolean*) = createHandler[Boolean](defaultValues: _*)
   def createNumberHandler(defaultValues: Double*) = createHandler[Double](defaultValues: _*)
 
-  def createHandler[T](defaultValues: T*): Handler[T] = {
+  def createHandler[T](defaultValues: T*): IO[Handler[T]] = {
     Sink.createHandler[T](defaultValues: _*)
   }
 }

--- a/src/main/scala/outwatch/dom/OutWatch.scala
+++ b/src/main/scala/outwatch/dom/OutWatch.scala
@@ -1,9 +1,10 @@
 package outwatch.dom
 
+import cats.effect.IO
 import org.scalajs.dom._
 import outwatch.dom.helpers.DomUtils
 
 object OutWatch {
-  def render(querySelector: String, vNode: VNode): Unit =
+  def render(querySelector: String, vNode: VNode): IO[Unit] =
     DomUtils.render(document.querySelector(querySelector), vNode)
 }

--- a/src/main/scala/outwatch/dom/OutWatch.scala
+++ b/src/main/scala/outwatch/dom/OutWatch.scala
@@ -3,8 +3,12 @@ package outwatch.dom
 import cats.effect.IO
 import org.scalajs.dom._
 import outwatch.dom.helpers.DomUtils
+import outwatch.util.Store
 
 object OutWatch {
   def render(querySelector: String, vNode: VNode): IO[Unit] =
     DomUtils.render(document.querySelector(querySelector), vNode)
+
+  def renderWithStore[S, A](initialState: S, reducer: (S, A) => S, querySelector: String, root: VNode): IO[Unit] =
+    Store.renderWithStore(initialState, reducer, querySelector, root)
 }

--- a/src/main/scala/outwatch/dom/Tags.scala
+++ b/src/main/scala/outwatch/dom/Tags.scala
@@ -12,69 +12,69 @@
 
 package outwatch.dom
 
-import outwatch.dom.helpers.DomUtils
-
 /** Trait that contains all tags, so they can be mixed in to other objects if needed.
   */
 trait Tags {
-  private def tag: (String) => (Seq[VDomModifier]) => VNode = DomUtils.hyperscriptHelper
+  import VDomModifier.VTree
+
+  private def tag(nodeType: String)(args: Seq[VDomModifier]): VTree = VTree(nodeType, args.toVector)
 
   /** Represents a hyperlink, linking to another resource.
     *
     *  MDN
     */
-  def a          (args: VDomModifier*): VNode = tag("a")(args)
+  def a          (args: VDomModifier*): VTree = tag("a")(args)
 
   /** An abbreviation or acronym; the expansion of the abbreviation can be
     * represented in the title attribute.
     *
     *  MDN
     */
-  def abbr       (args: VDomModifier*): VNode = tag("abbr")(args)
+  def abbr       (args: VDomModifier*): VTree = tag("abbr")(args)
 
   /** Defines a section containing contact information.
     *
     *  MDN
     */
-  def address    (args: VDomModifier*): VNode = tag("address")(args)
+  def address    (args: VDomModifier*): VTree = tag("address")(args)
 
   /** In conjunction with map, defines an image map
     *
     *  MDN
     */
-  def area       (args: VDomModifier*): VNode = tag("area")(args)
+  def area       (args: VDomModifier*): VTree = tag("area")(args)
 
   /** Defines self-contained content that could exist independently of the rest
     * of the content.
     *
     *  MDN
     */
-  def article    (args: VDomModifier*): VNode = tag("article")(args)
+  def article    (args: VDomModifier*): VTree = tag("article")(args)
 
   /** Defines some content loosely related to the page content. If it is removed,
     * the remaining content still makes sense.
     *
     *  MDN
     */
-  def aside      (args: VDomModifier*): VNode = tag("aside")(args)
+  def aside      (args: VDomModifier*): VTree = tag("aside")(args)
 
   /** Represents a sound or an audio stream.
     *
     *  MDN
     */
-  def audio      (args: VDomModifier*): VNode = tag("audio")(args)
+  def audio      (args: VDomModifier*): VTree = tag("audio")(args)
 
   /** Bold text.
     *
     *  MDN
     */
-  def b          (args: VDomModifier*): VNode = tag("b")(args)
+  def b          (args: VDomModifier*): VTree = tag("b")(args)
 
   /** Defines the base URL for relative URLs in the page.
     *
     *  MDN
     */
-  def base       (args: VDomModifier*): VNode = tag("base")(args)
+  def base       (args: VDomModifier*): VTree = tag("base")(args)
 
   /** Represents text that must be isolated from its surrounding for bidirectional
     * text formatting. It allows embedding a span of text with a different, or
@@ -82,278 +82,278 @@ trait Tags {
     *
     *  MDN
     */
-  def bdi        (args: VDomModifier*): VNode = tag("bdi")(args)
+  def bdi        (args: VDomModifier*): VTree = tag("bdi")(args)
 
   /** Represents the directionality of its children, in order to explicitly
     * override the Unicode bidirectional algorithm.
     *
     *  MDN
     */
-  def bdo        (args: VDomModifier*): VNode = tag("bdo")(args)
+  def bdo        (args: VDomModifier*): VTree = tag("bdo")(args)
 
   /** Represents a content that is quoted from another source.
     *
     *  MDN
     */
-  def blockquote (args: VDomModifier*): VNode = tag("blockquote")(args)
+  def blockquote (args: VDomModifier*): VTree = tag("blockquote")(args)
 
   /** Represents the content of an HTML document. There is only one body
     *   element in a document.
     *
     *  MDN
     */
-  def body       (args: VDomModifier*): VNode = tag("body")(args)
+  def body       (args: VDomModifier*): VTree = tag("body")(args)
 
   /** Represents a line break.
     *
     *  MDN
     */
-  def br         (args: VDomModifier*): VNode = tag("br")(args)
+  def br         (args: VDomModifier*): VTree = tag("br")(args)
 
   /** A button
     *
     *  MDN
     */
-  def button     (args: VDomModifier*): VNode = tag("button")(args)
+  def button     (args: VDomModifier*): VTree = tag("button")(args)
 
   /** Represents a bitmap area that scripts can use to render graphics like graphs,
     * games or any visual images on the fly.
     *
     *  MDN
     */
-  def canvas     (args: VDomModifier*): VNode = tag("canvas")(args)
+  def canvas     (args: VDomModifier*): VTree = tag("canvas")(args)
 
   /** The title of a table.
     *
     *  MDN
     */
-  def caption    (args: VDomModifier*): VNode = tag("caption")(args)
+  def caption    (args: VDomModifier*): VTree = tag("caption")(args)
 
   /** Represents the title of a work being cited.
     *
     *  MDN
     */
-  def cite       (args: VDomModifier*): VNode = tag("cite")(args)
+  def cite       (args: VDomModifier*): VTree = tag("cite")(args)
 
   /** Represents computer code.
     *
     *  MDN
     */
-  def code       (args: VDomModifier*): VNode = tag("code")(args)
+  def code       (args: VDomModifier*): VTree = tag("code")(args)
 
   /** A single column.
     *
     *  MDN
     */
-  def col        (args: VDomModifier*): VNode = tag("col")(args)
+  def col        (args: VDomModifier*): VTree = tag("col")(args)
 
   /** A set of columns.
     *
     *  MDN
     */
-  def colgroup   (args: VDomModifier*): VNode = tag("colgroup")(args)
+  def colgroup   (args: VDomModifier*): VTree = tag("colgroup")(args)
 
   /** Links a given content with a machine-readable translation.
     * If the content is time- or date-related, the `<time>` element must be used.
     *
     * MDN
     */
-  def dataElement(args: VDomModifier*): VNode = tag("data")(args)
+  def dataElement(args: VDomModifier*): VTree = tag("data")(args)
 
   /** A set of predefined options for other controls.
     *
     *  MDN
     */
-  def datalist   (args: VDomModifier*): VNode = tag("datalist")(args)
+  def datalist   (args: VDomModifier*): VTree = tag("datalist")(args)
 
   /** Represents the definition of the terms immediately listed before it.
     *
     * MDN
     */
-  def dd         (args: VDomModifier*): VNode = tag("dd")(args)
+  def dd         (args: VDomModifier*): VTree = tag("dd")(args)
 
   /** Defines a removal from the document.
     *
     * MDN
     */
-  def del        (args: VDomModifier*): VNode = tag("del")(args)
+  def del        (args: VDomModifier*): VTree = tag("del")(args)
 
   /** A widget from which the user can obtain additional information
     * or controls.
     *
     * MDN
     */
-  def details    (args: VDomModifier*): VNode = tag("details")(args)
+  def details    (args: VDomModifier*): VTree = tag("details")(args)
 
   /** Represents a term whose definition is contained in its nearest ancestor
     * content.
     *
     * MDN
     */
-  def dfn        (args: VDomModifier*): VNode = tag("dfn")(args)
+  def dfn        (args: VDomModifier*): VTree = tag("dfn")(args)
 
   /** Represents a dialog box or other interactive component, such as an inspector
     * or window.
     *
     * MDN
     */
-  def dialog     (args: VDomModifier*): VNode = tag("dialog")(args)
+  def dialog     (args: VDomModifier*): VTree = tag("dialog")(args)
 
   /** Represents a generic container with no special meaning.
     *
     * MDN
     */
-  def div        (args: VDomModifier*): VNode = tag("div")(args)
+  def div        (args: VDomModifier*): VTree = tag("div")(args)
 
   /** Defines a definition list; a list of terms and their associated definitions.
     *
     * MDN
     */
-  def dl         (args: VDomModifier*): VNode = tag("dl")(args)
+  def dl         (args: VDomModifier*): VTree = tag("dl")(args)
 
   /** Represents a term defined by the next dd
     *
     * MDN
     */
-  def dt         (args: VDomModifier*): VNode = tag("dt")(args)
+  def dt         (args: VDomModifier*): VTree = tag("dt")(args)
 
   /** Represents emphasized text.
     *
     * MDN
     */
-  def em         (args: VDomModifier*): VNode = tag("em")(args)
+  def em         (args: VDomModifier*): VTree = tag("em")(args)
 
   /** Represents a integration point for an external, often non-HTML, application
     * or interactive content.
     *
     * MDN
     */
-  def embed      (args: VDomModifier*): VNode = tag("embed")(args)
+  def embed      (args: VDomModifier*): VTree = tag("embed")(args)
 
   /** A set of fields.
     *
     * MDN
     */
-  def fieldset   (args: VDomModifier*): VNode = tag("fieldset")(args)
+  def fieldset   (args: VDomModifier*): VTree = tag("fieldset")(args)
 
   /** Represents the legend of a figure.
     *
     * MDN
     */
-  def figcaption (args: VDomModifier*): VNode = tag("figcaption")(args)
+  def figcaption (args: VDomModifier*): VTree = tag("figcaption")(args)
 
   /** Represents a figure illustrated as part of the document.
     *
     * MDN
     */
-  def figure     (args: VDomModifier*): VNode = tag("figure")(args)
+  def figure     (args: VDomModifier*): VTree = tag("figure")(args)
 
   /** Defines the footer for a page or section. It often contains a copyright
     * notice, some links to legal information, or addresses to give feedback.
     *
     * MDN
     */
-  def footer     (args: VDomModifier*): VNode = tag("footer")(args)
+  def footer     (args: VDomModifier*): VTree = tag("footer")(args)
 
   /** Represents a form, consisting of controls, that can be submitted to a
     * server for processing.
     *
     * MDN
     */
-  def form       (args: VDomModifier*): VNode = tag("form")(args)
+  def form       (args: VDomModifier*): VTree = tag("form")(args)
 
   /** Heading level 1
     *
     * MDN
     */
-  def h1         (args: VDomModifier*): VNode = tag("h1")(args)
+  def h1         (args: VDomModifier*): VTree = tag("h1")(args)
 
   /** Heading level 2
     *
     * MDN
     */
-  def h2         (args: VDomModifier*): VNode = tag("h2")(args)
+  def h2         (args: VDomModifier*): VTree = tag("h2")(args)
 
   /** Heading level 3
     *
     * MDN
     */
-  def h3         (args: VDomModifier*): VNode = tag("h3")(args)
+  def h3         (args: VDomModifier*): VTree = tag("h3")(args)
 
   /** Heading level 4
     *
     * MDN
     */
-  def h4         (args: VDomModifier*): VNode = tag("h4")(args)
+  def h4         (args: VDomModifier*): VTree = tag("h4")(args)
 
   /** Heading level 5
     *
     * MDN
     */
-  def h5         (args: VDomModifier*): VNode = tag("h5")(args)
+  def h5         (args: VDomModifier*): VTree = tag("h5")(args)
 
   /** Heading level 6
     *
     * MDN
     */
-  def h6         (args: VDomModifier*): VNode = tag("h6")(args)
+  def h6         (args: VDomModifier*): VTree = tag("h6")(args)
 
   /** Represents a collection of metadata about the document, including links to,
     * or definitions of, scripts and style sheets.
     *
     * MDN
     */
-  def head       (args: VDomModifier*): VNode = tag("head")(args)
+  def head       (args: VDomModifier*): VTree = tag("head")(args)
 
   /** Defines the header of a page or section. It often contains a logo, the
     * title of the Web site, and a navigational table of content.
     *
     * MDN
     */
-  def header     (args: VDomModifier*): VNode = tag("header")(args)
+  def header     (args: VDomModifier*): VTree = tag("header")(args)
 
   /** Represents a thematic break between paragraphs of a section or article or
     * any longer content.
     *
     * MDN
     */
-  def hr         (args: VDomModifier*): VNode = tag("hr")(args)
+  def hr         (args: VDomModifier*): VTree = tag("hr")(args)
 
   /** Italicized text.
     *
     * MDN
     */
-  def i          (args: VDomModifier*): VNode = tag("i")(args)
+  def i          (args: VDomModifier*): VTree = tag("i")(args)
 
   /** Represents a nested browsing context, that is an embedded HTML document.
     *
     * MDN
     */
-  def iframe     (args: VDomModifier*): VNode = tag("iframe")(args)
+  def iframe     (args: VDomModifier*): VTree = tag("iframe")(args)
 
   /** Represents an image.
     *
     * MDN
     */
-  def img        (args: VDomModifier*): VNode = tag("img")(args)
+  def img        (args: VDomModifier*): VTree = tag("img")(args)
 
   /** A typed data field allowing the user to input data.
     *
     * MDN
     */
-  def input      (args: VDomModifier*): VNode = tag("input")(args)
+  def input      (args: VDomModifier*): VTree = tag("input")(args)
 
   /** Defines an addition to the document.
     *
     * MDN
     */
-  def ins        (args: VDomModifier*): VNode = tag("ins")(args)
+  def ins        (args: VDomModifier*): VTree = tag("ins")(args)
 
   /** Represents user input, often from a keyboard, but not necessarily.
     *
     * MDN
     */
-  def kbd        (args: VDomModifier*): VNode = tag("kbd")(args)
+  def kbd        (args: VDomModifier*): VTree = tag("kbd")(args)
 
   /** A key-pair generator control.
     *
@@ -367,57 +367,57 @@ trait Tags {
       |compatibility table at the bottom of this page to guide your decision.
       |Be aware that this feature may cease to work at any time.
     """.stripMargin, "0.9.0")
-  def keygen     (args: VDomModifier*): VNode = tag("keygen")(args)
+  def keygen     (args: VDomModifier*): VTree = tag("keygen")(args)
 
   /** The caption of a single field
     *
     * MDN
     */
-  def label      (args: VDomModifier*): VNode = tag("label")(args)
+  def label      (args: VDomModifier*): VTree = tag("label")(args)
 
   /** The caption for a fieldset.
     *
     * MDN
     */
-  def legend     (args: VDomModifier*): VNode = tag("legend")(args)
+  def legend     (args: VDomModifier*): VTree = tag("legend")(args)
 
   /** Defines an item of an list.
     *
     * MDN
     */
-  def li         (args: VDomModifier*): VNode = tag("li")(args)
+  def li         (args: VDomModifier*): VTree = tag("li")(args)
 
   /** Used to link JavaScript and external CSS with the current HTML document.
     *
     * MDN
     */
-  def link       (args: VDomModifier*): VNode = tag("link")(args)
+  def link       (args: VDomModifier*): VTree = tag("link")(args)
 
   /** Defines the main or important content in the document. There is only one
     * main element in the document.
     *
     * MDN
     */
-  def main       (args: VDomModifier*): VNode = tag("main")(args)
+  def main       (args: VDomModifier*): VTree = tag("main")(args)
 
   /** In conjunction with area, defines an image map.
     *
     * MDN
     */
-  def map        (args: VDomModifier*): VNode = tag("map")(args)
+  def map        (args: VDomModifier*): VTree = tag("map")(args)
 
   /** Represents text highlighted for reference purposes, that is for its
     * relevance in another context.
     *
     * MDN
     */
-  def mark       (args: VDomModifier*): VNode = tag("mark")(args)
+  def mark       (args: VDomModifier*): VTree = tag("mark")(args)
 
   /** Defines a mathematical formula.
     *
     * MDN
     */
-  def math       (args: VDomModifier*): VNode = tag("math")(args)
+  def math       (args: VDomModifier*): VTree = tag("math")(args)
 
   /** Represents a group of commands that a user can perform or activate.
     * This includes both list menus, which might appear across the top of
@@ -426,7 +426,7 @@ trait Tags {
     *
     * MDN
     */
-  def menu       (args: VDomModifier*): VNode = tag("menu")(args)
+  def menu       (args: VDomModifier*): VTree = tag("menu")(args)
 
   /** Represents a command that a user is able to invoke through a popup menu.
     * This includes context menus, as well as menus that might be attached to
@@ -442,96 +442,96 @@ trait Tags {
     *
     * MDN
     */
-  def menuitem   (args: VDomModifier*): VNode = tag("menuitem")(args)
+  def menuitem   (args: VDomModifier*): VTree = tag("menuitem")(args)
 
   /** Defines metadata that can't be defined using another HTML element.
     *
     * MDN
     */
-  def meta       (args: VDomModifier*): VNode = tag("meta")(args)
+  def meta       (args: VDomModifier*): VTree = tag("meta")(args)
 
   /** A scalar measurement within a known range.
     *
     * MDN
     */
-  def meter      (args: VDomModifier*): VNode = tag("meter")(args)
+  def meter      (args: VDomModifier*): VTree = tag("meter")(args)
 
   /** Represents a section of a page that links to other pages or to parts within
     * the page: a section with navigation links.
     *
     * MDN
     */
-  def nav        (args: VDomModifier*): VNode = tag("nav")(args)
+  def nav        (args: VDomModifier*): VTree = tag("nav")(args)
 
   /** Defines alternative content to display when the browser doesn't support
     * scripting.
     *
     * MDN
     */
-  def noscript   (args: VDomModifier*): VNode = tag("noscript")(args)
+  def noscript   (args: VDomModifier*): VTree = tag("noscript")(args)
 
   /** Represents an external resource, which is treated as an image, an HTML
     * sub-document, or an external resource to be processed by a plug-in.
     *
     * MDN
     */
-  def `object`   (args: VDomModifier*): VNode = tag("object")(args)
+  def `object`   (args: VDomModifier*): VTree = tag("object")(args)
 
   /** Defines an ordered list of items.
     *
     * MDN
     */
-  def ol         (args: VDomModifier*): VNode = tag("ol")(args)
+  def ol         (args: VDomModifier*): VTree = tag("ol")(args)
 
   /** A set of options, logically grouped.
     *
     * MDN
     */
-  def optgroup   (args: VDomModifier*): VNode = tag("optgroup")(args)
+  def optgroup   (args: VDomModifier*): VTree = tag("optgroup")(args)
 
   /**
     * An option in a select element.
     *
     *  MDN
     */
-  def option     (args: VDomModifier*): VNode = tag("option")(args)
+  def option     (args: VDomModifier*): VTree = tag("option")(args)
 
   /** The result of a calculation
     *
     * MDN
     */
-  def output     (args: VDomModifier*): VNode = tag("output")(args)
+  def output     (args: VDomModifier*): VTree = tag("output")(args)
 
   /** Defines a portion that should be displayed as a paragraph.
     *
     * MDN
     */
-  def p          (args: VDomModifier*): VNode = tag("p")(args)
+  def p          (args: VDomModifier*): VTree = tag("p")(args)
 
   /** Defines parameters for use by plug-ins invoked by object elements.
     *
     * MDN
     */
-  def param      (args: VDomModifier*): VNode = tag("param")(args)
+  def param      (args: VDomModifier*): VTree = tag("param")(args)
 
   /** Indicates that its content is preformatted and that this format must be
     * preserved.
     *
     * MDN
     */
-  def pre        (args: VDomModifier*): VNode = tag("pre")(args)
+  def pre        (args: VDomModifier*): VTree = tag("pre")(args)
 
   /** A progress completion bar
     *
     * MDN
     */
-  def progress   (args: VDomModifier*): VNode = tag("progress")(args)
+  def progress   (args: VDomModifier*): VTree = tag("progress")(args)
 
   /** An inline quotation.
     *
     * MDN
     */
-  def q          (args: VDomModifier*): VNode = tag("q")(args)
+  def q          (args: VDomModifier*): VTree = tag("q")(args)
 
   /** Represents parenthesis around a ruby annotation, used to display the
     * annotation in an alternate way by browsers not supporting the standard
@@ -539,7 +539,7 @@ trait Tags {
     *
     * MDN
     */
-  def rp         (args: VDomModifier*): VNode = tag("rp")(args)
+  def rp         (args: VDomModifier*): VTree = tag("rp")(args)
 
   /** Represents content to be marked with ruby annotations, short runs of text
     * presented alongside the text. This is often used in conjunction with East
@@ -548,66 +548,66 @@ trait Tags {
     *
     * MDN
     */
-  def ruby         (args: VDomModifier*): VNode = tag("ruby")(args)
+  def ruby         (args: VDomModifier*): VTree = tag("ruby")(args)
 
   /** Represents the text of a ruby annotation.
     *
     * MDN
     */
-  def rt         (args: VDomModifier*): VNode = tag("rt")(args)
+  def rt         (args: VDomModifier*): VTree = tag("rt")(args)
 
   /** Strikethrough element, used for that is no longer accurate or relevant.
     *
     * MDN
     */
-  def s          (args: VDomModifier*): VNode = tag("s")(args)
+  def s          (args: VDomModifier*): VTree = tag("s")(args)
 
   /** Represents sample output of a program or a computer.
     *
     * MDN
     */
-  def samp       (args: VDomModifier*): VNode = tag("samp")(args)
+  def samp       (args: VDomModifier*): VTree = tag("samp")(args)
 
   /** Defines either an internal script or a link to an external script. The
     * script language is JavaScript.
     *
     * MDN
     */
-  def script     (args: VDomModifier*): VNode = tag("script")(args)
+  def script     (args: VDomModifier*): VTree = tag("script")(args)
 
   /** Represents a generic section of a document, i.e., a thematic grouping of
     * content, typically with a heading.
     *
     * MDN
     */
-  def section    (args: VDomModifier*): VNode = tag("section")(args)
+  def section    (args: VDomModifier*): VTree = tag("section")(args)
 
   /** A control that allows the user to select one of a set of options.
     *
     * MDN
     */
-  def select     (args: VDomModifier*): VNode = tag("select")(args)
+  def select     (args: VDomModifier*): VTree = tag("select")(args)
 
   /** Represents a placeholder inside a web component that you can fill with
     * your own markup, with the effect of composing different DOM trees together.
     *
     * MDN
     */
-  def slot       (args: VDomModifier*): VNode = tag("slot")(args)
+  def slot       (args: VDomModifier*): VTree = tag("slot")(args)
 
   /** Represents a side comment; text like a disclaimer or copyright, which is not
     * essential to the comprehension of the document.
     *
     * MDN
     */
-  def small      (args: VDomModifier*): VNode = tag("small")(args)
+  def small      (args: VDomModifier*): VTree = tag("small")(args)
 
   /** Allows the authors to specify alternate media resources for media elements
     * like video or audio
     *
     * MDN
     */
-  def source     (args: VDomModifier*): VNode = tag("source")(args)
+  def source     (args: VDomModifier*): VTree = tag("source")(args)
 
   /** Represents text with no specific meaning. This has to be used when no other
     * text-semantic element conveys an adequate meaning, which, in this case, is
@@ -615,86 +615,86 @@ trait Tags {
     *
     * MDN
     */
-  def span       (args: VDomModifier*): VNode = tag("span")(args)
+  def span       (args: VDomModifier*): VTree = tag("span")(args)
 
   /** Represents especially important text.
     *
     * MDN
     */
-  def strong     (args: VDomModifier*): VNode = tag("strong")(args)
+  def strong     (args: VDomModifier*): VTree = tag("strong")(args)
 
   /** Used to write inline CSS.
     *
     * MDN
     */
-  def style      (args: VDomModifier*): VNode = tag("style")(args)
+  def style      (args: VDomModifier*): VTree = tag("style")(args)
 
   /** Subscript tag
     *
     * MDN
     */
-  def sub        (args: VDomModifier*): VNode = tag("sub")(args)
+  def sub        (args: VDomModifier*): VTree = tag("sub")(args)
 
   /** A summary, caption, or legend for a given details.
     *
     * MDN
     */
-  def summary    (args: VDomModifier*): VNode = tag("summary")(args)
+  def summary    (args: VDomModifier*): VTree = tag("summary")(args)
 
   /** Superscript tag.
     *
     * MDN
     */
-  def sup        (args: VDomModifier*): VNode = tag("sup")(args)
+  def sup        (args: VDomModifier*): VTree = tag("sup")(args)
 
   /** Represents data with more than one dimension.
     *
     * MDN
     */
-  def table      (args: VDomModifier*): VNode = tag("table")(args)
+  def table      (args: VDomModifier*): VTree = tag("table")(args)
 
   /** The table body.
     *
     * MDN
     */
-  def tbody      (args: VDomModifier*): VNode = tag("tbody")(args)
+  def tbody      (args: VDomModifier*): VTree = tag("tbody")(args)
 
   /** A single cell in a table.
     *
     * MDN
     */
-  def td         (args: VDomModifier*): VNode = tag("td")(args)
+  def td         (args: VDomModifier*): VTree = tag("td")(args)
 
   /** A multiline text edit control.
     *
     * MDN
     */
-  def textarea   (args: VDomModifier*): VNode = tag("textarea")(args)
+  def textarea   (args: VDomModifier*): VTree = tag("textarea")(args)
 
   /** The table footer.
     *
     * MDN
     */
-  def tfoot      (args: VDomModifier*): VNode = tag("tfoot")(args)
+  def tfoot      (args: VDomModifier*): VTree = tag("tfoot")(args)
 
   /** A header cell in a table.
     *
     * MDN
     */
-  def th         (args: VDomModifier*): VNode = tag("th")(args)
+  def th         (args: VDomModifier*): VTree = tag("th")(args)
 
   /** The table headers.
     *
     * MDN
     */
-  def thead      (args: VDomModifier*): VNode = tag("thead")(args)
+  def thead      (args: VDomModifier*): VTree = tag("thead")(args)
 
   /** Represents a date and time value; the machine-readable equivalent can be
     * represented in the datetime attribetu
     *
     * MDN
     */
-  def time       (args: VDomModifier*): VNode = tag("time")(args)
+  def time       (args: VDomModifier*): VTree = tag("time")(args)
 
   /** Defines the title of the document, shown in a browser's title bar or on the
     * page's tab. It can only contain text and any contained tags are not
@@ -702,46 +702,46 @@ trait Tags {
     *
     * MDN
     */
-  def title      (args: VDomModifier*): VNode = tag("title")(args)
+  def title      (args: VDomModifier*): VTree = tag("title")(args)
 
   /** A single row in a table.
     *
     * MDN
     */
-  def tr         (args: VDomModifier*): VNode = tag("tr")(args)
+  def tr         (args: VDomModifier*): VTree = tag("tr")(args)
 
   /** Allows authors to specify timed text track for media elements like video or
     * audio
     *
     * MDN
     */
-  def track      (args: VDomModifier*): VNode = tag("track")(args)
+  def track      (args: VDomModifier*): VTree = tag("track")(args)
 
   /** Underlined text.
     *
     * MDN
     */
-  def u          (args: VDomModifier*): VNode = tag("u")(args)
+  def u          (args: VDomModifier*): VTree = tag("u")(args)
 
   /** Defines an unordered list of items.
     *
     * MDN
     */
-  def ul         (args: VDomModifier*): VNode = tag("ul")(args)
+  def ul         (args: VDomModifier*): VTree = tag("ul")(args)
 
   /** Represents a video, and its associated audio files and captions, with the
     * necessary interface to play it.
     *
     * MDN
     */
-  def video      (args: VDomModifier*): VNode = tag("video")(args)
+  def video      (args: VDomModifier*): VTree = tag("video")(args)
 
   /** Represents a line break opportunity, that is a suggested point for wrapping
     * text in order to improve readability of text split on several lines.
     *
     * MDN
     */
-  def wbr        (args: VDomModifier*): VNode = tag("wbr")(args)
+  def wbr        (args: VDomModifier*): VTree = tag("wbr")(args)
 }
 
 object Tags extends Tags

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -1,12 +1,15 @@
 package outwatch.dom
 
+import cats.effect.IO
 import org.scalajs.dom._
+
 import scala.scalajs.js.|
 import rxscalajs.{Observable, Observer}
 import snabbdom.{VNodeProxy, h}
 
-import scala.scalajs.js
-import collection.breakOut
+import cats.instances.list._
+import cats.syntax.traverse._
+import scala.scalajs.js.JSConverters._
 
 sealed trait VDomModifier extends Any
 
@@ -19,7 +22,7 @@ sealed trait Property extends VDomModifier
 sealed trait Receiver extends VDomModifier
 
 sealed trait VNode extends VDomModifier {
-  def asProxy: VNodeProxy
+  def asProxy: IO[VNodeProxy]
 }
 
 final case class EventEmitter[E <: Event](eventType: String, sink: Observer[E]) extends Emitter
@@ -27,7 +30,7 @@ final case class StringEventEmitter(eventType: String, sink: Observer[String]) e
 final case class BoolEventEmitter(eventType: String, sink: Observer[Boolean]) extends Emitter
 final case class NumberEventEmitter(eventType: String, sink: Observer[Double]) extends Emitter
 
-sealed trait Attribute extends Property{
+sealed trait Attribute extends Property {
   val title: String
 }
 
@@ -47,23 +50,24 @@ final case class AttributeStreamReceiver(attribute: String, attributeStream: Obs
 final case class ChildStreamReceiver(childStream: Observable[VNode]) extends Receiver
 final case class ChildrenStreamReceiver(childrenStream: Observable[Seq[VNode]]) extends Receiver
 
-final case object EmptyVDomModifier extends VDomModifier
-
+case object EmptyVDomModifier extends VDomModifier
 
 object VDomModifier {
-  final implicit class StringNode(string: String) extends VNode {
-    def asProxy = VNodeProxy.fromString(string)
+  implicit class StringNode(string: String) extends VNode {
+    val asProxy: IO[VNodeProxy] = IO.pure(VNodeProxy.fromString(string))
   }
 
-  implicit def OptionIsEmptyModifier(opt: Option[VDomModifier]): VDomModifier = opt getOrElse EmptyVDomModifier
+  implicit def optionIsEmptyModifier(opt: Option[VDomModifier]): VDomModifier = opt getOrElse EmptyVDomModifier
 
   final case class VTree(nodeType: String, modifiers: Vector[VDomModifier]) extends VNode {
     import helpers.DomUtils
 
-    def asProxy = {
+    val asProxy = {
       val (children, attributeObject) = DomUtils.extractChildrenAndDataObject(modifiers)
-      val childProxies: js.Array[VNodeProxy] = children.map(_.asProxy)(breakOut)
-      h(nodeType, attributeObject, childProxies)
+      for {
+        childProxies <- children.map(_.asProxy).sequence
+      }
+      yield h(nodeType, attributeObject, childProxies.toJSArray) // TODO: iterate only once over children
     }
 
     def apply(args: VDomModifier*):VNode = VTree(nodeType, modifiers ++ args)

--- a/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -15,9 +15,9 @@ object ChildStreamReceiverBuilder {
     ChildStreamReceiver(valueStream.map(anyToVNode))
   }
 
-  private val anyToVNode = (any: Any) => any match {
+  private val anyToVNode: Any => VNode = {
     case vn: VNode => vn
-    case _ => VDomModifier.StringNode(any.toString)
+    case any => any.toString
   }
 }
 

--- a/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -1,5 +1,6 @@
 package outwatch.dom.helpers
 
+import cats.effect.IO
 import org.scalajs.dom._
 import org.scalajs.dom.raw.HTMLInputElement
 import outwatch.dom._
@@ -118,7 +119,7 @@ object DomUtils {
     def toProxy(changable: (Seq[Attribute], Seq[VNode])): VNodeProxy = changable match {
       case (attributes, nodes) =>
         val updatedObj = proxy.data.withUpdatedAttributes(attributes)
-        h(proxy.sel, updatedObj, proxy.children ++ (nodes.map(_.asProxy)(breakOut):js.Array[VNodeProxy]))
+        h(proxy.sel, updatedObj, proxy.children ++ (nodes.map(_.asProxy.unsafeRunSync())(breakOut):js.Array[VNodeProxy])) //TODO why unsafe?
     }
 
     val subscription = changables.observable
@@ -141,55 +142,55 @@ object DomUtils {
 
 
   private[outwatch] final case class SeparatedModifiers(
-    emitters: Seq[Emitter] = Seq.empty[Emitter],
-    receivers: Seq[Receiver] = Seq.empty[Receiver],
-    properties: Seq[Property] = Seq.empty[Property],
-    vNodes: Seq[VNode] = Seq.empty[VNode]
+    emitters: List[Emitter] = Nil,
+    receivers: List[Receiver] = Nil,
+    properties: List[Property] = Nil,
+    vNodes: List[VNode] = Nil
   )
   private[outwatch] def separateModifiers(args: Seq[VDomModifier]): SeparatedModifiers = {
     args.foldRight(SeparatedModifiers())(separatorFn)
   }
 
   private[outwatch] def separatorFn(mod: VDomModifier, res: SeparatedModifiers): SeparatedModifiers = (mod, res) match {
-    case (em: Emitter, sf) => sf.copy(emitters = em +: sf.emitters)
-    case (rc: Receiver, sf) => sf.copy(receivers = rc +: sf.receivers)
-    case (pr: Property, sf) => sf.copy(properties = pr +: sf.properties)
-    case (vn: VNode, sf) => sf.copy(vNodes = vn +: sf.vNodes)
+    case (em: Emitter, sf) => sf.copy(emitters = em :: sf.emitters)
+    case (rc: Receiver, sf) => sf.copy(receivers = rc :: sf.receivers)
+    case (pr: Property, sf) => sf.copy(properties = pr :: sf.properties)
+    case (vn: VNode, sf) => sf.copy(vNodes = vn :: sf.vNodes)
     case (EmptyVDomModifier, sf) => sf
   }
 
 
   private[outwatch] final case class SeparatedReceivers(
-    childStream: Seq[ChildStreamReceiver] = Seq.empty[ChildStreamReceiver],
-    childrenStream: Seq[ChildrenStreamReceiver] = Seq.empty[ChildrenStreamReceiver],
-    attributeStream: Seq[AttributeStreamReceiver] = Seq.empty[AttributeStreamReceiver]
+    childStream: List[ChildStreamReceiver] = Nil,
+    childrenStream: List[ChildrenStreamReceiver] = Nil,
+    attributeStream: List[AttributeStreamReceiver] = Nil
   )
   private[outwatch] def separateReceivers(receivers: Seq[Receiver]): SeparatedReceivers = {
     receivers.foldRight(SeparatedReceivers()) {
-      case (cr: ChildStreamReceiver, sr) => sr.copy(childStream = cr +: sr.childStream)
-      case (cs: ChildrenStreamReceiver, sr) => sr.copy(childrenStream = cs +: sr.childrenStream)
-      case (ar: AttributeStreamReceiver, sr) => sr.copy(attributeStream = ar +: sr.attributeStream)
+      case (cr: ChildStreamReceiver, sr) => sr.copy(childStream = cr :: sr.childStream)
+      case (cs: ChildrenStreamReceiver, sr) => sr.copy(childrenStream = cs :: sr.childrenStream)
+      case (ar: AttributeStreamReceiver, sr) => sr.copy(attributeStream = ar :: sr.attributeStream)
     }
   }
 
   private[outwatch] final case class SeparatedProperties(
-    insertHooks: Seq[InsertHook] = Seq.empty[InsertHook],
-    destroyHooks: Seq[DestroyHook] = Seq.empty[DestroyHook],
-    updateHooks: Seq[UpdateHook] = Seq.empty[UpdateHook],
-    attributeHooks: Seq[Attribute] = Seq.empty[Attribute],
-    keys: Seq[Key] = Seq.empty[Key]
+    insertHooks: List[InsertHook] = Nil,
+    destroyHooks: List[DestroyHook] = Nil,
+    updateHooks: List[UpdateHook] = Nil,
+    attributeHooks: List[Attribute] = Nil,
+    keys: List[Key] = Nil
   )
   private[outwatch] def separateProperties(properties: Seq[Property]): SeparatedProperties = {
     properties.foldRight(SeparatedProperties()) {
-      case (ih: InsertHook, sp) => sp.copy(insertHooks = ih +: sp.insertHooks)
-      case (dh: DestroyHook, sp) => sp.copy(destroyHooks = dh +: sp.destroyHooks)
-      case (uh: UpdateHook, sp) => sp.copy(updateHooks = uh +: sp.updateHooks)
-      case (at: Attribute, sp)  => sp.copy(attributeHooks = at +: sp.attributeHooks)
-      case (key: Key, sp) => sp.copy(keys = key +: sp.keys)
+      case (ih: InsertHook, sp) => sp.copy(insertHooks = ih :: sp.insertHooks)
+      case (dh: DestroyHook, sp) => sp.copy(destroyHooks = dh :: sp.destroyHooks)
+      case (uh: UpdateHook, sp) => sp.copy(updateHooks = uh :: sp.updateHooks)
+      case (at: Attribute, sp)  => sp.copy(attributeHooks = at :: sp.attributeHooks)
+      case (key: Key, sp) => sp.copy(keys = key :: sp.keys)
     }
   }
 
-  private[outwatch] def extractChildrenAndDataObject(args: Seq[VDomModifier]): (Seq[VNode], DataObject) = {
+  private[outwatch] def extractChildrenAndDataObject(args: Seq[VDomModifier]): (List[VNode], DataObject) = {
     val SeparatedModifiers(emitters, receivers, properties, children) = separateModifiers(args)
 
     val SeparatedReceivers(childReceivers, childrenReceivers, attributeReceivers) = separateReceivers(receivers)
@@ -203,9 +204,10 @@ object DomUtils {
     (children, dataObject)
   }
 
-  def render(element: Element, vNode: VNode): Unit = {
-    val elem = document.createElement("app")
-    element.appendChild(elem)
-    patch(elem,vNode.asProxy)
-  }
+  def render(element: Element, vNode: VNode): IO[Unit] = for {
+    elem <- IO(document.createElement("app"))
+    _ <- IO(element.appendChild(elem))
+    node <- vNode.asProxy
+    _ <- IO(patch(elem, node))
+  } yield ()
 }

--- a/src/main/scala/outwatch/dom/helpers/STRef.scala
+++ b/src/main/scala/outwatch/dom/helpers/STRef.scala
@@ -4,11 +4,15 @@ import cats.effect.IO
 
 class STRef[A](private var unsafeGet: A) {
   def put(a: A): IO[A] = IO { unsafeGet = a; a }
-  def get: IO[A] = IO(unsafeGet)
+
+  def getOrThrow(t: Throwable): IO[A] = IO(unsafeGet)
+    .flatMap(s => if (s == null) IO.raiseError(t) else IO.pure(s)) // scalastyle:ignore
+
+  def get: IO[A] = getOrThrow(new IllegalStateException())
   def update(f: A => A): IO[A] = IO { unsafeGet = f(unsafeGet); unsafeGet }
 }
 
 object STRef {
   def apply[A](a: A) = new STRef(a)
-  def empty[A] = new STRef[A](null.asInstanceOf[A])
+  def empty[A] = new STRef[A](null.asInstanceOf[A]) // scalastyle:ignore
 }

--- a/src/main/scala/outwatch/dom/helpers/STRef.scala
+++ b/src/main/scala/outwatch/dom/helpers/STRef.scala
@@ -1,0 +1,14 @@
+package outwatch.dom.helpers
+
+import cats.effect.IO
+
+class STRef[A](private var unsafeGet: A) {
+  def put(a: A): IO[A] = IO { unsafeGet = a; a }
+  def get: IO[A] = IO(unsafeGet)
+  def update(f: A => A): IO[A] = IO { unsafeGet = f(unsafeGet); unsafeGet }
+}
+
+object STRef {
+  def apply[A](a: A) = new STRef(a)
+  def empty[A] = new STRef[A](null.asInstanceOf[A])
+}

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -3,7 +3,5 @@ package outwatch
 import rxscalajs.Observable
 
 package object dom extends Attributes with Tags with Handlers {
-
   type Handler[T] = Observable[T] with Sink[T]
-
 }

--- a/src/main/scala/outwatch/util/LocalStorage.scala
+++ b/src/main/scala/outwatch/util/LocalStorage.scala
@@ -1,5 +1,6 @@
 package outwatch.util
 
+import cats.effect.IO
 import outwatch.Sink
 import rxscalajs.Observable
 import org.scalajs.dom.window.localStorage
@@ -13,6 +14,6 @@ object LocalStorageReader {
 
 object LocalStorageWriter {
   def apply(key: String): Sink[String] = {
-    Sink.create[String](data => localStorage.setItem(key, data))
+    Sink.create[String](data => IO(localStorage.setItem(key, data)))
   }
 }

--- a/src/main/scala/outwatch/util/Store.scala
+++ b/src/main/scala/outwatch/util/Store.scala
@@ -2,7 +2,8 @@ package outwatch.util
 
 import cats.effect.IO
 import outwatch.Sink
-import outwatch.dom.createHandler
+import outwatch.dom._
+import outwatch.dom.helpers.STRef
 import rxscalajs.Observable
 import rxscalajs.subscription.Subscription
 
@@ -21,4 +22,20 @@ final case class Store[State, Action](initialState: State, reducer: (State, Acti
 object Store {
   implicit def toSink[Action](store: Store[_, Action]): Sink[Action] = store.sink
   implicit def toSource[State](store: Store[State, _]): Observable[State] = store.source
+
+  private val storeRef = STRef.empty
+
+  def renderWithStore[S, A](initialState: S, reducer: (S, A) => S, selector: String, root: VNode): IO[Unit] = for {
+    store <- IO(Store(initialState, reducer))
+    _ <- storeRef.asInstanceOf[STRef[Store[S, A]]].put(store)
+    _ <- OutWatch.render(selector, root)
+  } yield ()
+
+  def getStore[S, A]: VNodeIO[Store[S, A]] = Pure(
+    storeRef.asInstanceOf[STRef[Store[S, A]]].getOrThrow(NoStoreException)
+  )
+
+  private object NoStoreException extends
+    Exception("Application was rendered without specifying a Store, please use Outwatch.renderWithStore instead")
+
 }

--- a/src/main/scala/outwatch/util/WebSocket.scala
+++ b/src/main/scala/outwatch/util/WebSocket.scala
@@ -1,8 +1,10 @@
 package outwatch.util
 
+import cats.effect.IO
 import org.scalajs.dom.raw.{CloseEvent, ErrorEvent, MessageEvent}
 import outwatch.Sink
 import rxscalajs.Observable
+
 import scala.language.implicitConversions
 
 object WebSocket {
@@ -20,7 +22,7 @@ final case class WebSocket private(url: String) {
     () => ws.close()
   })
 
-  lazy val sink = Sink.create[String](s => ws.send(s), _ => (), () => ws.close())
+  lazy val sink = Sink.create[String](s => IO(ws.send(s)), _ => IO.pure(()), () => IO(ws.close()))
 
 }
 

--- a/src/main/scala/snabbdom/h.scala
+++ b/src/main/scala/snabbdom/h.scala
@@ -20,7 +20,7 @@ trait hFunction extends js.Any {
 
 object h {
   def apply(nodeType: String, dataObject: DataObject, children: String | js.Array[_ <: Any]): VNodeProxy = {
-    hProvider.default.apply(nodeType,dataObject,children)
+    hProvider.default.apply(nodeType, dataObject, children)
   }
 }
 

--- a/src/main/scala/snabbdom/h.scala
+++ b/src/main/scala/snabbdom/h.scala
@@ -110,7 +110,7 @@ object DataObject {
     )
   }
 
-  implicit class DataObjectExt(obj: DataObject) {
+  implicit class DataObjectExt(val obj: DataObject) extends AnyVal {
 
     def withUpdatedAttributes(attributes: Seq[Attribute]): DataObject = {
       import scala.scalajs.js.JSConverters._

--- a/src/test/scala/outwatch/AttributeSpec.scala
+++ b/src/test/scala/outwatch/AttributeSpec.scala
@@ -5,7 +5,7 @@ import outwatch.dom._
 class AttributeSpec extends UnitSpec {
 
   "data attribute" should "correctly render only data" in {
-    val node = input(data := "bar").asProxy
+    val node = input(data := "bar").asProxy.unsafeRunSync()
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data" -> "bar"
@@ -13,7 +13,7 @@ class AttributeSpec extends UnitSpec {
   }
 
   it should "correctly render expanded data with dynamic content" in {
-    val node = input(data.foo := "bar").asProxy
+    val node = input(data.foo := "bar").asProxy.unsafeRunSync()
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data-foo" -> "bar"
@@ -24,7 +24,7 @@ class AttributeSpec extends UnitSpec {
     val node = input(
       data.foo :=? Option("bar"),
       data.bar :=? Option.empty[String]
-    ).asProxy
+    ).asProxy.unsafeRunSync()
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data-foo" -> "bar"
@@ -38,7 +38,7 @@ class AttributeSpec extends UnitSpec {
     )(
       data := "buh",
       data.tomate := "gisela"
-    ).asProxy
+    ).asProxy.unsafeRunSync()
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data" -> "buh",
@@ -54,7 +54,7 @@ class AttributeSpec extends UnitSpec {
     )(
       Style("color", "blue"),
       Style("border", "1px solid black")
-    ).asProxy
+    ).asProxy.unsafeRunSync()
 
     node.data.style.toList should contain theSameElementsAs List(
       ("color", "blue"),
@@ -64,18 +64,18 @@ class AttributeSpec extends UnitSpec {
   }
 
   it should "correctly merge keys" in {
-    val node = input( dom.key := "bumm")( dom.key := "klapp").asProxy
+    val node = input( dom.key := "bumm")( dom.key := "klapp").asProxy.unsafeRunSync()
     node.data.key.toList should contain theSameElementsAs List("klapp")
 
-    val node2 = input()( dom.key := "klapp").asProxy
+    val node2 = input()( dom.key := "klapp").asProxy.unsafeRunSync()
     node2.data.key.toList should contain theSameElementsAs List("klapp")
 
-    val node3 = input( dom.key := "bumm")().asProxy
+    val node3 = input( dom.key := "bumm")().asProxy.unsafeRunSync()
     node3.data.key.toList should contain theSameElementsAs List("bumm")
   }
 
   "style attribute" should "render correctly" in {
-    val node = input(Style("color", "red")).asProxy
+    val node = input(Style("color", "red")).asProxy.unsafeRunSync()
 
     node.data.style.toList should contain theSameElementsAs List(
       "color" -> "red"

--- a/src/test/scala/outwatch/AttributeSpec.scala
+++ b/src/test/scala/outwatch/AttributeSpec.scala
@@ -7,15 +7,17 @@ class AttributeSpec extends UnitSpec {
   "data attribute" should "correctly render only data" in {
     val node = input(data := "bar").asProxy
 
-    node.data.attrs.iterator.contains("data" -> "bar") shouldBe true
-    node.data.attrs.size shouldBe 1
+    node.data.attrs.toList should contain theSameElementsAs List(
+      "data" -> "bar"
+    )
   }
 
   it should "correctly render expanded data with dynamic content" in {
     val node = input(data.foo := "bar").asProxy
 
-    node.data.attrs.iterator.contains("data-foo" -> "bar") shouldBe true
-    node.data.attrs.size shouldBe 1
+    node.data.attrs.toList should contain theSameElementsAs List(
+      "data-foo" -> "bar"
+    )
   }
 
   "optional attributes" should "correctly render" in {
@@ -24,14 +26,59 @@ class AttributeSpec extends UnitSpec {
       data.bar :=? Option.empty[String]
     ).asProxy
 
-    node.data.attrs.iterator.contains("data-foo" -> "bar") shouldBe true
-    node.data.attrs.size shouldBe 1
+    node.data.attrs.toList should contain theSameElementsAs List(
+      "data-foo" -> "bar"
+    )
   }
 
-  "data attribute" should "correctly render style" in {
+  "apply on vtree" should "correctly merge attributes" in {
+    val node = input(
+      data := "bar",
+      data.gurke := "franz"
+    )(
+      data := "buh",
+      data.tomate := "gisela"
+    ).asProxy
+
+    node.data.attrs.toList should contain theSameElementsAs List(
+      "data" -> "buh",
+      "data-gurke" -> "franz",
+      "data-tomate" -> "gisela"
+    )
+  }
+
+  it should "correctly merge styles" in {
+    val node = input(
+      Style("color", "red"),
+      Style("font-size", "5px")
+    )(
+      Style("color", "blue"),
+      Style("border", "1px solid black")
+    ).asProxy
+
+    node.data.style.toList should contain theSameElementsAs List(
+      ("color", "blue"),
+      ("font-size", "5px"),
+      ("border", "1px solid black")
+    )
+  }
+
+  it should "correctly merge keys" in {
+    val node = input( dom.key := "bumm")( dom.key := "klapp").asProxy
+    node.data.key.toList should contain theSameElementsAs List("klapp")
+
+    val node2 = input()( dom.key := "klapp").asProxy
+    node2.data.key.toList should contain theSameElementsAs List("klapp")
+
+    val node3 = input( dom.key := "bumm")().asProxy
+    node3.data.key.toList should contain theSameElementsAs List("bumm")
+  }
+
+  "style attribute" should "render correctly" in {
     val node = input(Style("color", "red")).asProxy
 
-    node.data.style.iterator.contains("color" -> "red") shouldBe true
-    node.data.style.size shouldBe 1
+    node.data.style.toList should contain theSameElementsAs List(
+      "color" -> "red"
+    )
   }
 }

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -12,6 +12,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
     val root = document.createElement("div")
     root.id = "app"
     document.body.appendChild(root)
+    ()
   }
 
   override def afterEach(): Unit = {
@@ -20,14 +21,17 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
 
   "EventStreams" should "emit and receive events correctly" in {
     import outwatch.dom._
-    val observable = createMouseHandler()
-    val buttonDisabled = observable.mapTo(true).startWith(false)
-    val vtree = div(id :="click", click --> observable,
-      button(id := "btn", disabled <-- buttonDisabled)
-    )
+
+    val vtree = for {
+      observable <- createMouseHandler()
+      buttonDisabled = observable.mapTo(true).startWith(false)
+      root <- div(id :="click", click --> observable,
+        button(id := "btn", disabled <-- buttonDisabled)
+      )
+    } yield root
 
 
-    OutWatch.render("#app", vtree)
+    OutWatch.render("#app", vtree).unsafeRunSync()
     document.getElementById("btn").hasAttribute("disabled") shouldBe false
 
     val event = document.createEvent("Events")
@@ -40,41 +44,50 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   it should "be converted to a generic emitter correctly" in {
     import outwatch.dom._
 
+    val message = "ad"
 
-        val observable = createStringHandler()
+    val vtree = for {
+      observable <- createStringHandler()
 
-        val message = "ad"
-        val vtree = div(id := "click", click(message) --> observable,
-          span(id := "child", child <-- observable)
-        )
+      root = div(id := "click", click(message) --> observable,
+       span(id := "child", child <-- observable)
+      )
+    } yield root
 
-        OutWatch.render("#app", vtree)
 
-        document.getElementById("child").innerHTML shouldBe ""
+    OutWatch.render("#app", vtree).unsafeRunSync()
 
-        val event = document.createEvent("Events")
-        event.initEvent("click", canBubbleArg = true, cancelableArg = false)
-        document.getElementById("click").dispatchEvent(event)
+    document.getElementById("child").innerHTML shouldBe ""
 
-        document.getElementById("child").innerHTML shouldBe message
+    val event = document.createEvent("Events")
+    event.initEvent("click", canBubbleArg = true, cancelableArg = false)
+    document.getElementById("click").dispatchEvent(event)
 
-        //dispatch another event
-        document.getElementById("click").dispatchEvent(event)
+    document.getElementById("child").innerHTML shouldBe message
 
-        document.getElementById("child").innerHTML shouldBe message
+    //dispatch another event
+    document.getElementById("click").dispatchEvent(event)
+
+    document.getElementById("child").innerHTML shouldBe message
 
 
   }
 
   it should "be converted to a generic stream emitter correctly" in {
     import outwatch.dom._
-    val stream = createStringHandler()
-    val messages = createStringHandler()
-    val vtree = div(id :="click", click(messages) --> stream,
-      span(id := "child", child <-- stream)
-    )
 
-    OutWatch.render("#app", vtree)
+    val messages = createStringHandler().value.unsafeRunSync()
+
+    val vtree = for {
+      stream <- createStringHandler()
+
+      root = div(id :="click", click(messages) --> stream,
+        span(id := "child", child <-- stream)
+      )
+    } yield root
+
+
+    OutWatch.render("#app", vtree).unsafeRunSync()
 
     document.getElementById("child").innerHTML shouldBe ""
 
@@ -107,7 +120,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
 
     val vtree = input(id:= "input", outwatch.dom.value <-- values)
 
-    OutWatch.render("#app", vtree)
+    OutWatch.render("#app", vtree).unsafeRunSync()
 
     val patched = document.getElementById("input").asInstanceOf[HTMLInputElement]
 
@@ -139,7 +152,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
       ul(id:= "list", children <-- state)
     )
 
-    OutWatch.render("#app", vtree)
+    OutWatch.render("#app", vtree).unsafeRunSync()
 
     val list = document.getElementById("list")
 
@@ -179,9 +192,9 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
     import outwatch.dom._
 
 
-    val first = createStringHandler()
+    val first = createStringHandler().value.unsafeRunSync()
 
-    val second = createStringHandler()
+    val second = createStringHandler().value.unsafeRunSync()
 
     val messages = ("Hello", "World")
 
@@ -191,7 +204,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
       span(id:="second",child <-- second)
     )
 
-    OutWatch.render("#app", node)
+    OutWatch.render("#app", node).unsafeRunSync()
 
     val event = document.createEvent("Events")
     event.initEvent("click", canBubbleArg = true, cancelableArg = false)
@@ -206,7 +219,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   it should "be able to be transformed by a function in place" in {
     import outwatch.dom._
 
-    val stream = createHandler[(MouseEvent, Int)]()
+    val stream = createHandler[(MouseEvent, Int)]().value.unsafeRunSync()
 
     val number = 42
 
@@ -217,7 +230,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
       span(id:="num",child <-- stream.map(_._2))
     )
 
-    OutWatch.render("#app", node)
+    OutWatch.render("#app", node).unsafeRunSync()
 
     val event = document.createEvent("Events")
     event.initEvent("click", canBubbleArg = true, cancelableArg = false)
@@ -231,7 +244,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   it should "be able to be transformed from strings" in {
     import outwatch.dom._
 
-    val stream = createHandler[Int]()
+    val stream = createHandler[Int]().value.unsafeRunSync()
 
     val number = 42
 
@@ -240,7 +253,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
       span(id:="num",child <-- stream)
     )
 
-    OutWatch.render("#app", node)
+    OutWatch.render("#app", node).unsafeRunSync()
 
     val inputEvt = document.createEvent("HTMLEvents")
     inputEvt.initEvent("input", false, true)
@@ -255,7 +268,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
     import outwatch.dom._
     import outwatch.util.SyntaxSugar._
 
-    val stream = createBoolHandler()
+    val stream = createBoolHandler().value.unsafeRunSync()
 
     val someClass = "some-class"
 
@@ -264,7 +277,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
       span(id:="toggled", stream ?= (className := someClass))
     )
 
-    OutWatch.render("#app", node)
+    OutWatch.render("#app", node).unsafeRunSync()
 
     val inputEvt = document.createEvent("HTMLEvents")
     inputEvt.initEvent("click", true, false)

--- a/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -1,5 +1,6 @@
 package outwatch
 
+import cats.effect.IO
 import org.scalajs.dom._
 import org.scalatest.BeforeAndAfterEach
 import outwatch.dom._
@@ -11,6 +12,7 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
     val root = document.createElement("div")
     root.id = "app"
     document.body.appendChild(root)
+    ()
   }
 
   override def afterEach(): Unit = {
@@ -20,13 +22,13 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
   "Insertion hooks" should "be called correctly" in {
 
     var switch = false
-    val sink = Sink.create((_: Element) => switch = true)
+    val sink = Sink.create((_: Element) => IO { switch = true })
 
     val node = div(insert --> sink)
 
     switch shouldBe false
 
-    OutWatch.render("#app", node)
+    OutWatch.render("#app", node).unsafeRunSync()
 
     switch shouldBe true
 
@@ -53,13 +55,13 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
   "Destruction hooks" should "be called correctly" in {
 
     var switch = false
-    val sink = Sink.create((_: Element) => switch = true)
+    val sink = Sink.create((_: Element) => IO { switch = true })
 
     val node = div(child <-- Observable.of(span(destroy --> sink), "Hasdasd"))
 
     switch shouldBe false
 
-    OutWatch.render("#app", node)
+    OutWatch.render("#app", node).unsafeRunSync()
 
     switch shouldBe true
 
@@ -86,13 +88,13 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
   "Update hooks" should "be called correctly" in {
 
     var switch = false
-    val sink = Sink.create((_: (Element, Element)) => switch = true)
+    val sink = Sink.create((_: (Element, Element)) => IO { switch = true })
 
     val node = div(child <-- Observable.of(span(update --> sink, "Hello"), span(update --> sink, "Hey")))
 
     switch shouldBe false
 
-    OutWatch.render("#app", node)
+    OutWatch.render("#app", node).unsafeRunSync()
 
     switch shouldBe true
 

--- a/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -3,7 +3,7 @@ package outwatch
 import org.scalajs.dom._
 import org.scalatest.BeforeAndAfterEach
 import outwatch.dom._
-import rxscalajs.Observable
+import rxscalajs.{Observable, Subject}
 
 class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
 
@@ -32,6 +32,24 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
 
   }
 
+  "Insertion hooks" should "be called correctly on merged nodes" in {
+    var switch = false
+    val sink = Sink.create((_: Element) => switch = true)
+    var switch2 = false
+    val sink2 = Sink.create((_: Element) => switch2 = true)
+
+    val node = div(insert --> sink)(insert --> sink2)
+
+    switch shouldBe false
+    switch2 shouldBe false
+
+    OutWatch.render("#app", node)
+
+    switch shouldBe true
+    switch2 shouldBe true
+
+  }
+
   "Destruction hooks" should "be called correctly" in {
 
     var switch = false
@@ -44,6 +62,24 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
     OutWatch.render("#app", node)
 
     switch shouldBe true
+
+  }
+  "Destruction hooks" should "be called correctly on merged nodes" in {
+
+    var switch = false
+    val sink = Sink.create((_: Element) => switch = true)
+    var switch2 = false
+    val sink2 = Sink.create((_: Element) => switch2 = true)
+
+    val node = div(child <-- Observable.of(span(destroy --> sink)(destroy --> sink2), "Hasdasd"))
+
+    switch shouldBe false
+    switch2 shouldBe false
+
+    OutWatch.render("#app", node)
+
+    switch shouldBe true
+    switch2 shouldBe true
 
   }
 
@@ -60,6 +96,24 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
 
     switch shouldBe true
 
+  }
+
+  "Update hooks" should "be called correctly on merged nodes" in {
+    var switch1 = false
+    val sink1 = Sink.create((_: (Element, Element)) => switch1 = true)
+    var switch2 = false
+    val sink2 = Sink.create((_: (Element, Element)) => switch2 = true)
+
+    val message = Subject[String]()
+    val node = div(child <-- message, update --> sink1)(update --> sink2)
+
+    OutWatch.render("#app", node)
+    switch1 shouldBe false
+    switch2 shouldBe false
+    
+    message.next("wursi")
+    switch1 shouldBe true
+    switch2 shouldBe true
   }
 
 }

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -1,9 +1,10 @@
 package outwatch
 
 import org.scalajs.dom.raw.{HTMLElement, HTMLInputElement}
+import cats.effect.IO
 import org.scalajs.dom.{Event, KeyboardEvent, document}
 import org.scalatest.BeforeAndAfterEach
-import outwatch.dom.VDomModifier.VTree
+import outwatch.dom.VDomModifier.StringNode
 import outwatch.dom._
 import outwatch.dom.helpers._
 import rxscalajs.{Observable, Subject}
@@ -59,7 +60,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
       Attribute("class", "red"),
       EmptyVDomModifier,
       EventEmitter("click", Subject()),
-      VDomModifier.StringNode("Test"),
+      new VDomModifier.StringNode("Test"),
       VTree("div", Vector.empty),
       AttributeStreamReceiver("hidden",Observable.of())
     )
@@ -161,7 +162,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val node = document.createElement("div")
     document.body.appendChild(node)
 
-    DomUtils.render(node, vtree)
+    DomUtils.render(node, vtree).unsafeRunSync()
 
     val patchedNode = document.getElementById(id)
 
@@ -174,7 +175,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
   it should "be replaced if they contain changeables" in {
 
     def page(num: Int): VNode = {
-      val pageNum = createHandler[Int](num)
+      val pageNum = createHandler[Int](num).value.unsafeRunSync()
 
       div( id := "page",
         num match {
@@ -195,7 +196,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val node = document.createElement("div")
     document.body.appendChild(node)
 
-    DomUtils.render(node, vtree)
+    DomUtils.render(node, vtree).unsafeRunSync()
 
     pageHandler.next(1)
 
@@ -213,7 +214,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
 
     val vtree = div(cls := "red", id := "msg",
       span("Hello")
-    )
+    ).value.unsafeRunSync()
 
     JSON.stringify(vtree.asProxy) shouldBe JSON.stringify(fixture.proxy)
 
@@ -225,7 +226,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val vtree = div(cls := "red", id := "msg",
       Option(span("Hello")),
       Option.empty[VDomModifier]
-    )
+    ).value.unsafeRunSync()
 
     JSON.stringify(vtree.asProxy) shouldBe JSON.stringify(fixture.proxy)
 
@@ -242,7 +243,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
       boolBuilder("c") := false,
       anyBuilder("d") := true,
       anyBuilder("e") := false
-    )
+    ).value.unsafeRunSync()
 
     val attrs = js.Dictionary[String | Boolean]("a" -> true, "b" -> true, "c" -> false, "d" -> "true", "e" -> "false")
     val expected = h("div", DataObject(attrs, js.Dictionary()), js.Array[Any]())
@@ -267,7 +268,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val node = document.createElement("div")
     document.body.appendChild(node)
 
-    DomUtils.render(node, vtree)
+    DomUtils.render(node, vtree).unsafeRunSync()
 
     val patchedNode = document.getElementById("test")
 
@@ -287,7 +288,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val node = document.createElement("div")
     document.body.appendChild(node)
 
-    DomUtils.render(node, vtree)
+    DomUtils.render(node, vtree).unsafeRunSync()
 
     val field = document.getElementById("input").asInstanceOf[HTMLInputElement]
 

--- a/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -4,36 +4,38 @@ import org.scalajs.dom._
 import org.scalajs.dom.raw.HTMLInputElement
 import org.scalatest.BeforeAndAfterEach
 import outwatch.dom.helpers.DomUtils
-
-import scala.language.reflectiveCalls
+import outwatch.dom._
 
 class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
   override def afterEach(): Unit = {
     document.body.innerHTML = ""
   }
 
-  val fixture = new {
-    val event = document.createEvent("Events")
+  override def beforeEach(): Unit = {
+    val root = document.createElement("div")
+    root.id = "app"
+    document.body.appendChild(root)
+    ()
   }
 
   "A simple counter application" should "work as intended" in {
-    import outwatch.dom._
+
 
 
     val node = for {
       handlePlus <- createMouseHandler()
-      plusOne$ = handlePlus.mapTo(1)
+      plusOne = handlePlus.mapTo(1)
 
       handleMinus <- createMouseHandler()
-      minusOne$ = handleMinus.mapTo(-1)
+      minusOne = handleMinus.mapTo(-1)
 
-      count$ = plusOne$.merge(minusOne$).scan(0)(_ + _).startWith(0)
+      count = plusOne.merge(minusOne).scan(0)(_ + _).startWith(0)
 
       root <- div(
         div(
           button(id := "plus", "+", click --> handlePlus),
           button(id := "minus", "-", click --> handleMinus),
-          span(id:="counter",child <-- count$)
+          span(id:="counter",child <-- count)
         )
       )
     } yield root
@@ -43,10 +45,8 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
 
     DomUtils.render(root, node).unsafeRunSync()
 
-    val event = fixture.event
+    val event = document.createEvent("Events")
     event.initEvent("click", canBubbleArg = true, cancelableArg = false)
-
-    println(document.getElementById("counter"))
 
     document.getElementById("counter").innerHTML shouldBe 0.toString
 
@@ -62,8 +62,6 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
   }
 
   "A simple name application" should "work as intended" in {
-    import outwatch.dom._
-
     val greetStart = "Hello ,"
 
     val node = for {
@@ -100,7 +98,6 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
   }
 
   "A todo application" should "work with components" in {
-    import outwatch.dom._
 
     def TodoComponent(title: String, deleteStream: Sink[String]) =
       li(
@@ -121,10 +118,10 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
       enterPressed = keyStream
         .filter(_.key == "Enter")
 
-      confirm$ = enterPressed.merge(clickStream)
+      confirm = enterPressed.merge(clickStream)
         .withLatestFromWith(textFieldStream)((_, input) => input)
 
-      _ <- Pure(outputStream <-- confirm$)
+      _ <- Pure(outputStream <-- confirm)
 
       root <- div(
         label(labelText),

--- a/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -19,29 +19,34 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
   "A simple counter application" should "work as intended" in {
     import outwatch.dom._
 
-    val handlePlus = createMouseHandler()
-    val plusOne$ = handlePlus.mapTo(1)
 
-    val handleMinus = createMouseHandler()
-    val minusOne$ = handleMinus.mapTo(-1)
+    val node = for {
+      handlePlus <- createMouseHandler()
+      plusOne$ = handlePlus.mapTo(1)
 
-    val count$ = plusOne$.merge(minusOne$).scan(0)(_ + _).startWith(0)
+      handleMinus <- createMouseHandler()
+      minusOne$ = handleMinus.mapTo(-1)
 
-    val node = div(
-      div(
-        button(id := "plus", "+", click --> handlePlus),
-        button(id := "minus", "-", click --> handleMinus),
-        span(id:="counter",child <-- count$)
+      count$ = plusOne$.merge(minusOne$).scan(0)(_ + _).startWith(0)
+
+      root <- div(
+        div(
+          button(id := "plus", "+", click --> handlePlus),
+          button(id := "minus", "-", click --> handleMinus),
+          span(id:="counter",child <-- count$)
+        )
       )
-    )
+    } yield root
 
     val root = document.createElement("div")
     document.body.appendChild(root)
 
-    DomUtils.render(root, node)
+    DomUtils.render(root, node).unsafeRunSync()
 
     val event = fixture.event
     event.initEvent("click", canBubbleArg = true, cancelableArg = false)
+
+    println(document.getElementById("counter"))
 
     document.getElementById("counter").innerHTML shouldBe 0.toString
 
@@ -59,20 +64,22 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
   "A simple name application" should "work as intended" in {
     import outwatch.dom._
 
-    val nameHandler = createStringHandler()
-
     val greetStart = "Hello ,"
 
-    val node = div(
-      label("Name:"),
-      input(id := "input", inputType := "text", inputString --> nameHandler),
-      hr(),
-      h1(id :="greeting", greetStart, child <-- nameHandler)
-    )
+    val node = for {
+      nameHandler <- createStringHandler()
+      root <- div(
+        label("Name:"),
+        input(id := "input", inputType := "text", inputString --> nameHandler),
+        hr(),
+        h1(id :="greeting", greetStart, child <-- nameHandler)
+      )
+    } yield root
+
     val root = document.createElement("div")
     document.body.appendChild(root)
 
-    DomUtils.render(root, node)
+    DomUtils.render(root, node).unsafeRunSync()
 
 
     val evt = document.createEvent("HTMLEvents")
@@ -101,33 +108,32 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
         button(id:= title, click(title) --> deleteStream, "Delete")
       )
 
-    def TextFieldComponent(labelText: String, outputStream: Sink[String]) = {
+    def TextFieldComponent(labelText: String, outputStream: Sink[String]) = for {
 
-      val textFieldStream = createStringHandler()
-      val clickStream = createMouseHandler()
-      val keyStream = createKeyboardHandler()
+      textFieldStream <- createStringHandler()
+      clickStream <- createMouseHandler()
+      keyStream <- createKeyboardHandler()
 
-      val buttonDisabled = textFieldStream
+      buttonDisabled = textFieldStream
         .map(_.length < 2)
         .startWith(true)
 
-      val enterPressed = keyStream
+      enterPressed = keyStream
         .filter(_.key == "Enter")
 
-      val confirm$ = enterPressed.merge(clickStream)
+      confirm$ = enterPressed.merge(clickStream)
         .withLatestFromWith(textFieldStream)((_, input) => input)
 
-      outputStream <-- confirm$
+      _ <- Pure(outputStream <-- confirm$)
 
-      div(
+      root <- div(
         label(labelText),
         input(id:= "input", inputType := "text", inputString --> textFieldStream, keyup --> keyStream),
         button(id := "submit", click --> clickStream, disabled <-- buttonDisabled, "Submit")
       )
-    }
+    } yield root
 
-    val inputHandler = createStringHandler()
-    val deleteHandler = createStringHandler()
+
 
     def addToList(todo: String) = {
       (list: Vector[String]) => list :+ todo
@@ -137,26 +143,31 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
       (list: Vector[String]) => list.filterNot(_ == todo)
     }
 
-    val adds = inputHandler
-      .map(addToList)
+    val vtree = for {
+      inputHandler <- createStringHandler()
+      deleteHandler <- createStringHandler()
 
-    val deletes = deleteHandler
-      .map(removeFromList)
+      adds = inputHandler
+        .map(addToList)
 
-    val state = adds.merge(deletes)
-      .scan(Vector[String]())((state, modify) => modify(state))
-      .map(_.map(n => TodoComponent(n, deleteHandler)))
+      deletes = deleteHandler
+        .map(removeFromList)
+
+      state = adds.merge(deletes)
+        .scan(Vector[String]())((state, modify) => modify(state))
+        .map(_.map(n => TodoComponent(n, deleteHandler)))
 
 
-    val vtree = div(
-      TextFieldComponent("Todo: ", inputHandler),
-      ul(id:= "list", children <-- state)
-    )
+      root <- div(
+        TextFieldComponent("Todo: ", inputHandler),
+        ul(id:= "list", children <-- state)
+      )
+    } yield root
 
     val root = document.createElement("div")
     document.body.appendChild(root)
 
-    DomUtils.render(root, vtree)
+    DomUtils.render(root, vtree).unsafeRunSync()
 
     val inputEvt = document.createEvent("HTMLEvents")
     inputEvt.initEvent("input", false, true)

--- a/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -30,7 +30,7 @@ class SnabbdomSpec extends UnitSpec {
   it should "correctly patch nodes with keys" in {
     import outwatch.dom._
 
-    val clicks = createHandler[Int](1)
+    val clicks = createHandler[Int](1).value.unsafeRunSync()
     val nodes = clicks.map { i =>
       div(
         dom.key := s"key-$i",
@@ -43,7 +43,7 @@ class SnabbdomSpec extends UnitSpec {
     node.id = "app"
     document.body.appendChild(node)
 
-    OutWatch.render("#app", div(child <-- nodes))
+    OutWatch.render("#app", div(child <-- nodes)).unsafeRunSync()
 
     val inputEvt = document.createEvent("HTMLEvents")
     inputEvt.initEvent("input", false, true)


### PR DESCRIPTION
We have rebased your referential transparency branch on our vnode-apply. Now, only the `asProxy` method in `VNode` returns an `IO[VNodeProxy]` as well as the `Handler[T]` factories (we are not totally sure about this). The tests currently do not compile yet. What do you think? Is this maybe a simpler alternative implementation?