### PR TITLE
Never hide IO Monad in API

### DIFF
--- a/src/main/scala/outwatch/Sink.scala
+++ b/src/main/scala/outwatch/Sink.scala
@@ -88,14 +88,14 @@ object Sink {
     * @tparam T the type parameter of the elements
     * @return the newly created Handler.
     */
-  def createHandler[T](seeds: T*): Handler[T] = {
+  def createHandler[T](seeds: T*): IO[Handler[T]] = {
     val handler = new SubjectSink[T]
 
     if (seeds.nonEmpty) {
-      Handler(IO(ObservableSink[T](handler, handler.startWithMany(seeds: _*))))
+      IO(ObservableSink[T](handler, handler.startWithMany(seeds: _*)))
     }
     else {
-      Handler(IO(handler))
+      IO(handler)
     }
   }
 
@@ -122,7 +122,7 @@ object Sink {
     * @return the resulting sink, that will forward the values
     */
   def redirect[T,R](sink: Sink[T])(project: Observable[R] => Observable[T]): Sink[R] = {
-    val forward = Sink.createHandler[R]().value.unsafeRunSync()
+    val forward = Sink.createHandler[R]().unsafeRunSync()
 
     completionObservable(sink)
       .fold(project(forward))(completed => project(forward).takeUntil(completed))
@@ -144,8 +144,8 @@ object Sink {
     * @return the two resulting sinks, that will forward the values
     */
   def redirect2[T,U,R](sink: Sink[T])(project: (Observable[R], Observable[U]) => Observable[T]): (Sink[R], Sink[U]) = {
-    val r = Sink.createHandler[R]().value.unsafeRunSync()
-    val u = Sink.createHandler[U]().value.unsafeRunSync()
+    val r = Sink.createHandler[R]().unsafeRunSync()
+    val u = Sink.createHandler[U]().unsafeRunSync()
 
     completionObservable(sink)
       .fold(project(r, u))(completed => project(r, u).takeUntil(completed))
@@ -170,9 +170,9 @@ object Sink {
   def redirect3[T,U,V,R](sink: Sink[T])
                        (project: (Observable[R], Observable[U], Observable[V]) => Observable[T])
                        :(Sink[R], Sink[U], Sink[V]) = {
-    val r = Sink.createHandler[R]().value.unsafeRunSync()
-    val u = Sink.createHandler[U]().value.unsafeRunSync()
-    val v = Sink.createHandler[V]().value.unsafeRunSync()
+    val r = Sink.createHandler[R]().unsafeRunSync()
+    val u = Sink.createHandler[U]().unsafeRunSync()
+    val v = Sink.createHandler[V]().unsafeRunSync()
 
     completionObservable(sink)
       .fold(project(r, u, v))(completed => project(r, u, v).takeUntil(completed))

--- a/src/main/scala/outwatch/dom/Handlers.scala
+++ b/src/main/scala/outwatch/dom/Handlers.scala
@@ -4,11 +4,15 @@ import org.scalajs.dom.MouseEvent
 import org.scalajs.dom.raw.{ClipboardEvent, DragEvent, KeyboardEvent}
 import outwatch.Sink
 import outwatch.dom.helpers.InputEvent
+import rxscalajs.Observable
+import cats.effect.IO
 
 /**
   * Trait containing event handlers, so they can be mixed in to other objects if needed.
   */
 trait Handlers {
+  type Handler[A] = Observable[A] with Sink[A]
+
   def createInputHandler() = createHandler[InputEvent]()
   def createMouseHandler() = createHandler[MouseEvent]()
   def createKeyboardHandler() = createHandler[KeyboardEvent]()
@@ -18,9 +22,7 @@ trait Handlers {
   def createBoolHandler(defaultValues: Boolean*) = createHandler[Boolean](defaultValues: _*)
   def createNumberHandler(defaultValues: Double*) = createHandler[Double](defaultValues: _*)
 
-  def createHandler[T](defaultValues: T*): Handler[T] = {
-    Sink.createHandler[T](defaultValues: _*)
-  }
+  def createHandler[T](defaultValues: T*): IO[Handler[T]] = Sink.createHandler[T](defaultValues: _*)
 }
 
 object Handlers extends Handlers

--- a/src/main/scala/outwatch/dom/Tags.scala
+++ b/src/main/scala/outwatch/dom/Tags.scala
@@ -19,7 +19,7 @@ import outwatch.dom.helpers.DomUtils
 /** Trait that contains all tags, so they can be mixed in to other objects if needed.
   */
 trait Tags {
-  private def tag(nodeType: String)(args: Seq[VDomModifier]): VNode = VDomIO(IO(VTree(nodeType, args)))
+  private def tag(nodeType: String)(args: Seq[VDomModifier]): VNode = VTree(nodeType, args)
 
   /** Represents a hyperlink, linking to another resource.
     *

--- a/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -4,6 +4,7 @@ import scala.language.dynamics
 import outwatch.dom._
 import rxscalajs.Observable
 import scala.language.implicitConversions
+import outwatch.dom.VDomModifier.StringNode
 
 trait ValueBuilder[T] extends Any {
   def :=(value: T): VDomModifier
@@ -16,7 +17,7 @@ object ChildStreamReceiverBuilder {
   }
 
   private val anyToVNode: Any => VNode = {
-    case vn: VNodeIO[_] => vn.asInstanceOf[VNode]
+    case vn: VNode => vn.asInstanceOf[VNode]
     case any => any.toString
   }
 }

--- a/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -117,7 +117,7 @@ object DomUtils {
     def toProxy(changable: (Seq[Attribute], Seq[VNode])): VNodeProxy = changable match {
       case (attributes, nodes) =>
         val updatedObj = proxy.data.withUpdatedAttributes(attributes)
-        h(proxy.sel, updatedObj, proxy.children ++ (nodes.map(_.value.unsafeRunSync().asProxy)(breakOut):js.Array[VNodeProxy]))
+        h(proxy.sel, updatedObj, proxy.children ++ (nodes.map(_.asProxy)(breakOut):js.Array[VNodeProxy]))
     }
 
     val subscription = changables.observable
@@ -152,7 +152,7 @@ object DomUtils {
     case (em: Emitter, sf) => sf.copy(emitters = em :: sf.emitters)
     case (rc: Receiver, sf) => sf.copy(receivers = rc :: sf.receivers)
     case (pr: Property, sf) => sf.copy(properties = pr :: sf.properties)
-    case (vn: VNodeIO[_], sf) => sf.copy(vNodes = vn.asInstanceOf[VNode] :: sf.vNodes)
+    case (vn: VNode, sf) => sf.copy(vNodes = vn :: sf.vNodes)
     case (EmptyVDomModifier, sf) => sf
   }
 
@@ -201,12 +201,9 @@ object DomUtils {
     (children, dataObject)
   }
 
-  def render(element: Element, vNode: VNode): IO[Unit] = for {
-    node <- vNode.value
-    elem <- IO(document.createElement("app"))
-    _ <- IO(element.appendChild(elem))
-    _ <- IO(patch(elem, node.asProxy))
-  } yield ()
-
-
+  def render(element: Element, vNode: VNode): IO[Unit] = IO {
+    val elem = document.createElement("app")
+    element.appendChild(elem)
+    patch(elem, vNode.asProxy)
+  }
 }

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -2,6 +2,4 @@ package outwatch
 
 
 
-package object dom extends Attributes with Tags with Handlers {
-  type VNode = VNodeIO[VDom]
-}
+package object dom extends Attributes with Tags with Handlers 

--- a/src/main/scala/outwatch/http/Http.scala
+++ b/src/main/scala/outwatch/http/Http.scala
@@ -1,7 +1,6 @@
 package outwatch.http
 
 import cats.effect.IO
-import outwatch.dom.VDomHttp
 import rxscalajs.Observable
 import rxscalajs.dom.{Request, Response}
 
@@ -26,25 +25,25 @@ object Http {
         .subscribe(response => cb(Right(response)), err => cb(Left(new Exception(err.toString))))
     }
 
-  private def request(observable: Observable[Request], requestType: HttpRequestType): VDomHttp =
-    VDomHttp(IO(observable.switchMap(data => Observable.ajax(data.copy(method = requestType.toString))).share))
+  private def request(observable: Observable[Request], requestType: HttpRequestType) =
+    observable.switchMap(data => Observable.ajax(data.copy(method = requestType.toString))).share
 
-  private def requestWithUrl(urls: Observable[String], requestType: HttpRequestType): VDomHttp =
+  private def requestWithUrl(urls: Observable[String], requestType: HttpRequestType) =
     request(urls.map(url => Request(url)), requestType: HttpRequestType)
 
-  def getWithUrl(urls: Observable[String]): VDomHttp = requestWithUrl(urls, Get)
+  def getWithUrl(urls: Observable[String]) = requestWithUrl(urls, Get)
 
-  def get(requests: Observable[Request]): VDomHttp = request(requests, Get)
+  def get(requests: Observable[Request]) = request(requests, Get)
 
-  def post(requests: Observable[Request]): VDomHttp = request(requests, Post)
+  def post(requests: Observable[Request]) = request(requests, Post)
 
-  def delete(requests: Observable[Request]): VDomHttp = request(requests, Delete)
+  def delete(requests: Observable[Request]) = request(requests, Delete)
 
-  def put(requests: Observable[Request]): VDomHttp = request(requests, Put)
+  def put(requests: Observable[Request]) = request(requests, Put)
 
-  def options(requests: Observable[Request]): VDomHttp = request(requests, Options)
+  def options(requests: Observable[Request]) = request(requests, Options)
 
-  def head(requests: Observable[Request]): VDomHttp = request(requests, Head)
+  def head(requests: Observable[Request]) = request(requests, Head)
 
 
 }

--- a/src/main/scala/outwatch/util/Store.scala
+++ b/src/main/scala/outwatch/util/Store.scala
@@ -41,15 +41,14 @@ object Store {
   private val storeRef = STRef.empty
 
   def renderWithStore[S, A](initialState: S, reducer: (S, A) => (S, Option[IO[A]]), selector: String, root: VNode): IO[Unit] = for {
-    handler <- createHandler[A]().value
+    handler <- createHandler[A]()
     store <- IO(Store(initialState, reducer, handler))
     _ <- storeRef.asInstanceOf[STRef[Store[S, A]]].put(store)
     _ <- OutWatch.render(selector, root)
   } yield ()
 
-  def getStore[S, A]: VNodeIO[Store[S, A]] = Pure(
+  def getStore[S, A]: IO[Store[S, A]] = 
     storeRef.asInstanceOf[STRef[Store[S, A]]].getOrThrow(NoStoreException)
-  )
 
   private object NoStoreException extends
     Exception("Application was rendered without specifying a Store, please use Outwatch.renderWithStore instead")

--- a/src/test/scala/outwatch/AttributeSpec.scala
+++ b/src/test/scala/outwatch/AttributeSpec.scala
@@ -5,7 +5,7 @@ import outwatch.dom._
 class AttributeSpec extends UnitSpec {
 
   "data attribute" should "correctly render only data" in {
-    val node = input(data := "bar").value.unsafeRunSync().asProxy
+    val node = input(data := "bar").asProxy
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data" -> "bar"
@@ -13,7 +13,7 @@ class AttributeSpec extends UnitSpec {
   }
 
   it should "correctly render expanded data with dynamic content" in {
-    val node = input(data.foo := "bar").value.unsafeRunSync().asProxy
+    val node = input(data.foo := "bar").asProxy
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data-foo" -> "bar"
@@ -24,7 +24,7 @@ class AttributeSpec extends UnitSpec {
     val node = input(
       data.foo :=? Option("bar"),
       data.bar :=? Option.empty[String]
-    ).value.unsafeRunSync().asProxy
+    ).asProxy
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data-foo" -> "bar"
@@ -33,7 +33,7 @@ class AttributeSpec extends UnitSpec {
 
   "apply on vtree" should "correctly merge attributes" in {
     val node = input(data := "bar",
-        data.gurke := "franz")(data := "buh", data.tomate := "gisela").value.unsafeRunSync().asProxy
+        data.gurke := "franz")(data := "buh", data.tomate := "gisela").asProxy
 
     node.data.attrs.toList should contain theSameElementsAs List(
         "data" -> "buh",
@@ -49,7 +49,7 @@ class AttributeSpec extends UnitSpec {
     )(
       Style("color", "blue"),
       Style("border", "1px solid black")
-    ).value.unsafeRunSync().asProxy
+    ).asProxy
 
     node.data.style.toList should contain theSameElementsAs List(
       ("color", "blue"),
@@ -59,18 +59,18 @@ class AttributeSpec extends UnitSpec {
   }
 
   it should "correctly merge keys" in {
-    val node = input( dom.key := "bumm")( dom.key := "klapp").value.unsafeRunSync().asProxy
+    val node = input( dom.key := "bumm")( dom.key := "klapp").asProxy
     node.data.key.toList should contain theSameElementsAs List("klapp")
 
-    val node2 = input()( dom.key := "klapp").value.unsafeRunSync().asProxy
+    val node2 = input()( dom.key := "klapp").asProxy
     node2.data.key.toList should contain theSameElementsAs List("klapp")
 
-    val node3 = input( dom.key := "bumm")().value.unsafeRunSync().asProxy
+    val node3 = input( dom.key := "bumm")().asProxy
     node3.data.key.toList should contain theSameElementsAs List("bumm")
   }
 
   "style attribute" should "render correctly" in {
-    val node = input(Style("color", "red")).value.unsafeRunSync().asProxy
+    val node = input(Style("color", "red")).asProxy
 
     node.data.style.toList should contain theSameElementsAs List(
       "color" -> "red"

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -25,13 +25,12 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
     val vtree = for {
       observable <- createMouseHandler()
       buttonDisabled = observable.mapTo(true).startWith(false)
-      root <- div(id :="click", click --> observable,
+    } yield div(id :="click", click --> observable,
         button(id := "btn", disabled <-- buttonDisabled)
       )
-    } yield root
 
 
-    OutWatch.render("#app", vtree).unsafeRunSync()
+    vtree.flatMap(vtree => OutWatch.render("#app", vtree)).unsafeRunSync()
     document.getElementById("btn").hasAttribute("disabled") shouldBe false
 
     val event = document.createEvent("Events")
@@ -48,14 +47,12 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
 
     val vtree = for {
       observable <- createStringHandler()
-
-      root <- div(id := "click", click(message) --> observable,
-       span(id := "child", child <-- observable)
+    } yield div(id := "click", click(message) --> observable,
+        span(id := "child", child <-- observable)
       )
-    } yield root
 
 
-    OutWatch.render("#app", vtree).unsafeRunSync()
+    vtree.flatMap(vtree => OutWatch.render("#app", vtree)).unsafeRunSync()
 
     document.getElementById("child").innerHTML shouldBe ""
 
@@ -76,18 +73,16 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   it should "be converted to a generic stream emitter correctly" in {
     import outwatch.dom._
 
-    val messages = createStringHandler().value.unsafeRunSync()
+    val messages = createStringHandler().unsafeRunSync()
 
     val vtree = for {
       stream <- createStringHandler()
-
-      root <- div(id :="click", click(messages) --> stream,
+    } yield div(id :="click", click(messages) --> stream,
         span(id := "child", child <-- stream)
       )
-    } yield root
 
 
-    OutWatch.render("#app", vtree).unsafeRunSync()
+    vtree.flatMap(vtree => OutWatch.render("#app", vtree)).unsafeRunSync()
 
     document.getElementById("child").innerHTML shouldBe ""
 
@@ -192,9 +187,9 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
     import outwatch.dom._
 
 
-    val first = createStringHandler().value.unsafeRunSync()
+    val first = createStringHandler().unsafeRunSync()
 
-    val second = createStringHandler().value.unsafeRunSync()
+    val second = createStringHandler().unsafeRunSync()
 
     val messages = ("Hello", "World")
 
@@ -219,7 +214,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   it should "be able to be transformed by a function in place" in {
     import outwatch.dom._
 
-    val stream = createHandler[(MouseEvent, Int)]().value.unsafeRunSync()
+    val stream = createHandler[(MouseEvent, Int)]().unsafeRunSync()
 
     val number = 42
 
@@ -244,7 +239,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   it should "be able to be transformed from strings" in {
     import outwatch.dom._
 
-    val stream = createHandler[Int]().value.unsafeRunSync()
+    val stream = createHandler[Int]().unsafeRunSync()
 
     val number = 42
 
@@ -268,7 +263,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
     import outwatch.dom._
     import outwatch.util.SyntaxSugar._
 
-    val stream = createBoolHandler().value.unsafeRunSync()
+    val stream = createBoolHandler().unsafeRunSync()
 
     val someClass = "some-class"
 

--- a/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -36,9 +36,9 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
 
   it should "be called correctly on merged nodes" in {
     var switch = false
-    val sink = Sink.create((_: Element) => IO(switch = true))
+    val sink = Sink.create((_: Element) => IO{switch = true})
     var switch2 = false
-    val sink2 = Sink.create((_: Element) => IO(switch2 = true))
+    val sink2 = Sink.create((_: Element) => IO{switch2 = true})
 
     val node = div(insert --> sink)(insert --> sink2)
 
@@ -55,9 +55,9 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
   "Destruction hooks" should "be called correctly on merged nodes" in {
 
     var switch = false
-    val sink = Sink.create((_: Element) => IO(switch = true))
+    val sink = Sink.create((_: Element) => IO{switch = true})
     var switch2 = false
-    val sink2 = Sink.create((_: Element) => IO(switch2 = true))
+    val sink2 = Sink.create((_: Element) => IO{switch2 = true})
 
     val node = div(child <-- Observable.of(span(destroy --> sink)(destroy --> sink2), "Hasdasd"))
 
@@ -88,9 +88,9 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
 
   "Update hooks" should "be called correctly on merged nodes" in {
     var switch1 = false
-    val sink1 = Sink.create((_: (Element, Element)) => IO(switch1 = true))
+    val sink1 = Sink.create((_: (Element, Element)) => IO{switch1 = true})
     var switch2 = false
-    val sink2 = Sink.create((_: (Element, Element)) => IO(switch2 = true))
+    val sink2 = Sink.create((_: (Element, Element)) => IO{switch2 = true})
 
     val message = Subject[String]()
     val node = div(child <-- message, update --> sink1)(update --> sink2)

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -60,7 +60,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
       Attribute("class", "red"),
       EmptyVDomModifier,
       EventEmitter("click", Subject()),
-      VDomIO(IO(new StringNode("Test"))),
+      new StringNode("Test"),
       div(),
       AttributeStreamReceiver("hidden",Observable.of())
     )
@@ -142,7 +142,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val attributes = List(Attribute("class", "red"), Attribute("id", "msg"))
     val message = "Hello"
     val child = span(message)
-    val vtree = div(attributes.head, attributes(1), child).value.unsafeRunSync()
+    val vtree = div(attributes.head, attributes(1), child)
 
     val proxy = fixture.proxy
 
@@ -154,7 +154,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val attributes = List(Attribute("class", "red"), Attribute("id", "msg"))
     val message = "Hello"
     val child = span(message)
-    val vtree = div(attributes.head, attributes(1), child).value.unsafeRunSync()
+    val vtree = div(attributes.head, attributes(1), child)
 
     JSON.stringify(vtree.asProxy) shouldBe JSON.stringify(fixture.proxy)
   }
@@ -185,7 +185,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
   it should "be replaced if they contain changeables" in {
 
     def page(num: Int): VNode = {
-      val pageNum = createHandler[Int](num).value.unsafeRunSync()
+      val pageNum = createHandler[Int](num).unsafeRunSync()
 
       div( id := "page",
         num match {
@@ -225,7 +225,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
 
     val vtree = div(cls := "red", id := "msg",
       span("Hello")
-    ).value.unsafeRunSync()
+    )
 
     JSON.stringify(vtree.asProxy) shouldBe JSON.stringify(fixture.proxy)
 
@@ -237,7 +237,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val vtree = div(cls := "red", id := "msg",
       Option(span("Hello")),
       Option.empty[VDomModifier]
-    ).value.unsafeRunSync()
+    )
 
     JSON.stringify(vtree.asProxy) shouldBe JSON.stringify(fixture.proxy)
 
@@ -254,7 +254,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
       boolBuilder("c") := false,
       anyBuilder("d") := true,
       anyBuilder("e") := false
-    ).value.unsafeRunSync()
+    )
 
     val attrs = js.Dictionary[String | Boolean]("a" -> true, "b" -> true, "c" -> false, "d" -> "true", "e" -> "false")
     val expected = h("div", DataObject(attrs, js.Dictionary()), js.Array[Any]())

--- a/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -30,7 +30,7 @@ class SnabbdomSpec extends UnitSpec {
   it should "correctly patch nodes with keys" in {
     import outwatch.dom._
 
-    val clicks = createHandler[Int](1).value.unsafeRunSync()
+    val clicks = createHandler[Int](1).unsafeRunSync()
     val nodes = clicks.map { i =>
       div(
         dom.key := s"key-$i",


### PR DESCRIPTION
This PR does not hide the IO Monad anymore. This means that the following code:
```scala
val pureComponent:VNodeIO = div(...)
val component:VNodeIO = for {
  handler <- createHandler
  div <- div( ... handler ... )
} yield div
val bigComponent = div(component, purecomponent)
```
now needs to be written like:

```scala
val pureComponent:VNode = div(...)
val component:IO[VNode] = for {
  handler <- createHandler
} yield div( ... handler ... )
val bigComponent = for{
  component <- component
} yield div(component, purecomponent)
```
Note how pure Components don't need any `IO`. Also it is now possible to write the html-tags in `yield`.

One one hand this does not hide IO anymore. So it is more intuitive what's going on. People can transfer their Monad-Knowledge from `Future` or `Option`. On the other hand in some cases it is more cumbersome to write. I'd like to have some opinions on this. Further examples (Counter, Todo) can be seen in the ScenarioTests:
original version: https://github.com/OutWatch/outwatch/blob/master/src/test/scala/outwatch/ScenarioTestSpec.scala#L21

version of this PR: https://github.com/OutWatch/outwatch/blob/consistent-monad-interface/src/test/scala/outwatch/ScenarioTestSpec.scala#L21

When looking at code-changes, it makes sense to compare this branch against a state before referential transparency was introduced: https://github.com/OutWatch/outwatch/compare/07a0f2d2d129bd9d1990f94140c90d4e73093d8a...consistent-monad-interface