### PR TITLE
Another referential transparent API refactoring

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "OutWatch"
 
 normalizedName := "outwatch"
 
-version := "0.11-SNAPSHOT"
+version := "0.11.1-SNAPSHOT"
 
 organization := "io.github.outwatch"
 

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ scalacOptions ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, 12)) =>
       "-Ywarn-extra-implicit" ::
-      "-Ywarn-unused:-params,_" ::
+      "-Ywarn-unused:-explicits,-implicits,_" ::
       Nil
     case _             =>
       "-Ywarn-unused" ::

--- a/src/main/scala/outwatch/Sink.scala
+++ b/src/main/scala/outwatch/Sink.scala
@@ -88,14 +88,14 @@ object Sink {
     * @tparam T the type parameter of the elements
     * @return the newly created Handler.
     */
-  def createHandler[T](seeds: T*): IO[Handler[T]] = {
+  def createHandler[T](seeds: T*): IO[Handler[T]] = IO {
     val handler = new SubjectSink[T]
 
     if (seeds.nonEmpty) {
-      IO(ObservableSink[T](handler, handler.startWithMany(seeds: _*)))
+      ObservableSink[T](handler, handler.startWithMany(seeds: _*))
     }
     else {
-      IO(handler)
+      handler
     }
   }
 

--- a/src/main/scala/outwatch/Sink.scala
+++ b/src/main/scala/outwatch/Sink.scala
@@ -88,14 +88,14 @@ object Sink {
     * @tparam T the type parameter of the elements
     * @return the newly created Handler.
     */
-  def createHandler[T](seeds: T*): Handler[T] = {
+  def createHandler[T](seeds: T*): IO[Handler[T]] = {
     val handler = new SubjectSink[T]
 
     if (seeds.nonEmpty) {
-      Handler(IO(ObservableSink[T](handler, handler.startWithMany(seeds: _*))))
+      IO(ObservableSink[T](handler, handler.startWithMany(seeds: _*)))
     }
     else {
-      Handler(IO(handler))
+      IO(handler)
     }
   }
 
@@ -122,7 +122,7 @@ object Sink {
     * @return the resulting sink, that will forward the values
     */
   def redirect[T,R](sink: Sink[T])(project: Observable[R] => Observable[T]): Sink[R] = {
-    val forward = Sink.createHandler[R]().value.unsafeRunSync()
+    val forward = Sink.createHandler[R]().unsafeRunSync()
 
     completionObservable(sink)
       .fold(project(forward))(completed => project(forward).takeUntil(completed))
@@ -144,8 +144,8 @@ object Sink {
     * @return the two resulting sinks, that will forward the values
     */
   def redirect2[T,U,R](sink: Sink[T])(project: (Observable[R], Observable[U]) => Observable[T]): (Sink[R], Sink[U]) = {
-    val r = Sink.createHandler[R]().value.unsafeRunSync()
-    val u = Sink.createHandler[U]().value.unsafeRunSync()
+    val r = Sink.createHandler[R]().unsafeRunSync()
+    val u = Sink.createHandler[U]().unsafeRunSync()
 
     completionObservable(sink)
       .fold(project(r, u))(completed => project(r, u).takeUntil(completed))
@@ -170,9 +170,9 @@ object Sink {
   def redirect3[T,U,V,R](sink: Sink[T])
                        (project: (Observable[R], Observable[U], Observable[V]) => Observable[T])
                        :(Sink[R], Sink[U], Sink[V]) = {
-    val r = Sink.createHandler[R]().value.unsafeRunSync()
-    val u = Sink.createHandler[U]().value.unsafeRunSync()
-    val v = Sink.createHandler[V]().value.unsafeRunSync()
+    val r = Sink.createHandler[R]().unsafeRunSync()
+    val u = Sink.createHandler[U]().unsafeRunSync()
+    val v = Sink.createHandler[V]().unsafeRunSync()
 
     completionObservable(sink)
       .fold(project(r, u, v))(completed => project(r, u, v).takeUntil(completed))

--- a/src/main/scala/outwatch/dom/Handlers.scala
+++ b/src/main/scala/outwatch/dom/Handlers.scala
@@ -4,11 +4,15 @@ import org.scalajs.dom.MouseEvent
 import org.scalajs.dom.raw.{ClipboardEvent, DragEvent, KeyboardEvent}
 import outwatch.Sink
 import outwatch.dom.helpers.InputEvent
+import rxscalajs.Observable
+import cats.effect.IO
 
 /**
   * Trait containing event handlers, so they can be mixed in to other objects if needed.
   */
 trait Handlers {
+  type Handler[A] = Observable[A] with Sink[A]
+
   def createInputHandler() = createHandler[InputEvent]()
   def createMouseHandler() = createHandler[MouseEvent]()
   def createKeyboardHandler() = createHandler[KeyboardEvent]()
@@ -18,9 +22,7 @@ trait Handlers {
   def createBoolHandler(defaultValues: Boolean*) = createHandler[Boolean](defaultValues: _*)
   def createNumberHandler(defaultValues: Double*) = createHandler[Double](defaultValues: _*)
 
-  def createHandler[T](defaultValues: T*): Handler[T] = {
-    Sink.createHandler[T](defaultValues: _*)
-  }
+  def createHandler[T](defaultValues: T*): IO[Handler[T]] = Sink.createHandler[T](defaultValues: _*)
 }
 
 object Handlers extends Handlers

--- a/src/main/scala/outwatch/dom/Tags.scala
+++ b/src/main/scala/outwatch/dom/Tags.scala
@@ -18,64 +18,64 @@ import cats.effect.IO
 /** Trait that contains all tags, so they can be mixed in to other objects if needed.
   */
 trait Tags {
-  private def tag(nodeType: String)(args: Seq[VDomModifier]): IO[VTree] = IO.pure(VTree(nodeType, args))
+  private def tag(nodeType: String)(args: Seq[VDomModifier]): VNode = IO.pure(VTree(nodeType, args))
 
   /** Represents a hyperlink, linking to another resource.
     *
     *  MDN
     */
-  def a          (args: VDomModifier*): IO[VTree] = tag("a")(args)
+  def a          (args: VDomModifier*): VNode = tag("a")(args)
 
   /** An abbreviation or acronym; the expansion of the abbreviation can be
     * represented in the title attribute.
     *
     *  MDN
     */
-  def abbr       (args: VDomModifier*): IO[VTree] = tag("abbr")(args)
+  def abbr       (args: VDomModifier*): VNode = tag("abbr")(args)
 
   /** Defines a section containing contact information.
     *
     *  MDN
     */
-  def address    (args: VDomModifier*): IO[VTree] = tag("address")(args)
+  def address    (args: VDomModifier*): VNode = tag("address")(args)
 
   /** In conjunction with map, defines an image map
     *
     *  MDN
     */
-  def area       (args: VDomModifier*): IO[VTree] = tag("area")(args)
+  def area       (args: VDomModifier*): VNode = tag("area")(args)
 
   /** Defines self-contained content that could exist independently of the rest
     * of the content.
     *
     *  MDN
     */
-  def article    (args: VDomModifier*): IO[VTree] = tag("article")(args)
+  def article    (args: VDomModifier*): VNode = tag("article")(args)
 
   /** Defines some content loosely related to the page content. If it is removed,
     * the remaining content still makes sense.
     *
     *  MDN
     */
-  def aside      (args: VDomModifier*): IO[VTree] = tag("aside")(args)
+  def aside      (args: VDomModifier*): VNode = tag("aside")(args)
 
   /** Represents a sound or an audio stream.
     *
     *  MDN
     */
-  def audio      (args: VDomModifier*): IO[VTree] = tag("audio")(args)
+  def audio      (args: VDomModifier*): VNode = tag("audio")(args)
 
   /** Bold text.
     *
     *  MDN
     */
-  def b          (args: VDomModifier*): IO[VTree] = tag("b")(args)
+  def b          (args: VDomModifier*): VNode = tag("b")(args)
 
   /** Defines the base URL for relative URLs in the page.
     *
     *  MDN
     */
-  def base       (args: VDomModifier*): IO[VTree] = tag("base")(args)
+  def base       (args: VDomModifier*): VNode = tag("base")(args)
 
   /** Represents text that must be isolated from its surrounding for bidirectional
     * text formatting. It allows embedding a span of text with a different, or
@@ -83,278 +83,278 @@ trait Tags {
     *
     *  MDN
     */
-  def bdi        (args: VDomModifier*): IO[VTree] = tag("bdi")(args)
+  def bdi        (args: VDomModifier*): VNode = tag("bdi")(args)
 
   /** Represents the directionality of its children, in order to explicitly
     * override the Unicode bidirectional algorithm.
     *
     *  MDN
     */
-  def bdo        (args: VDomModifier*): IO[VTree] = tag("bdo")(args)
+  def bdo        (args: VDomModifier*): VNode = tag("bdo")(args)
 
   /** Represents a content that is quoted from another source.
     *
     *  MDN
     */
-  def blockquote (args: VDomModifier*): IO[VTree] = tag("blockquote")(args)
+  def blockquote (args: VDomModifier*): VNode = tag("blockquote")(args)
 
   /** Represents the content of an HTML document. There is only one body
     *   element in a document.
     *
     *  MDN
     */
-  def body       (args: VDomModifier*): IO[VTree] = tag("body")(args)
+  def body       (args: VDomModifier*): VNode = tag("body")(args)
 
   /** Represents a line break.
     *
     *  MDN
     */
-  def br         (args: VDomModifier*): IO[VTree] = tag("br")(args)
+  def br         (args: VDomModifier*): VNode = tag("br")(args)
 
   /** A button
     *
     *  MDN
     */
-  def button     (args: VDomModifier*): IO[VTree] = tag("button")(args)
+  def button     (args: VDomModifier*): VNode = tag("button")(args)
 
   /** Represents a bitmap area that scripts can use to render graphics like graphs,
     * games or any visual images on the fly.
     *
     *  MDN
     */
-  def canvas     (args: VDomModifier*): IO[VTree] = tag("canvas")(args)
+  def canvas     (args: VDomModifier*): VNode = tag("canvas")(args)
 
   /** The title of a table.
     *
     *  MDN
     */
-  def caption    (args: VDomModifier*): IO[VTree] = tag("caption")(args)
+  def caption    (args: VDomModifier*): VNode = tag("caption")(args)
 
   /** Represents the title of a work being cited.
     *
     *  MDN
     */
-  def cite       (args: VDomModifier*): IO[VTree] = tag("cite")(args)
+  def cite       (args: VDomModifier*): VNode = tag("cite")(args)
 
   /** Represents computer code.
     *
     *  MDN
     */
-  def code       (args: VDomModifier*): IO[VTree] = tag("code")(args)
+  def code       (args: VDomModifier*): VNode = tag("code")(args)
 
   /** A single column.
     *
     *  MDN
     */
-  def col        (args: VDomModifier*): IO[VTree] = tag("col")(args)
+  def col        (args: VDomModifier*): VNode = tag("col")(args)
 
   /** A set of columns.
     *
     *  MDN
     */
-  def colgroup   (args: VDomModifier*): IO[VTree] = tag("colgroup")(args)
+  def colgroup   (args: VDomModifier*): VNode = tag("colgroup")(args)
 
   /** Links a given content with a machine-readable translation.
     * If the content is time- or date-related, the `<time>` element must be used.
     *
     * MDN
     */
-  def dataElement(args: VDomModifier*): IO[VTree] = tag("data")(args)
+  def dataElement(args: VDomModifier*): VNode = tag("data")(args)
 
   /** A set of predefined options for other controls.
     *
     *  MDN
     */
-  def datalist   (args: VDomModifier*): IO[VTree] = tag("datalist")(args)
+  def datalist   (args: VDomModifier*): VNode = tag("datalist")(args)
 
   /** Represents the definition of the terms immediately listed before it.
     *
     * MDN
     */
-  def dd         (args: VDomModifier*): IO[VTree] = tag("dd")(args)
+  def dd         (args: VDomModifier*): VNode = tag("dd")(args)
 
   /** Defines a removal from the document.
     *
     * MDN
     */
-  def del        (args: VDomModifier*): IO[VTree] = tag("del")(args)
+  def del        (args: VDomModifier*): VNode = tag("del")(args)
 
   /** A widget from which the user can obtain additional information
     * or controls.
     *
     * MDN
     */
-  def details    (args: VDomModifier*): IO[VTree] = tag("details")(args)
+  def details    (args: VDomModifier*): VNode = tag("details")(args)
 
   /** Represents a term whose definition is contained in its nearest ancestor
     * content.
     *
     * MDN
     */
-  def dfn        (args: VDomModifier*): IO[VTree] = tag("dfn")(args)
+  def dfn        (args: VDomModifier*): VNode = tag("dfn")(args)
 
   /** Represents a dialog box or other interactive component, such as an inspector
     * or window.
     *
     * MDN
     */
-  def dialog     (args: VDomModifier*): IO[VTree] = tag("dialog")(args)
+  def dialog     (args: VDomModifier*): VNode = tag("dialog")(args)
 
   /** Represents a generic container with no special meaning.
     *
     * MDN
     */
-  def div        (args: VDomModifier*): IO[VTree] = tag("div")(args)
+  def div        (args: VDomModifier*): VNode = tag("div")(args)
 
   /** Defines a definition list; a list of terms and their associated definitions.
     *
     * MDN
     */
-  def dl         (args: VDomModifier*): IO[VTree] = tag("dl")(args)
+  def dl         (args: VDomModifier*): VNode = tag("dl")(args)
 
   /** Represents a term defined by the next dd
     *
     * MDN
     */
-  def dt         (args: VDomModifier*): IO[VTree] = tag("dt")(args)
+  def dt         (args: VDomModifier*): VNode = tag("dt")(args)
 
   /** Represents emphasized text.
     *
     * MDN
     */
-  def em         (args: VDomModifier*): IO[VTree] = tag("em")(args)
+  def em         (args: VDomModifier*): VNode = tag("em")(args)
 
   /** Represents a integration point for an external, often non-HTML, application
     * or interactive content.
     *
     * MDN
     */
-  def embed      (args: VDomModifier*): IO[VTree] = tag("embed")(args)
+  def embed      (args: VDomModifier*): VNode = tag("embed")(args)
 
   /** A set of fields.
     *
     * MDN
     */
-  def fieldset   (args: VDomModifier*): IO[VTree] = tag("fieldset")(args)
+  def fieldset   (args: VDomModifier*): VNode = tag("fieldset")(args)
 
   /** Represents the legend of a figure.
     *
     * MDN
     */
-  def figcaption (args: VDomModifier*): IO[VTree] = tag("figcaption")(args)
+  def figcaption (args: VDomModifier*): VNode = tag("figcaption")(args)
 
   /** Represents a figure illustrated as part of the document.
     *
     * MDN
     */
-  def figure     (args: VDomModifier*): IO[VTree] = tag("figure")(args)
+  def figure     (args: VDomModifier*): VNode = tag("figure")(args)
 
   /** Defines the footer for a page or section. It often contains a copyright
     * notice, some links to legal information, or addresses to give feedback.
     *
     * MDN
     */
-  def footer     (args: VDomModifier*): IO[VTree] = tag("footer")(args)
+  def footer     (args: VDomModifier*): VNode = tag("footer")(args)
 
   /** Represents a form, consisting of controls, that can be submitted to a
     * server for processing.
     *
     * MDN
     */
-  def form       (args: VDomModifier*): IO[VTree] = tag("form")(args)
+  def form       (args: VDomModifier*): VNode = tag("form")(args)
 
   /** Heading level 1
     *
     * MDN
     */
-  def h1         (args: VDomModifier*): IO[VTree] = tag("h1")(args)
+  def h1         (args: VDomModifier*): VNode = tag("h1")(args)
 
   /** Heading level 2
     *
     * MDN
     */
-  def h2         (args: VDomModifier*): IO[VTree] = tag("h2")(args)
+  def h2         (args: VDomModifier*): VNode = tag("h2")(args)
 
   /** Heading level 3
     *
     * MDN
     */
-  def h3         (args: VDomModifier*): IO[VTree] = tag("h3")(args)
+  def h3         (args: VDomModifier*): VNode = tag("h3")(args)
 
   /** Heading level 4
     *
     * MDN
     */
-  def h4         (args: VDomModifier*): IO[VTree] = tag("h4")(args)
+  def h4         (args: VDomModifier*): VNode = tag("h4")(args)
 
   /** Heading level 5
     *
     * MDN
     */
-  def h5         (args: VDomModifier*): IO[VTree] = tag("h5")(args)
+  def h5         (args: VDomModifier*): VNode = tag("h5")(args)
 
   /** Heading level 6
     *
     * MDN
     */
-  def h6         (args: VDomModifier*): IO[VTree] = tag("h6")(args)
+  def h6         (args: VDomModifier*): VNode = tag("h6")(args)
 
   /** Represents a collection of metadata about the document, including links to,
     * or definitions of, scripts and style sheets.
     *
     * MDN
     */
-  def head       (args: VDomModifier*): IO[VTree] = tag("head")(args)
+  def head       (args: VDomModifier*): VNode = tag("head")(args)
 
   /** Defines the header of a page or section. It often contains a logo, the
     * title of the Web site, and a navigational table of content.
     *
     * MDN
     */
-  def header     (args: VDomModifier*): IO[VTree] = tag("header")(args)
+  def header     (args: VDomModifier*): VNode = tag("header")(args)
 
   /** Represents a thematic break between paragraphs of a section or article or
     * any longer content.
     *
     * MDN
     */
-  def hr         (args: VDomModifier*): IO[VTree] = tag("hr")(args)
+  def hr         (args: VDomModifier*): VNode = tag("hr")(args)
 
   /** Italicized text.
     *
     * MDN
     */
-  def i          (args: VDomModifier*): IO[VTree] = tag("i")(args)
+  def i          (args: VDomModifier*): VNode = tag("i")(args)
 
   /** Represents a nested browsing context, that is an embedded HTML document.
     *
     * MDN
     */
-  def iframe     (args: VDomModifier*): IO[VTree] = tag("iframe")(args)
+  def iframe     (args: VDomModifier*): VNode = tag("iframe")(args)
 
   /** Represents an image.
     *
     * MDN
     */
-  def img        (args: VDomModifier*): IO[VTree] = tag("img")(args)
+  def img        (args: VDomModifier*): VNode = tag("img")(args)
 
   /** A typed data field allowing the user to input data.
     *
     * MDN
     */
-  def input      (args: VDomModifier*): IO[VTree] = tag("input")(args)
+  def input      (args: VDomModifier*): VNode = tag("input")(args)
 
   /** Defines an addition to the document.
     *
     * MDN
     */
-  def ins        (args: VDomModifier*): IO[VTree] = tag("ins")(args)
+  def ins        (args: VDomModifier*): VNode = tag("ins")(args)
 
   /** Represents user input, often from a keyboard, but not necessarily.
     *
     * MDN
     */
-  def kbd        (args: VDomModifier*): IO[VTree] = tag("kbd")(args)
+  def kbd        (args: VDomModifier*): VNode = tag("kbd")(args)
 
   /** A key-pair generator control.
     *
@@ -368,57 +368,57 @@ trait Tags {
       |compatibility table at the bottom of this page to guide your decision.
       |Be aware that this feature may cease to work at any time.
     """.stripMargin, "0.9.0")
-  def keygen     (args: VDomModifier*): IO[VTree] = tag("keygen")(args)
+  def keygen     (args: VDomModifier*): VNode = tag("keygen")(args)
 
   /** The caption of a single field
     *
     * MDN
     */
-  def label      (args: VDomModifier*): IO[VTree] = tag("label")(args)
+  def label      (args: VDomModifier*): VNode = tag("label")(args)
 
   /** The caption for a fieldset.
     *
     * MDN
     */
-  def legend     (args: VDomModifier*): IO[VTree] = tag("legend")(args)
+  def legend     (args: VDomModifier*): VNode = tag("legend")(args)
 
   /** Defines an item of an list.
     *
     * MDN
     */
-  def li         (args: VDomModifier*): IO[VTree] = tag("li")(args)
+  def li         (args: VDomModifier*): VNode = tag("li")(args)
 
   /** Used to link JavaScript and external CSS with the current HTML document.
     *
     * MDN
     */
-  def link       (args: VDomModifier*): IO[VTree] = tag("link")(args)
+  def link       (args: VDomModifier*): VNode = tag("link")(args)
 
   /** Defines the main or important content in the document. There is only one
     * main element in the document.
     *
     * MDN
     */
-  def main       (args: VDomModifier*): IO[VTree] = tag("main")(args)
+  def main       (args: VDomModifier*): VNode = tag("main")(args)
 
   /** In conjunction with area, defines an image map.
     *
     * MDN
     */
-  def map        (args: VDomModifier*): IO[VTree] = tag("map")(args)
+  def map        (args: VDomModifier*): VNode = tag("map")(args)
 
   /** Represents text highlighted for reference purposes, that is for its
     * relevance in another context.
     *
     * MDN
     */
-  def mark       (args: VDomModifier*): IO[VTree] = tag("mark")(args)
+  def mark       (args: VDomModifier*): VNode = tag("mark")(args)
 
   /** Defines a mathematical formula.
     *
     * MDN
     */
-  def math       (args: VDomModifier*): IO[VTree] = tag("math")(args)
+  def math       (args: VDomModifier*): VNode = tag("math")(args)
 
   /** Represents a group of commands that a user can perform or activate.
     * This includes both list menus, which might appear across the top of
@@ -427,7 +427,7 @@ trait Tags {
     *
     * MDN
     */
-  def menu       (args: VDomModifier*): IO[VTree] = tag("menu")(args)
+  def menu       (args: VDomModifier*): VNode = tag("menu")(args)
 
   /** Represents a command that a user is able to invoke through a popup menu.
     * This includes context menus, as well as menus that might be attached to
@@ -443,96 +443,96 @@ trait Tags {
     *
     * MDN
     */
-  def menuitem   (args: VDomModifier*): IO[VTree] = tag("menuitem")(args)
+  def menuitem   (args: VDomModifier*): VNode = tag("menuitem")(args)
 
   /** Defines metadata that can't be defined using another HTML element.
     *
     * MDN
     */
-  def meta       (args: VDomModifier*): IO[VTree] = tag("meta")(args)
+  def meta       (args: VDomModifier*): VNode = tag("meta")(args)
 
   /** A scalar measurement within a known range.
     *
     * MDN
     */
-  def meter      (args: VDomModifier*): IO[VTree] = tag("meter")(args)
+  def meter      (args: VDomModifier*): VNode = tag("meter")(args)
 
   /** Represents a section of a page that links to other pages or to parts within
     * the page: a section with navigation links.
     *
     * MDN
     */
-  def nav        (args: VDomModifier*): IO[VTree] = tag("nav")(args)
+  def nav        (args: VDomModifier*): VNode = tag("nav")(args)
 
   /** Defines alternative content to display when the browser doesn't support
     * scripting.
     *
     * MDN
     */
-  def noscript   (args: VDomModifier*): IO[VTree] = tag("noscript")(args)
+  def noscript   (args: VDomModifier*): VNode = tag("noscript")(args)
 
   /** Represents an external resource, which is treated as an image, an HTML
     * sub-document, or an external resource to be processed by a plug-in.
     *
     * MDN
     */
-  def `object`   (args: VDomModifier*): IO[VTree] = tag("object")(args)
+  def `object`   (args: VDomModifier*): VNode = tag("object")(args)
 
   /** Defines an ordered list of items.
     *
     * MDN
     */
-  def ol         (args: VDomModifier*): IO[VTree] = tag("ol")(args)
+  def ol         (args: VDomModifier*): VNode = tag("ol")(args)
 
   /** A set of options, logically grouped.
     *
     * MDN
     */
-  def optgroup   (args: VDomModifier*): IO[VTree] = tag("optgroup")(args)
+  def optgroup   (args: VDomModifier*): VNode = tag("optgroup")(args)
 
   /**
     * An option in a select element.
     *
     *  MDN
     */
-  def option     (args: VDomModifier*): IO[VTree] = tag("option")(args)
+  def option     (args: VDomModifier*): VNode = tag("option")(args)
 
   /** The result of a calculation
     *
     * MDN
     */
-  def output     (args: VDomModifier*): IO[VTree] = tag("output")(args)
+  def output     (args: VDomModifier*): VNode = tag("output")(args)
 
   /** Defines a portion that should be displayed as a paragraph.
     *
     * MDN
     */
-  def p          (args: VDomModifier*): IO[VTree] = tag("p")(args)
+  def p          (args: VDomModifier*): VNode = tag("p")(args)
 
   /** Defines parameters for use by plug-ins invoked by object elements.
     *
     * MDN
     */
-  def param      (args: VDomModifier*): IO[VTree] = tag("param")(args)
+  def param      (args: VDomModifier*): VNode = tag("param")(args)
 
   /** Indicates that its content is preformatted and that this format must be
     * preserved.
     *
     * MDN
     */
-  def pre        (args: VDomModifier*): IO[VTree] = tag("pre")(args)
+  def pre        (args: VDomModifier*): VNode = tag("pre")(args)
 
   /** A progress completion bar
     *
     * MDN
     */
-  def progress   (args: VDomModifier*): IO[VTree] = tag("progress")(args)
+  def progress   (args: VDomModifier*): VNode = tag("progress")(args)
 
   /** An inline quotation.
     *
     * MDN
     */
-  def q          (args: VDomModifier*): IO[VTree] = tag("q")(args)
+  def q          (args: VDomModifier*): VNode = tag("q")(args)
 
   /** Represents parenthesis around a ruby annotation, used to display the
     * annotation in an alternate way by browsers not supporting the standard
@@ -540,7 +540,7 @@ trait Tags {
     *
     * MDN
     */
-  def rp         (args: VDomModifier*): IO[VTree] = tag("rp")(args)
+  def rp         (args: VDomModifier*): VNode = tag("rp")(args)
 
   /** Represents content to be marked with ruby annotations, short runs of text
     * presented alongside the text. This is often used in conjunction with East
@@ -549,66 +549,66 @@ trait Tags {
     *
     * MDN
     */
-  def ruby         (args: VDomModifier*): IO[VTree] = tag("ruby")(args)
+  def ruby         (args: VDomModifier*): VNode = tag("ruby")(args)
 
   /** Represents the text of a ruby annotation.
     *
     * MDN
     */
-  def rt         (args: VDomModifier*): IO[VTree] = tag("rt")(args)
+  def rt         (args: VDomModifier*): VNode = tag("rt")(args)
 
   /** Strikethrough element, used for that is no longer accurate or relevant.
     *
     * MDN
     */
-  def s          (args: VDomModifier*): IO[VTree] = tag("s")(args)
+  def s          (args: VDomModifier*): VNode = tag("s")(args)
 
   /** Represents sample output of a program or a computer.
     *
     * MDN
     */
-  def samp       (args: VDomModifier*): IO[VTree] = tag("samp")(args)
+  def samp       (args: VDomModifier*): VNode = tag("samp")(args)
 
   /** Defines either an internal script or a link to an external script. The
     * script language is JavaScript.
     *
     * MDN
     */
-  def script     (args: VDomModifier*): IO[VTree] = tag("script")(args)
+  def script     (args: VDomModifier*): VNode = tag("script")(args)
 
   /** Represents a generic section of a document, i.e., a thematic grouping of
     * content, typically with a heading.
     *
     * MDN
     */
-  def section    (args: VDomModifier*): IO[VTree] = tag("section")(args)
+  def section    (args: VDomModifier*): VNode = tag("section")(args)
 
   /** A control that allows the user to select one of a set of options.
     *
     * MDN
     */
-  def select     (args: VDomModifier*): IO[VTree] = tag("select")(args)
+  def select     (args: VDomModifier*): VNode = tag("select")(args)
 
   /** Represents a placeholder inside a web component that you can fill with
     * your own markup, with the effect of composing different DOM trees together.
     *
     * MDN
     */
-  def slot       (args: VDomModifier*): IO[VTree] = tag("slot")(args)
+  def slot       (args: VDomModifier*): VNode = tag("slot")(args)
 
   /** Represents a side comment; text like a disclaimer or copyright, which is not
     * essential to the comprehension of the document.
     *
     * MDN
     */
-  def small      (args: VDomModifier*): IO[VTree] = tag("small")(args)
+  def small      (args: VDomModifier*): VNode = tag("small")(args)
 
   /** Allows the authors to specify alternate media resources for media elements
     * like video or audio
     *
     * MDN
     */
-  def source     (args: VDomModifier*): IO[VTree] = tag("source")(args)
+  def source     (args: VDomModifier*): VNode = tag("source")(args)
 
   /** Represents text with no specific meaning. This has to be used when no other
     * text-semantic element conveys an adequate meaning, which, in this case, is
@@ -616,86 +616,86 @@ trait Tags {
     *
     * MDN
     */
-  def span       (args: VDomModifier*): IO[VTree] = tag("span")(args)
+  def span       (args: VDomModifier*): VNode = tag("span")(args)
 
   /** Represents especially important text.
     *
     * MDN
     */
-  def strong     (args: VDomModifier*): IO[VTree] = tag("strong")(args)
+  def strong     (args: VDomModifier*): VNode = tag("strong")(args)
 
   /** Used to write inline CSS.
     *
     * MDN
     */
-  def style      (args: VDomModifier*): IO[VTree] = tag("style")(args)
+  def style      (args: VDomModifier*): VNode = tag("style")(args)
 
   /** Subscript tag
     *
     * MDN
     */
-  def sub        (args: VDomModifier*): IO[VTree] = tag("sub")(args)
+  def sub        (args: VDomModifier*): VNode = tag("sub")(args)
 
   /** A summary, caption, or legend for a given details.
     *
     * MDN
     */
-  def summary    (args: VDomModifier*): IO[VTree] = tag("summary")(args)
+  def summary    (args: VDomModifier*): VNode = tag("summary")(args)
 
   /** Superscript tag.
     *
     * MDN
     */
-  def sup        (args: VDomModifier*): IO[VTree] = tag("sup")(args)
+  def sup        (args: VDomModifier*): VNode = tag("sup")(args)
 
   /** Represents data with more than one dimension.
     *
     * MDN
     */
-  def table      (args: VDomModifier*): IO[VTree] = tag("table")(args)
+  def table      (args: VDomModifier*): VNode = tag("table")(args)
 
   /** The table body.
     *
     * MDN
     */
-  def tbody      (args: VDomModifier*): IO[VTree] = tag("tbody")(args)
+  def tbody      (args: VDomModifier*): VNode = tag("tbody")(args)
 
   /** A single cell in a table.
     *
     * MDN
     */
-  def td         (args: VDomModifier*): IO[VTree] = tag("td")(args)
+  def td         (args: VDomModifier*): VNode = tag("td")(args)
 
   /** A multiline text edit control.
     *
     * MDN
     */
-  def textarea   (args: VDomModifier*): IO[VTree] = tag("textarea")(args)
+  def textarea   (args: VDomModifier*): VNode = tag("textarea")(args)
 
   /** The table footer.
     *
     * MDN
     */
-  def tfoot      (args: VDomModifier*): IO[VTree] = tag("tfoot")(args)
+  def tfoot      (args: VDomModifier*): VNode = tag("tfoot")(args)
 
   /** A header cell in a table.
     *
     * MDN
     */
-  def th         (args: VDomModifier*): IO[VTree] = tag("th")(args)
+  def th         (args: VDomModifier*): VNode = tag("th")(args)
 
   /** The table headers.
     *
     * MDN
     */
-  def thead      (args: VDomModifier*): IO[VTree] = tag("thead")(args)
+  def thead      (args: VDomModifier*): VNode = tag("thead")(args)
 
   /** Represents a date and time value; the machine-readable equivalent can be
     * represented in the datetime attribetu
     *
     * MDN
     */
-  def time       (args: VDomModifier*): IO[VTree] = tag("time")(args)
+  def time       (args: VDomModifier*): VNode = tag("time")(args)
 
   /** Defines the title of the document, shown in a browser's title bar or on the
     * page's tab. It can only contain text and any contained tags are not
@@ -703,46 +703,46 @@ trait Tags {
     *
     * MDN
     */
-  def title      (args: VDomModifier*): IO[VTree] = tag("title")(args)
+  def title      (args: VDomModifier*): VNode = tag("title")(args)
 
   /** A single row in a table.
     *
     * MDN
     */
-  def tr         (args: VDomModifier*): IO[VTree] = tag("tr")(args)
+  def tr         (args: VDomModifier*): VNode = tag("tr")(args)
 
   /** Allows authors to specify timed text track for media elements like video or
     * audio
     *
     * MDN
     */
-  def track      (args: VDomModifier*): IO[VTree] = tag("track")(args)
+  def track      (args: VDomModifier*): VNode = tag("track")(args)
 
   /** Underlined text.
     *
     * MDN
     */
-  def u          (args: VDomModifier*): IO[VTree] = tag("u")(args)
+  def u          (args: VDomModifier*): VNode = tag("u")(args)
 
   /** Defines an unordered list of items.
     *
     * MDN
     */
-  def ul         (args: VDomModifier*): IO[VTree] = tag("ul")(args)
+  def ul         (args: VDomModifier*): VNode = tag("ul")(args)
 
   /** Represents a video, and its associated audio files and captions, with the
     * necessary interface to play it.
     *
     * MDN
     */
-  def video      (args: VDomModifier*): IO[VTree] = tag("video")(args)
+  def video      (args: VDomModifier*): VNode = tag("video")(args)
 
   /** Represents a line break opportunity, that is a suggested point for wrapping
     * text in order to improve readability of text split on several lines.
     *
     * MDN
     */
-  def wbr        (args: VDomModifier*): IO[VTree] = tag("wbr")(args)
+  def wbr        (args: VDomModifier*): VNode = tag("wbr")(args)
 }
 
 object Tags extends Tags

--- a/src/main/scala/outwatch/dom/Tags.scala
+++ b/src/main/scala/outwatch/dom/Tags.scala
@@ -19,7 +19,7 @@ import outwatch.dom.helpers.DomUtils
 /** Trait that contains all tags, so they can be mixed in to other objects if needed.
   */
 trait Tags {
-  private def tag(nodeType: String)(args: Seq[VDomModifier]): VNode = VDomIO(IO(VTree(nodeType, args)))
+  private def tag(nodeType: String)(args: Seq[VDomModifier]): VNode = VTree(nodeType, args)
 
   /** Represents a hyperlink, linking to another resource.
     *

--- a/src/main/scala/outwatch/dom/Tags.scala
+++ b/src/main/scala/outwatch/dom/Tags.scala
@@ -14,69 +14,69 @@ package outwatch.dom
 
 import cats.effect.IO
 import outwatch.dom.VDomModifier.VTree
-import outwatch.dom.helpers.DomUtils
+
 
 /** Trait that contains all tags, so they can be mixed in to other objects if needed.
   */
 trait Tags {
-  private def tag(nodeType: String)(args: Seq[VDomModifier]): VNode = VTree(nodeType, args)
+  private def tag(nodeType: String)(args: Seq[VDomModifier]): IO[VTree] = IO.pure(VTree(nodeType, args))
 
   /** Represents a hyperlink, linking to another resource.
     *
     *  MDN
     */
-  def a          (args: VDomModifier*): VNode = tag("a")(args)
+  def a          (args: VDomModifier*): IO[VTree] = tag("a")(args)
 
   /** An abbreviation or acronym; the expansion of the abbreviation can be
     * represented in the title attribute.
     *
     *  MDN
     */
-  def abbr       (args: VDomModifier*): VNode = tag("abbr")(args)
+  def abbr       (args: VDomModifier*): IO[VTree] = tag("abbr")(args)
 
   /** Defines a section containing contact information.
     *
     *  MDN
     */
-  def address    (args: VDomModifier*): VNode = tag("address")(args)
+  def address    (args: VDomModifier*): IO[VTree] = tag("address")(args)
 
   /** In conjunction with map, defines an image map
     *
     *  MDN
     */
-  def area       (args: VDomModifier*): VNode = tag("area")(args)
+  def area       (args: VDomModifier*): IO[VTree] = tag("area")(args)
 
   /** Defines self-contained content that could exist independently of the rest
     * of the content.
     *
     *  MDN
     */
-  def article    (args: VDomModifier*): VNode = tag("article")(args)
+  def article    (args: VDomModifier*): IO[VTree] = tag("article")(args)
 
   /** Defines some content loosely related to the page content. If it is removed,
     * the remaining content still makes sense.
     *
     *  MDN
     */
-  def aside      (args: VDomModifier*): VNode = tag("aside")(args)
+  def aside      (args: VDomModifier*): IO[VTree] = tag("aside")(args)
 
   /** Represents a sound or an audio stream.
     *
     *  MDN
     */
-  def audio      (args: VDomModifier*): VNode = tag("audio")(args)
+  def audio      (args: VDomModifier*): IO[VTree] = tag("audio")(args)
 
   /** Bold text.
     *
     *  MDN
     */
-  def b          (args: VDomModifier*): VNode = tag("b")(args)
+  def b          (args: VDomModifier*): IO[VTree] = tag("b")(args)
 
   /** Defines the base URL for relative URLs in the page.
     *
     *  MDN
     */
-  def base       (args: VDomModifier*): VNode = tag("base")(args)
+  def base       (args: VDomModifier*): IO[VTree] = tag("base")(args)
 
   /** Represents text that must be isolated from its surrounding for bidirectional
     * text formatting. It allows embedding a span of text with a different, or
@@ -84,278 +84,278 @@ trait Tags {
     *
     *  MDN
     */
-  def bdi        (args: VDomModifier*): VNode = tag("bdi")(args)
+  def bdi        (args: VDomModifier*): IO[VTree] = tag("bdi")(args)
 
   /** Represents the directionality of its children, in order to explicitly
     * override the Unicode bidirectional algorithm.
     *
     *  MDN
     */
-  def bdo        (args: VDomModifier*): VNode = tag("bdo")(args)
+  def bdo        (args: VDomModifier*): IO[VTree] = tag("bdo")(args)
 
   /** Represents a content that is quoted from another source.
     *
     *  MDN
     */
-  def blockquote (args: VDomModifier*): VNode = tag("blockquote")(args)
+  def blockquote (args: VDomModifier*): IO[VTree] = tag("blockquote")(args)
 
   /** Represents the content of an HTML document. There is only one body
     *   element in a document.
     *
     *  MDN
     */
-  def body       (args: VDomModifier*): VNode = tag("body")(args)
+  def body       (args: VDomModifier*): IO[VTree] = tag("body")(args)
 
   /** Represents a line break.
     *
     *  MDN
     */
-  def br         (args: VDomModifier*): VNode = tag("br")(args)
+  def br         (args: VDomModifier*): IO[VTree] = tag("br")(args)
 
   /** A button
     *
     *  MDN
     */
-  def button     (args: VDomModifier*): VNode = tag("button")(args)
+  def button     (args: VDomModifier*): IO[VTree] = tag("button")(args)
 
   /** Represents a bitmap area that scripts can use to render graphics like graphs,
     * games or any visual images on the fly.
     *
     *  MDN
     */
-  def canvas     (args: VDomModifier*): VNode = tag("canvas")(args)
+  def canvas     (args: VDomModifier*): IO[VTree] = tag("canvas")(args)
 
   /** The title of a table.
     *
     *  MDN
     */
-  def caption    (args: VDomModifier*): VNode = tag("caption")(args)
+  def caption    (args: VDomModifier*): IO[VTree] = tag("caption")(args)
 
   /** Represents the title of a work being cited.
     *
     *  MDN
     */
-  def cite       (args: VDomModifier*): VNode = tag("cite")(args)
+  def cite       (args: VDomModifier*): IO[VTree] = tag("cite")(args)
 
   /** Represents computer code.
     *
     *  MDN
     */
-  def code       (args: VDomModifier*): VNode = tag("code")(args)
+  def code       (args: VDomModifier*): IO[VTree] = tag("code")(args)
 
   /** A single column.
     *
     *  MDN
     */
-  def col        (args: VDomModifier*): VNode = tag("col")(args)
+  def col        (args: VDomModifier*): IO[VTree] = tag("col")(args)
 
   /** A set of columns.
     *
     *  MDN
     */
-  def colgroup   (args: VDomModifier*): VNode = tag("colgroup")(args)
+  def colgroup   (args: VDomModifier*): IO[VTree] = tag("colgroup")(args)
 
   /** Links a given content with a machine-readable translation.
     * If the content is time- or date-related, the `<time>` element must be used.
     *
     * MDN
     */
-  def dataElement(args: VDomModifier*): VNode = tag("data")(args)
+  def dataElement(args: VDomModifier*): IO[VTree] = tag("data")(args)
 
   /** A set of predefined options for other controls.
     *
     *  MDN
     */
-  def datalist   (args: VDomModifier*): VNode = tag("datalist")(args)
+  def datalist   (args: VDomModifier*): IO[VTree] = tag("datalist")(args)
 
   /** Represents the definition of the terms immediately listed before it.
     *
     * MDN
     */
-  def dd         (args: VDomModifier*): VNode = tag("dd")(args)
+  def dd         (args: VDomModifier*): IO[VTree] = tag("dd")(args)
 
   /** Defines a removal from the document.
     *
     * MDN
     */
-  def del        (args: VDomModifier*): VNode = tag("del")(args)
+  def del        (args: VDomModifier*): IO[VTree] = tag("del")(args)
 
   /** A widget from which the user can obtain additional information
     * or controls.
     *
     * MDN
     */
-  def details    (args: VDomModifier*): VNode = tag("details")(args)
+  def details    (args: VDomModifier*): IO[VTree] = tag("details")(args)
 
   /** Represents a term whose definition is contained in its nearest ancestor
     * content.
     *
     * MDN
     */
-  def dfn        (args: VDomModifier*): VNode = tag("dfn")(args)
+  def dfn        (args: VDomModifier*): IO[VTree] = tag("dfn")(args)
 
   /** Represents a dialog box or other interactive component, such as an inspector
     * or window.
     *
     * MDN
     */
-  def dialog     (args: VDomModifier*): VNode = tag("dialog")(args)
+  def dialog     (args: VDomModifier*): IO[VTree] = tag("dialog")(args)
 
   /** Represents a generic container with no special meaning.
     *
     * MDN
     */
-  def div        (args: VDomModifier*): VNode = tag("div")(args)
+  def div        (args: VDomModifier*): IO[VTree] = tag("div")(args)
 
   /** Defines a definition list; a list of terms and their associated definitions.
     *
     * MDN
     */
-  def dl         (args: VDomModifier*): VNode = tag("dl")(args)
+  def dl         (args: VDomModifier*): IO[VTree] = tag("dl")(args)
 
   /** Represents a term defined by the next dd
     *
     * MDN
     */
-  def dt         (args: VDomModifier*): VNode = tag("dt")(args)
+  def dt         (args: VDomModifier*): IO[VTree] = tag("dt")(args)
 
   /** Represents emphasized text.
     *
     * MDN
     */
-  def em         (args: VDomModifier*): VNode = tag("em")(args)
+  def em         (args: VDomModifier*): IO[VTree] = tag("em")(args)
 
   /** Represents a integration point for an external, often non-HTML, application
     * or interactive content.
     *
     * MDN
     */
-  def embed      (args: VDomModifier*): VNode = tag("embed")(args)
+  def embed      (args: VDomModifier*): IO[VTree] = tag("embed")(args)
 
   /** A set of fields.
     *
     * MDN
     */
-  def fieldset   (args: VDomModifier*): VNode = tag("fieldset")(args)
+  def fieldset   (args: VDomModifier*): IO[VTree] = tag("fieldset")(args)
 
   /** Represents the legend of a figure.
     *
     * MDN
     */
-  def figcaption (args: VDomModifier*): VNode = tag("figcaption")(args)
+  def figcaption (args: VDomModifier*): IO[VTree] = tag("figcaption")(args)
 
   /** Represents a figure illustrated as part of the document.
     *
     * MDN
     */
-  def figure     (args: VDomModifier*): VNode = tag("figure")(args)
+  def figure     (args: VDomModifier*): IO[VTree] = tag("figure")(args)
 
   /** Defines the footer for a page or section. It often contains a copyright
     * notice, some links to legal information, or addresses to give feedback.
     *
     * MDN
     */
-  def footer     (args: VDomModifier*): VNode = tag("footer")(args)
+  def footer     (args: VDomModifier*): IO[VTree] = tag("footer")(args)
 
   /** Represents a form, consisting of controls, that can be submitted to a
     * server for processing.
     *
     * MDN
     */
-  def form       (args: VDomModifier*): VNode = tag("form")(args)
+  def form       (args: VDomModifier*): IO[VTree] = tag("form")(args)
 
   /** Heading level 1
     *
     * MDN
     */
-  def h1         (args: VDomModifier*): VNode = tag("h1")(args)
+  def h1         (args: VDomModifier*): IO[VTree] = tag("h1")(args)
 
   /** Heading level 2
     *
     * MDN
     */
-  def h2         (args: VDomModifier*): VNode = tag("h2")(args)
+  def h2         (args: VDomModifier*): IO[VTree] = tag("h2")(args)
 
   /** Heading level 3
     *
     * MDN
     */
-  def h3         (args: VDomModifier*): VNode = tag("h3")(args)
+  def h3         (args: VDomModifier*): IO[VTree] = tag("h3")(args)
 
   /** Heading level 4
     *
     * MDN
     */
-  def h4         (args: VDomModifier*): VNode = tag("h4")(args)
+  def h4         (args: VDomModifier*): IO[VTree] = tag("h4")(args)
 
   /** Heading level 5
     *
     * MDN
     */
-  def h5         (args: VDomModifier*): VNode = tag("h5")(args)
+  def h5         (args: VDomModifier*): IO[VTree] = tag("h5")(args)
 
   /** Heading level 6
     *
     * MDN
     */
-  def h6         (args: VDomModifier*): VNode = tag("h6")(args)
+  def h6         (args: VDomModifier*): IO[VTree] = tag("h6")(args)
 
   /** Represents a collection of metadata about the document, including links to,
     * or definitions of, scripts and style sheets.
     *
     * MDN
     */
-  def head       (args: VDomModifier*): VNode = tag("head")(args)
+  def head       (args: VDomModifier*): IO[VTree] = tag("head")(args)
 
   /** Defines the header of a page or section. It often contains a logo, the
     * title of the Web site, and a navigational table of content.
     *
     * MDN
     */
-  def header     (args: VDomModifier*): VNode = tag("header")(args)
+  def header     (args: VDomModifier*): IO[VTree] = tag("header")(args)
 
   /** Represents a thematic break between paragraphs of a section or article or
     * any longer content.
     *
     * MDN
     */
-  def hr         (args: VDomModifier*): VNode = tag("hr")(args)
+  def hr         (args: VDomModifier*): IO[VTree] = tag("hr")(args)
 
   /** Italicized text.
     *
     * MDN
     */
-  def i          (args: VDomModifier*): VNode = tag("i")(args)
+  def i          (args: VDomModifier*): IO[VTree] = tag("i")(args)
 
   /** Represents a nested browsing context, that is an embedded HTML document.
     *
     * MDN
     */
-  def iframe     (args: VDomModifier*): VNode = tag("iframe")(args)
+  def iframe     (args: VDomModifier*): IO[VTree] = tag("iframe")(args)
 
   /** Represents an image.
     *
     * MDN
     */
-  def img        (args: VDomModifier*): VNode = tag("img")(args)
+  def img        (args: VDomModifier*): IO[VTree] = tag("img")(args)
 
   /** A typed data field allowing the user to input data.
     *
     * MDN
     */
-  def input      (args: VDomModifier*): VNode = tag("input")(args)
+  def input      (args: VDomModifier*): IO[VTree] = tag("input")(args)
 
   /** Defines an addition to the document.
     *
     * MDN
     */
-  def ins        (args: VDomModifier*): VNode = tag("ins")(args)
+  def ins        (args: VDomModifier*): IO[VTree] = tag("ins")(args)
 
   /** Represents user input, often from a keyboard, but not necessarily.
     *
     * MDN
     */
-  def kbd        (args: VDomModifier*): VNode = tag("kbd")(args)
+  def kbd        (args: VDomModifier*): IO[VTree] = tag("kbd")(args)
 
   /** A key-pair generator control.
     *
@@ -369,57 +369,57 @@ trait Tags {
       |compatibility table at the bottom of this page to guide your decision.
       |Be aware that this feature may cease to work at any time.
     """.stripMargin, "0.9.0")
-  def keygen     (args: VDomModifier*): VNode = tag("keygen")(args)
+  def keygen     (args: VDomModifier*): IO[VTree] = tag("keygen")(args)
 
   /** The caption of a single field
     *
     * MDN
     */
-  def label      (args: VDomModifier*): VNode = tag("label")(args)
+  def label      (args: VDomModifier*): IO[VTree] = tag("label")(args)
 
   /** The caption for a fieldset.
     *
     * MDN
     */
-  def legend     (args: VDomModifier*): VNode = tag("legend")(args)
+  def legend     (args: VDomModifier*): IO[VTree] = tag("legend")(args)
 
   /** Defines an item of an list.
     *
     * MDN
     */
-  def li         (args: VDomModifier*): VNode = tag("li")(args)
+  def li         (args: VDomModifier*): IO[VTree] = tag("li")(args)
 
   /** Used to link JavaScript and external CSS with the current HTML document.
     *
     * MDN
     */
-  def link       (args: VDomModifier*): VNode = tag("link")(args)
+  def link       (args: VDomModifier*): IO[VTree] = tag("link")(args)
 
   /** Defines the main or important content in the document. There is only one
     * main element in the document.
     *
     * MDN
     */
-  def main       (args: VDomModifier*): VNode = tag("main")(args)
+  def main       (args: VDomModifier*): IO[VTree] = tag("main")(args)
 
   /** In conjunction with area, defines an image map.
     *
     * MDN
     */
-  def map        (args: VDomModifier*): VNode = tag("map")(args)
+  def map        (args: VDomModifier*): IO[VTree] = tag("map")(args)
 
   /** Represents text highlighted for reference purposes, that is for its
     * relevance in another context.
     *
     * MDN
     */
-  def mark       (args: VDomModifier*): VNode = tag("mark")(args)
+  def mark       (args: VDomModifier*): IO[VTree] = tag("mark")(args)
 
   /** Defines a mathematical formula.
     *
     * MDN
     */
-  def math       (args: VDomModifier*): VNode = tag("math")(args)
+  def math       (args: VDomModifier*): IO[VTree] = tag("math")(args)
 
   /** Represents a group of commands that a user can perform or activate.
     * This includes both list menus, which might appear across the top of
@@ -428,7 +428,7 @@ trait Tags {
     *
     * MDN
     */
-  def menu       (args: VDomModifier*): VNode = tag("menu")(args)
+  def menu       (args: VDomModifier*): IO[VTree] = tag("menu")(args)
 
   /** Represents a command that a user is able to invoke through a popup menu.
     * This includes context menus, as well as menus that might be attached to
@@ -444,96 +444,96 @@ trait Tags {
     *
     * MDN
     */
-  def menuitem   (args: VDomModifier*): VNode = tag("menuitem")(args)
+  def menuitem   (args: VDomModifier*): IO[VTree] = tag("menuitem")(args)
 
   /** Defines metadata that can't be defined using another HTML element.
     *
     * MDN
     */
-  def meta       (args: VDomModifier*): VNode = tag("meta")(args)
+  def meta       (args: VDomModifier*): IO[VTree] = tag("meta")(args)
 
   /** A scalar measurement within a known range.
     *
     * MDN
     */
-  def meter      (args: VDomModifier*): VNode = tag("meter")(args)
+  def meter      (args: VDomModifier*): IO[VTree] = tag("meter")(args)
 
   /** Represents a section of a page that links to other pages or to parts within
     * the page: a section with navigation links.
     *
     * MDN
     */
-  def nav        (args: VDomModifier*): VNode = tag("nav")(args)
+  def nav        (args: VDomModifier*): IO[VTree] = tag("nav")(args)
 
   /** Defines alternative content to display when the browser doesn't support
     * scripting.
     *
     * MDN
     */
-  def noscript   (args: VDomModifier*): VNode = tag("noscript")(args)
+  def noscript   (args: VDomModifier*): IO[VTree] = tag("noscript")(args)
 
   /** Represents an external resource, which is treated as an image, an HTML
     * sub-document, or an external resource to be processed by a plug-in.
     *
     * MDN
     */
-  def `object`   (args: VDomModifier*): VNode = tag("object")(args)
+  def `object`   (args: VDomModifier*): IO[VTree] = tag("object")(args)
 
   /** Defines an ordered list of items.
     *
     * MDN
     */
-  def ol         (args: VDomModifier*): VNode = tag("ol")(args)
+  def ol         (args: VDomModifier*): IO[VTree] = tag("ol")(args)
 
   /** A set of options, logically grouped.
     *
     * MDN
     */
-  def optgroup   (args: VDomModifier*): VNode = tag("optgroup")(args)
+  def optgroup   (args: VDomModifier*): IO[VTree] = tag("optgroup")(args)
 
   /**
     * An option in a select element.
     *
     *  MDN
     */
-  def option     (args: VDomModifier*): VNode = tag("option")(args)
+  def option     (args: VDomModifier*): IO[VTree] = tag("option")(args)
 
   /** The result of a calculation
     *
     * MDN
     */
-  def output     (args: VDomModifier*): VNode = tag("output")(args)
+  def output     (args: VDomModifier*): IO[VTree] = tag("output")(args)
 
   /** Defines a portion that should be displayed as a paragraph.
     *
     * MDN
     */
-  def p          (args: VDomModifier*): VNode = tag("p")(args)
+  def p          (args: VDomModifier*): IO[VTree] = tag("p")(args)
 
   /** Defines parameters for use by plug-ins invoked by object elements.
     *
     * MDN
     */
-  def param      (args: VDomModifier*): VNode = tag("param")(args)
+  def param      (args: VDomModifier*): IO[VTree] = tag("param")(args)
 
   /** Indicates that its content is preformatted and that this format must be
     * preserved.
     *
     * MDN
     */
-  def pre        (args: VDomModifier*): VNode = tag("pre")(args)
+  def pre        (args: VDomModifier*): IO[VTree] = tag("pre")(args)
 
   /** A progress completion bar
     *
     * MDN
     */
-  def progress   (args: VDomModifier*): VNode = tag("progress")(args)
+  def progress   (args: VDomModifier*): IO[VTree] = tag("progress")(args)
 
   /** An inline quotation.
     *
     * MDN
     */
-  def q          (args: VDomModifier*): VNode = tag("q")(args)
+  def q          (args: VDomModifier*): IO[VTree] = tag("q")(args)
 
   /** Represents parenthesis around a ruby annotation, used to display the
     * annotation in an alternate way by browsers not supporting the standard
@@ -541,7 +541,7 @@ trait Tags {
     *
     * MDN
     */
-  def rp         (args: VDomModifier*): VNode = tag("rp")(args)
+  def rp         (args: VDomModifier*): IO[VTree] = tag("rp")(args)
 
   /** Represents content to be marked with ruby annotations, short runs of text
     * presented alongside the text. This is often used in conjunction with East
@@ -550,66 +550,66 @@ trait Tags {
     *
     * MDN
     */
-  def ruby         (args: VDomModifier*): VNode = tag("ruby")(args)
+  def ruby         (args: VDomModifier*): IO[VTree] = tag("ruby")(args)
 
   /** Represents the text of a ruby annotation.
     *
     * MDN
     */
-  def rt         (args: VDomModifier*): VNode = tag("rt")(args)
+  def rt         (args: VDomModifier*): IO[VTree] = tag("rt")(args)
 
   /** Strikethrough element, used for that is no longer accurate or relevant.
     *
     * MDN
     */
-  def s          (args: VDomModifier*): VNode = tag("s")(args)
+  def s          (args: VDomModifier*): IO[VTree] = tag("s")(args)
 
   /** Represents sample output of a program or a computer.
     *
     * MDN
     */
-  def samp       (args: VDomModifier*): VNode = tag("samp")(args)
+  def samp       (args: VDomModifier*): IO[VTree] = tag("samp")(args)
 
   /** Defines either an internal script or a link to an external script. The
     * script language is JavaScript.
     *
     * MDN
     */
-  def script     (args: VDomModifier*): VNode = tag("script")(args)
+  def script     (args: VDomModifier*): IO[VTree] = tag("script")(args)
 
   /** Represents a generic section of a document, i.e., a thematic grouping of
     * content, typically with a heading.
     *
     * MDN
     */
-  def section    (args: VDomModifier*): VNode = tag("section")(args)
+  def section    (args: VDomModifier*): IO[VTree] = tag("section")(args)
 
   /** A control that allows the user to select one of a set of options.
     *
     * MDN
     */
-  def select     (args: VDomModifier*): VNode = tag("select")(args)
+  def select     (args: VDomModifier*): IO[VTree] = tag("select")(args)
 
   /** Represents a placeholder inside a web component that you can fill with
     * your own markup, with the effect of composing different DOM trees together.
     *
     * MDN
     */
-  def slot       (args: VDomModifier*): VNode = tag("slot")(args)
+  def slot       (args: VDomModifier*): IO[VTree] = tag("slot")(args)
 
   /** Represents a side comment; text like a disclaimer or copyright, which is not
     * essential to the comprehension of the document.
     *
     * MDN
     */
-  def small      (args: VDomModifier*): VNode = tag("small")(args)
+  def small      (args: VDomModifier*): IO[VTree] = tag("small")(args)
 
   /** Allows the authors to specify alternate media resources for media elements
     * like video or audio
     *
     * MDN
     */
-  def source     (args: VDomModifier*): VNode = tag("source")(args)
+  def source     (args: VDomModifier*): IO[VTree] = tag("source")(args)
 
   /** Represents text with no specific meaning. This has to be used when no other
     * text-semantic element conveys an adequate meaning, which, in this case, is
@@ -617,86 +617,86 @@ trait Tags {
     *
     * MDN
     */
-  def span       (args: VDomModifier*): VNode = tag("span")(args)
+  def span       (args: VDomModifier*): IO[VTree] = tag("span")(args)
 
   /** Represents especially important text.
     *
     * MDN
     */
-  def strong     (args: VDomModifier*): VNode = tag("strong")(args)
+  def strong     (args: VDomModifier*): IO[VTree] = tag("strong")(args)
 
   /** Used to write inline CSS.
     *
     * MDN
     */
-  def style      (args: VDomModifier*): VNode = tag("style")(args)
+  def style      (args: VDomModifier*): IO[VTree] = tag("style")(args)
 
   /** Subscript tag
     *
     * MDN
     */
-  def sub        (args: VDomModifier*): VNode = tag("sub")(args)
+  def sub        (args: VDomModifier*): IO[VTree] = tag("sub")(args)
 
   /** A summary, caption, or legend for a given details.
     *
     * MDN
     */
-  def summary    (args: VDomModifier*): VNode = tag("summary")(args)
+  def summary    (args: VDomModifier*): IO[VTree] = tag("summary")(args)
 
   /** Superscript tag.
     *
     * MDN
     */
-  def sup        (args: VDomModifier*): VNode = tag("sup")(args)
+  def sup        (args: VDomModifier*): IO[VTree] = tag("sup")(args)
 
   /** Represents data with more than one dimension.
     *
     * MDN
     */
-  def table      (args: VDomModifier*): VNode = tag("table")(args)
+  def table      (args: VDomModifier*): IO[VTree] = tag("table")(args)
 
   /** The table body.
     *
     * MDN
     */
-  def tbody      (args: VDomModifier*): VNode = tag("tbody")(args)
+  def tbody      (args: VDomModifier*): IO[VTree] = tag("tbody")(args)
 
   /** A single cell in a table.
     *
     * MDN
     */
-  def td         (args: VDomModifier*): VNode = tag("td")(args)
+  def td         (args: VDomModifier*): IO[VTree] = tag("td")(args)
 
   /** A multiline text edit control.
     *
     * MDN
     */
-  def textarea   (args: VDomModifier*): VNode = tag("textarea")(args)
+  def textarea   (args: VDomModifier*): IO[VTree] = tag("textarea")(args)
 
   /** The table footer.
     *
     * MDN
     */
-  def tfoot      (args: VDomModifier*): VNode = tag("tfoot")(args)
+  def tfoot      (args: VDomModifier*): IO[VTree] = tag("tfoot")(args)
 
   /** A header cell in a table.
     *
     * MDN
     */
-  def th         (args: VDomModifier*): VNode = tag("th")(args)
+  def th         (args: VDomModifier*): IO[VTree] = tag("th")(args)
 
   /** The table headers.
     *
     * MDN
     */
-  def thead      (args: VDomModifier*): VNode = tag("thead")(args)
+  def thead      (args: VDomModifier*): IO[VTree] = tag("thead")(args)
 
   /** Represents a date and time value; the machine-readable equivalent can be
     * represented in the datetime attribetu
     *
     * MDN
     */
-  def time       (args: VDomModifier*): VNode = tag("time")(args)
+  def time       (args: VDomModifier*): IO[VTree] = tag("time")(args)
 
   /** Defines the title of the document, shown in a browser's title bar or on the
     * page's tab. It can only contain text and any contained tags are not
@@ -704,46 +704,46 @@ trait Tags {
     *
     * MDN
     */
-  def title      (args: VDomModifier*): VNode = tag("title")(args)
+  def title      (args: VDomModifier*): IO[VTree] = tag("title")(args)
 
   /** A single row in a table.
     *
     * MDN
     */
-  def tr         (args: VDomModifier*): VNode = tag("tr")(args)
+  def tr         (args: VDomModifier*): IO[VTree] = tag("tr")(args)
 
   /** Allows authors to specify timed text track for media elements like video or
     * audio
     *
     * MDN
     */
-  def track      (args: VDomModifier*): VNode = tag("track")(args)
+  def track      (args: VDomModifier*): IO[VTree] = tag("track")(args)
 
   /** Underlined text.
     *
     * MDN
     */
-  def u          (args: VDomModifier*): VNode = tag("u")(args)
+  def u          (args: VDomModifier*): IO[VTree] = tag("u")(args)
 
   /** Defines an unordered list of items.
     *
     * MDN
     */
-  def ul         (args: VDomModifier*): VNode = tag("ul")(args)
+  def ul         (args: VDomModifier*): IO[VTree] = tag("ul")(args)
 
   /** Represents a video, and its associated audio files and captions, with the
     * necessary interface to play it.
     *
     * MDN
     */
-  def video      (args: VDomModifier*): VNode = tag("video")(args)
+  def video      (args: VDomModifier*): IO[VTree] = tag("video")(args)
 
   /** Represents a line break opportunity, that is a suggested point for wrapping
     * text in order to improve readability of text split on several lines.
     *
     * MDN
     */
-  def wbr        (args: VDomModifier*): VNode = tag("wbr")(args)
+  def wbr        (args: VDomModifier*): IO[VTree] = tag("wbr")(args)
 }
 
 object Tags extends Tags

--- a/src/main/scala/outwatch/dom/Tags.scala
+++ b/src/main/scala/outwatch/dom/Tags.scala
@@ -13,7 +13,6 @@
 package outwatch.dom
 
 import cats.effect.IO
-import outwatch.dom.VDomModifier.VTree
 
 
 /** Trait that contains all tags, so they can be mixed in to other objects if needed.

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -54,33 +54,32 @@ sealed trait VNode_ extends VDomModifier_ {
   def asProxy: VNodeProxy
 }
 
-object VDomModifier {
-  //TODO: extends AnyVal
-  case class StringNode(string: String) extends VNode_ {
-    val asProxy: VNodeProxy = VNodeProxy.fromString(string)
-  }
-
-  // TODO: instead of Seq[VDomModifier] use Vector or JSArray?
-  // Fast concatenation and lastOption operations are important
-  // Needs to be benchmarked in the Browser
-  final case class VTree(nodeType: String,
-                         modifiers: Seq[VDomModifier]) extends VNode_ {
-
-    def asProxy = {
-      val modifiers_ = modifiers.map(_.unsafeRunSync())
-      val (children, attributeObject) = DomUtils.extractChildrenAndDataObject(modifiers_)
-      //TODO: use .sequence instead of unsafeRunSync?
-      // import cats.instances.list._
-      // import cats.syntax.traverse._
-      // for { childProxies <- children.map(_.value).sequence }
-      // yield h(nodeType, attributeObject, childProxies.map(_.apsProxy)(breakOut))
-      val childProxies: js.Array[VNodeProxy] = children.map(_.asProxy)(breakOut)
-      h(nodeType, attributeObject, childProxies)
-    }
-
-    override def apply(args: VDomModifier*) = IO.pure(VTree(nodeType, modifiers ++ args))
-  }
+//TODO: extends AnyVal
+private[outwatch] case class StringNode(string: String) extends VNode_ {
+  val asProxy: VNodeProxy = VNodeProxy.fromString(string)
 }
+
+// TODO: instead of Seq[VDomModifier] use Vector or JSArray?
+// Fast concatenation and lastOption operations are important
+// Needs to be benchmarked in the Browser
+private[outwatch] final case class VTree(nodeType: String,
+                       modifiers: Seq[VDomModifier]) extends VNode_ {
+
+  def asProxy = {
+    val modifiers_ = modifiers.map(_.unsafeRunSync())
+    val (children, attributeObject) = DomUtils.extractChildrenAndDataObject(modifiers_)
+    //TODO: use .sequence instead of unsafeRunSync?
+    // import cats.instances.list._
+    // import cats.syntax.traverse._
+    // for { childProxies <- children.map(_.value).sequence }
+    // yield h(nodeType, attributeObject, childProxies.map(_.apsProxy)(breakOut))
+    val childProxies: js.Array[VNodeProxy] = children.map(_.asProxy)(breakOut)
+    h(nodeType, attributeObject, childProxies)
+  }
+
+  override def apply(args: VDomModifier*) = IO.pure(VTree(nodeType, modifiers ++ args))
+}
+
 
 
 

--- a/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -7,7 +7,7 @@ import outwatch.dom._
 import rxscalajs.Observable
 
 import scala.language.implicitConversions
-import outwatch.dom.VDomModifier.StringNode
+import outwatch.dom.StringNode
 
 trait ValueBuilder[T] extends Any {
   def :=(value: T): VDomModifier

--- a/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -4,6 +4,7 @@ import scala.language.dynamics
 import outwatch.dom._
 import rxscalajs.Observable
 import scala.language.implicitConversions
+import outwatch.dom.VDomModifier.StringNode
 
 trait ValueBuilder[T] extends Any {
   def :=(value: T): VDomModifier
@@ -16,7 +17,7 @@ object ChildStreamReceiverBuilder {
   }
 
   private val anyToVNode: Any => VNode = {
-    case vn: VNodeIO[_] => vn.asInstanceOf[VNode]
+    case vn: VNode => vn.asInstanceOf[VNode]
     case any => any.toString
   }
 }

--- a/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -34,7 +34,7 @@ object ChildrenStreamReceiverBuilder {
 
 final class AttributeBuilder[T](val attributeName: String) extends AnyVal with ValueBuilder[T] {
 
-  def assign(value: T) = Attribute(attributeName, value.toString)
+  private def assign(value: T) = Attribute(attributeName, value.toString)
 
   def :=(value: T) = IO.pure(assign(value))
 
@@ -44,7 +44,7 @@ final class AttributeBuilder[T](val attributeName: String) extends AnyVal with V
 }
 
 final class PropertyBuilder[T](val attributeName: String) extends AnyVal with ValueBuilder[T] {
-  def assign(value: T) = Prop(attributeName, value.toString)
+  private def assign(value: T) = Prop(attributeName, value.toString)
 
   def :=(value: T) = IO.pure(assign(value))
 
@@ -54,7 +54,7 @@ final class PropertyBuilder[T](val attributeName: String) extends AnyVal with Va
 }
 
 final class StyleBuilder(val attributeName: String) extends AnyVal with ValueBuilder[String] {
-  def assign(value: String) = Style(attributeName, value)
+  private def assign(value: String) = Style(attributeName, value)
 
   def :=(value: String) = IO.pure(assign(value))
 
@@ -68,7 +68,7 @@ final class DynamicAttributeBuilder[T](parts: List[String]) extends Dynamic with
 
   def selectDynamic(s: String) = new DynamicAttributeBuilder[T](s :: parts)
 
-  def assign(value: T) = Attribute(name, value.toString)
+  private def assign(value: T) = Attribute(name, value.toString)
 
   def :=(value: T) = IO.pure(assign(value))
 
@@ -79,7 +79,7 @@ final class DynamicAttributeBuilder[T](parts: List[String]) extends Dynamic with
 
 final class BoolAttributeBuilder(val attributeName: String) extends AnyVal with ValueBuilder[Boolean] {
 
-  def assign(value: Boolean) = Attribute(attributeName, value)
+  private def assign(value: Boolean) = Attribute(attributeName, value)
 
   def :=(value: Boolean) = IO.pure(assign(value))
 

--- a/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -34,7 +34,7 @@ object ChildrenStreamReceiverBuilder {
 
 final class AttributeBuilder[T](val attributeName: String) extends AnyVal with ValueBuilder[T] {
 
-  private def assign(value: T) = Attribute(attributeName, value.toString)
+  @inline private def assign(value: T) = Attribute(attributeName, value.toString)
 
   def :=(value: T) = IO.pure(assign(value))
 
@@ -44,7 +44,8 @@ final class AttributeBuilder[T](val attributeName: String) extends AnyVal with V
 }
 
 final class PropertyBuilder[T](val attributeName: String) extends AnyVal with ValueBuilder[T] {
-  private def assign(value: T) = Prop(attributeName, value.toString)
+
+  @inline private def assign(value: T) = Prop(attributeName, value.toString)
 
   def :=(value: T) = IO.pure(assign(value))
 
@@ -54,7 +55,8 @@ final class PropertyBuilder[T](val attributeName: String) extends AnyVal with Va
 }
 
 final class StyleBuilder(val attributeName: String) extends AnyVal with ValueBuilder[String] {
-  private def assign(value: String) = Style(attributeName, value)
+
+  @inline private def assign(value: String) = Style(attributeName, value)
 
   def :=(value: String) = IO.pure(assign(value))
 
@@ -68,7 +70,7 @@ final class DynamicAttributeBuilder[T](parts: List[String]) extends Dynamic with
 
   def selectDynamic(s: String) = new DynamicAttributeBuilder[T](s :: parts)
 
-  private def assign(value: T) = Attribute(name, value.toString)
+  @inline private def assign(value: T) = Attribute(name, value.toString)
 
   def :=(value: T) = IO.pure(assign(value))
 
@@ -79,7 +81,7 @@ final class DynamicAttributeBuilder[T](parts: List[String]) extends Dynamic with
 
 final class BoolAttributeBuilder(val attributeName: String) extends AnyVal with ValueBuilder[Boolean] {
 
-  private def assign(value: Boolean) = Attribute(attributeName, value)
+  @inline private def assign(value: Boolean) = Attribute(attributeName, value)
 
   def :=(value: Boolean) = IO.pure(assign(value))
 

--- a/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -117,7 +117,7 @@ object DomUtils {
     def toProxy(changable: (Seq[Attribute], Seq[VNode])): VNodeProxy = changable match {
       case (attributes, nodes) =>
         val updatedObj = proxy.data.withUpdatedAttributes(attributes)
-        h(proxy.sel, updatedObj, proxy.children ++ (nodes.map(_.asProxy)(breakOut):js.Array[VNodeProxy]))
+        h(proxy.sel, updatedObj, proxy.children ++ (nodes.map(_.unsafeRunSync().asProxy)(breakOut):js.Array[VNodeProxy]))
     }
 
     val subscription = changables.observable
@@ -142,17 +142,17 @@ object DomUtils {
     emitters: List[Emitter] = Nil,
     receivers: List[Receiver] = Nil,
     properties: List[Property] = Nil,
-    vNodes: List[VNode] = Nil
+    vNodes: List[VNode_] = Nil
   )
-  private[outwatch] def separateModifiers(args: Seq[VDomModifier]): SeparatedModifiers = {
+  private[outwatch] def separateModifiers(args: Seq[VDomModifier_]): SeparatedModifiers = {
     args.foldRight(SeparatedModifiers())(separatorFn)
   }
 
-  private[outwatch] def separatorFn(mod: VDomModifier, res: SeparatedModifiers): SeparatedModifiers = (mod, res) match {
+  private[outwatch] def separatorFn(mod: VDomModifier_, res: SeparatedModifiers): SeparatedModifiers = (mod, res) match {
     case (em: Emitter, sf) => sf.copy(emitters = em :: sf.emitters)
     case (rc: Receiver, sf) => sf.copy(receivers = rc :: sf.receivers)
     case (pr: Property, sf) => sf.copy(properties = pr :: sf.properties)
-    case (vn: VNode, sf) => sf.copy(vNodes = vn :: sf.vNodes)
+    case (vn: VNode_, sf) => sf.copy(vNodes = vn :: sf.vNodes)
     case (EmptyVDomModifier, sf) => sf
   }
 
@@ -187,7 +187,7 @@ object DomUtils {
     }
   }
 
-  private[outwatch] def extractChildrenAndDataObject(args: Seq[VDomModifier]): (Seq[VNode], DataObject) = {
+  private[outwatch] def extractChildrenAndDataObject(args: Seq[VDomModifier_]): (Seq[VNode_], DataObject) = {
     val SeparatedModifiers(emitters, receivers, properties, children) = separateModifiers(args)
 
     val SeparatedReceivers(childReceivers, childrenReceivers, attributeReceivers) = separateReceivers(receivers)
@@ -201,9 +201,10 @@ object DomUtils {
     (children, dataObject)
   }
 
-  def render(element: Element, vNode: VNode): IO[Unit] = IO {
-    val elem = document.createElement("app")
-    element.appendChild(elem)
-    patch(elem, vNode.asProxy)
-  }
+  def render(element: Element, vNode: VNode): IO[Unit] = for {
+    node <- vNode
+    elem <- IO(document.createElement("app"))
+    _ <- IO(element.appendChild(elem))
+    _ <- IO(patch(elem, node.asProxy))
+  } yield ()
 }

--- a/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -117,7 +117,7 @@ object DomUtils {
     def toProxy(changable: (Seq[Attribute], Seq[VNode])): VNodeProxy = changable match {
       case (attributes, nodes) =>
         val updatedObj = proxy.data.withUpdatedAttributes(attributes)
-        h(proxy.sel, updatedObj, proxy.children ++ (nodes.map(_.value.unsafeRunSync().asProxy)(breakOut):js.Array[VNodeProxy]))
+        h(proxy.sel, updatedObj, proxy.children ++ (nodes.map(_.asProxy)(breakOut):js.Array[VNodeProxy]))
     }
 
     val subscription = changables.observable
@@ -152,7 +152,7 @@ object DomUtils {
     case (em: Emitter, sf) => sf.copy(emitters = em :: sf.emitters)
     case (rc: Receiver, sf) => sf.copy(receivers = rc :: sf.receivers)
     case (pr: Property, sf) => sf.copy(properties = pr :: sf.properties)
-    case (vn: VNodeIO[_], sf) => sf.copy(vNodes = vn.asInstanceOf[VNode] :: sf.vNodes)
+    case (vn: VNode, sf) => sf.copy(vNodes = vn :: sf.vNodes)
     case (EmptyVDomModifier, sf) => sf
   }
 
@@ -201,12 +201,9 @@ object DomUtils {
     (children, dataObject)
   }
 
-  def render(element: Element, vNode: VNode): IO[Unit] = for {
-    node <- vNode.value
-    elem <- IO(document.createElement("app"))
-    _ <- IO(element.appendChild(elem))
-    _ <- IO(patch(elem, node.asProxy))
-  } yield ()
-
-
+  def render(element: Element, vNode: VNode): IO[Unit] = IO {
+    val elem = document.createElement("app")
+    element.appendChild(elem)
+    patch(elem, vNode.asProxy)
+  }
 }

--- a/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
+++ b/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
@@ -1,13 +1,14 @@
 package outwatch.dom.helpers
 
+import cats.effect.IO
 import org.scalajs.dom._
 import outwatch.Sink
 import outwatch.dom.{BoolEventEmitter, NumberEventEmitter, StringEventEmitter, _}
 import rxscalajs.{Observable, Observer}
 
 final case class GenericMappedEmitterBuilder[T,E](constructor: Observer[E] => Emitter, mapping: E => T){
-  def -->[U >: T](sink: Sink[U]): Emitter = {
-    constructor(sink.redirectMap(mapping).observer)
+  def -->[U >: T](sink: Sink[U]): IO[Emitter] = {
+    IO.pure(constructor(sink.redirectMap(mapping).observer))
   }
 }
 
@@ -16,15 +17,15 @@ final case class FilteredGenericMappedEmitterBuilder[T,E](
   mapping: E => T,
   predicate: E => Boolean
 ) {
-  def -->[U >: T](sink: Sink[U]): Emitter = {
-    constructor(sink.redirect[E](_.filter(predicate).map(mapping)).observer)
+  def -->[U >: T](sink: Sink[U]): IO[Emitter] = {
+    IO.pure(constructor(sink.redirect[E](_.filter(predicate).map(mapping)).observer))
   }
 }
 
 final case class WithLatestFromEmitterBuilder[T, E <: Event](eventType: String, stream: Observable[T]) {
-  def -->[U >: T](sink: Sink[U]): EventEmitter[E] = {
+  def -->[U >: T](sink: Sink[U]): IO[EventEmitter[E]] = {
     val proxy: Sink[E] = sink.redirect[E](_.withLatestFromWith(stream)((_,u) => u))
-    EventEmitter(eventType, proxy.observer)
+    IO.pure(EventEmitter(eventType, proxy.observer))
   }
 }
 
@@ -33,15 +34,15 @@ final case class FilteredWithLatestFromEmitterBuilder[T, E <: Event](
   stream: Observable[T],
   predicate: E => Boolean
 ) {
-  def -->[U >: T](sink: Sink[U]): EventEmitter[E] = {
+  def -->[U >: T](sink: Sink[U]): IO[EventEmitter[E]] = {
     val proxy: Sink[E] = sink.redirect(_.filter(predicate).withLatestFromWith(stream)((_, u) => u))
-    EventEmitter(eventType, proxy.observer)
+    IO.pure(EventEmitter(eventType, proxy.observer))
   }
 }
 
 final case class FilteredEmitterBuilder[E](eventType: String, predicate: E => Boolean) {
   def -->(sink: Sink[E]) =
-    EventEmitter(eventType, sink.redirect[E](_.filter(predicate)).observer)
+    IO.pure(EventEmitter(eventType, sink.redirect[E](_.filter(predicate)).observer))
 
   def apply[T](t: T) =
     FilteredGenericMappedEmitterBuilder(EventEmitter(eventType, _:Observer[E]), (_: E) => t, predicate)
@@ -54,7 +55,7 @@ final case class FilteredEmitterBuilder[E](eventType: String, predicate: E => Bo
 
 final class EventEmitterBuilder[E <: Event](val eventType: String) extends AnyVal {
   def -->(sink: Sink[E]) =
-    EventEmitter(eventType, sink.observer)
+    IO.pure(EventEmitter(eventType, sink.observer))
 
   def apply[T](t: T) =
     GenericMappedEmitterBuilder(EventEmitter(eventType, _:Observer[E]), (_: E) => t)
@@ -69,7 +70,7 @@ final class EventEmitterBuilder[E <: Event](val eventType: String) extends AnyVa
 
 final class StringEventEmitterBuilder(val eventType: String) extends AnyVal {
   def -->(sink: Sink[String]) =
-    StringEventEmitter(eventType, sink.observer)
+    IO.pure(StringEventEmitter(eventType, sink.observer))
 
   def apply[T](f: String => T) =
     GenericMappedEmitterBuilder(StringEventEmitter(eventType, _: Observer[String]), f)
@@ -77,7 +78,7 @@ final class StringEventEmitterBuilder(val eventType: String) extends AnyVal {
 
 final class BoolEventEmitterBuilder(val eventType: String) extends AnyVal {
   def -->(sink: Sink[Boolean]) =
-    BoolEventEmitter(eventType, sink.observer)
+    IO.pure(BoolEventEmitter(eventType, sink.observer))
 
   def apply[T](f: Boolean => T) =
     GenericMappedEmitterBuilder(BoolEventEmitter(eventType, _: Observer[Boolean]), f)
@@ -85,20 +86,20 @@ final class BoolEventEmitterBuilder(val eventType: String) extends AnyVal {
 
 final class NumberEventEmitterBuilder(val eventType: String) extends AnyVal {
   def -->(sink: Sink[Double]) =
-    NumberEventEmitter(eventType, sink.observer)
+    IO.pure(NumberEventEmitter(eventType, sink.observer))
 
   def apply[T](f: Double => T) =
     GenericMappedEmitterBuilder(NumberEventEmitter(eventType, _: Observer[Double]), f)
 }
 
 object InsertHookBuilder {
-  def -->(sink: Sink[Element]) = InsertHook(sink.observer)
+  def -->(sink: Sink[Element]) = IO.pure(InsertHook(sink.observer))
 }
 
 object DestroyHookBuilder {
-  def -->(sink: Sink[Element]) = DestroyHook(sink.observer)
+  def -->(sink: Sink[Element]) = IO.pure(DestroyHook(sink.observer))
 }
 
 object UpdateHookBuilder {
-  def -->(sink: Sink[(Element, Element)]) = UpdateHook(sink.observer)
+  def -->(sink: Sink[(Element, Element)]) = IO.pure(UpdateHook(sink.observer))
 }

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -2,6 +2,4 @@ package outwatch
 
 
 
-package object dom extends Attributes with Tags with Handlers {
-  type VNode = VNodeIO[VDom]
-}
+package object dom extends Attributes with Tags with Handlers 

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -20,5 +20,5 @@ package object dom extends Attributes with Tags with Handlers {
     }
   }
 
-
+  def stl(property:String) = new helpers.StyleBuilder(property)
 }

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -15,7 +15,7 @@ package object dom extends Attributes with Tags with Handlers {
 
   implicit def optionIsEmptyModifier(opt: Option[VDomModifier]): VDomModifier = opt getOrElse IO.pure(EmptyVDomModifier)
 
-  implicit class ioVtree(tree: IO[VTree]) {
+  implicit class ioVTreeMerge(tree: IO[VTree]) {
     def apply(args: VDomModifier*): IO[VTree] = {
       tree.flatMap(vtree => IO.pure(VTree(vtree.nodeType, vtree.modifiers ++ args)))
     }

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -1,7 +1,6 @@
 package outwatch
 
 import cats.effect.IO
-import outwatch.dom.VDomModifier.{StringNode, VTree}
 
 import scala.language.implicitConversions
 
@@ -20,4 +19,6 @@ package object dom extends Attributes with Tags with Handlers {
       tree.flatMap(vtree => IO.pure(VTree(vtree.nodeType, vtree.modifiers ++ args)))
     }
   }
+
+
 }

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -1,5 +1,23 @@
 package outwatch
 
+import cats.effect.IO
+import outwatch.dom.VDomModifier.{StringNode, VTree}
+
+import scala.language.implicitConversions
 
 
-package object dom extends Attributes with Tags with Handlers 
+package object dom extends Attributes with Tags with Handlers {
+
+  type VNode = IO[VNode_]
+  type VDomModifier = IO[VDomModifier_]
+
+  implicit def stringNode(string: String): VDomModifier = IO.pure(StringNode(string))
+
+  implicit def optionIsEmptyModifier(opt: Option[VDomModifier]): VDomModifier = opt getOrElse IO.pure(EmptyVDomModifier)
+
+  implicit class ioVtree(tree: IO[VTree]) {
+    def apply(args: VDomModifier*): IO[VTree] = {
+      tree.flatMap(vtree => IO.pure(VTree(vtree.nodeType, vtree.modifiers ++ args)))
+    }
+  }
+}

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -14,9 +14,9 @@ package object dom extends Attributes with Tags with Handlers {
 
   implicit def optionIsEmptyModifier(opt: Option[VDomModifier]): VDomModifier = opt getOrElse IO.pure(EmptyVDomModifier)
 
-  implicit class ioVTreeMerge(tree: IO[VTree]) {
-    def apply(args: VDomModifier*): IO[VTree] = {
-      tree.flatMap(vtree => IO.pure(VTree(vtree.nodeType, vtree.modifiers ++ args)))
+  implicit class ioVTreeMerge(vnode: VNode) {
+    def apply(args: VDomModifier*): VNode = {
+      vnode.flatMap(vnode_ => vnode_(args:_*))
     }
   }
 

--- a/src/main/scala/outwatch/http/Http.scala
+++ b/src/main/scala/outwatch/http/Http.scala
@@ -1,7 +1,6 @@
 package outwatch.http
 
 import cats.effect.IO
-import outwatch.dom.VDomHttp
 import rxscalajs.Observable
 import rxscalajs.dom.{Request, Response}
 
@@ -26,25 +25,25 @@ object Http {
         .subscribe(response => cb(Right(response)), err => cb(Left(new Exception(err.toString))))
     }
 
-  private def request(observable: Observable[Request], requestType: HttpRequestType): VDomHttp =
-    VDomHttp(IO(observable.switchMap(data => Observable.ajax(data.copy(method = requestType.toString))).share))
+  private def request(observable: Observable[Request], requestType: HttpRequestType) =
+    observable.switchMap(data => Observable.ajax(data.copy(method = requestType.toString))).share
 
-  private def requestWithUrl(urls: Observable[String], requestType: HttpRequestType): VDomHttp =
+  private def requestWithUrl(urls: Observable[String], requestType: HttpRequestType) =
     request(urls.map(url => Request(url)), requestType: HttpRequestType)
 
-  def getWithUrl(urls: Observable[String]): VDomHttp = requestWithUrl(urls, Get)
+  def getWithUrl(urls: Observable[String]) = requestWithUrl(urls, Get)
 
-  def get(requests: Observable[Request]): VDomHttp = request(requests, Get)
+  def get(requests: Observable[Request]) = request(requests, Get)
 
-  def post(requests: Observable[Request]): VDomHttp = request(requests, Post)
+  def post(requests: Observable[Request]) = request(requests, Post)
 
-  def delete(requests: Observable[Request]): VDomHttp = request(requests, Delete)
+  def delete(requests: Observable[Request]) = request(requests, Delete)
 
-  def put(requests: Observable[Request]): VDomHttp = request(requests, Put)
+  def put(requests: Observable[Request]) = request(requests, Put)
 
-  def options(requests: Observable[Request]): VDomHttp = request(requests, Options)
+  def options(requests: Observable[Request]) = request(requests, Options)
 
-  def head(requests: Observable[Request]): VDomHttp = request(requests, Head)
+  def head(requests: Observable[Request]) = request(requests, Head)
 
 
 }

--- a/src/main/scala/outwatch/util/Store.scala
+++ b/src/main/scala/outwatch/util/Store.scala
@@ -41,15 +41,14 @@ object Store {
   private val storeRef = STRef.empty
 
   def renderWithStore[S, A](initialState: S, reducer: (S, A) => (S, Option[IO[A]]), selector: String, root: VNode): IO[Unit] = for {
-    handler <- createHandler[A]().value
+    handler <- createHandler[A]()
     store <- IO(Store(initialState, reducer, handler))
     _ <- storeRef.asInstanceOf[STRef[Store[S, A]]].put(store)
     _ <- OutWatch.render(selector, root)
   } yield ()
 
-  def getStore[S, A]: VNodeIO[Store[S, A]] = Pure(
+  def getStore[S, A]: IO[Store[S, A]] = 
     storeRef.asInstanceOf[STRef[Store[S, A]]].getOrThrow(NoStoreException)
-  )
 
   private object NoStoreException extends
     Exception("Application was rendered without specifying a Store, please use Outwatch.renderWithStore instead")

--- a/src/main/scala/outwatch/util/SyntaxSugar.scala
+++ b/src/main/scala/outwatch/util/SyntaxSugar.scala
@@ -12,10 +12,11 @@ object SyntaxSugar {
 
   implicit class BooleanSelector(val values: Observable[Boolean]) extends AnyVal {
     def ?=(attr: IO[Attribute]): IO[AttributeStreamReceiver] = {
-      val attr_ = attr.unsafeRunSync()
-      val attributes =
-        values.map(b => if (b) attr_ else emptyAttribute)
-      IO.pure(AttributeStreamReceiver(attr_.title, attributes))
+      attr.map { attr =>
+        val attributes = values.map(b => if (b) attr else emptyAttribute)
+        AttributeStreamReceiver(attr.title, attributes)
+      }
     }
   }
+
 }

--- a/src/main/scala/outwatch/util/SyntaxSugar.scala
+++ b/src/main/scala/outwatch/util/SyntaxSugar.scala
@@ -1,5 +1,6 @@
 package outwatch.util
 
+import cats.effect.IO
 import outwatch.dom.{Attribute, AttributeStreamReceiver}
 import rxscalajs.Observable
 
@@ -10,10 +11,11 @@ object SyntaxSugar {
   private val emptyAttribute = Attribute("hidden", "")
 
   implicit class BooleanSelector(val values: Observable[Boolean]) extends AnyVal {
-    def ?=(attr: Attribute): AttributeStreamReceiver = {
+    def ?=(attr: IO[Attribute]): IO[AttributeStreamReceiver] = {
+      val attr_ = attr.unsafeRunSync()
       val attributes =
-        values.map(b => if (b) attr else emptyAttribute)
-      AttributeStreamReceiver(attr.title, attributes)
+        values.map(b => if (b) attr_ else emptyAttribute)
+      IO.pure(AttributeStreamReceiver(attr_.title, attributes))
     }
   }
 }

--- a/src/test/scala/outwatch/AttributeSpec.scala
+++ b/src/test/scala/outwatch/AttributeSpec.scala
@@ -1,6 +1,5 @@
 package outwatch
 
-import cats.effect.IO
 import outwatch.dom._
 
 class AttributeSpec extends UnitSpec {
@@ -43,15 +42,13 @@ class AttributeSpec extends UnitSpec {
     )
   }
 
-  def style_(title: String, value: String): IO[Style] = IO.pure(Style(title: String, value: String))
-
   it should "correctly merge styles" in {
     val node = input(
-      style_("color", "red"),
-      style_("font-size", "5px")
+      stl("color") := "red",
+      stl("font-size") := "5px"
     )(
-      style_("color", "blue"),
-      style_("border", "1px solid black")
+      stl("color") := "blue",
+      stl("border") := "1px solid black"
     ).map(_.asProxy).unsafeRunSync()
 
     node.data.style.toList should contain theSameElementsAs List(
@@ -73,7 +70,7 @@ class AttributeSpec extends UnitSpec {
   }
 
   "style attribute" should "render correctly" in {
-    val node = input(style_("color", "red")).map(_.asProxy).unsafeRunSync()
+    val node = input(stl("color") := "red").map(_.asProxy).unsafeRunSync()
 
     node.data.style.toList should contain theSameElementsAs List(
       "color" -> "red"

--- a/src/test/scala/outwatch/AttributeSpec.scala
+++ b/src/test/scala/outwatch/AttributeSpec.scala
@@ -5,7 +5,7 @@ import outwatch.dom._
 class AttributeSpec extends UnitSpec {
 
   "data attribute" should "correctly render only data" in {
-    val node = input(data := "bar").value.unsafeRunSync().asProxy
+    val node = input(data := "bar").asProxy
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data" -> "bar"
@@ -13,7 +13,7 @@ class AttributeSpec extends UnitSpec {
   }
 
   it should "correctly render expanded data with dynamic content" in {
-    val node = input(data.foo := "bar").value.unsafeRunSync().asProxy
+    val node = input(data.foo := "bar").asProxy
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data-foo" -> "bar"
@@ -24,7 +24,7 @@ class AttributeSpec extends UnitSpec {
     val node = input(
       data.foo :=? Option("bar"),
       data.bar :=? Option.empty[String]
-    ).value.unsafeRunSync().asProxy
+    ).asProxy
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data-foo" -> "bar"
@@ -33,7 +33,7 @@ class AttributeSpec extends UnitSpec {
 
   "apply on vtree" should "correctly merge attributes" in {
     val node = input(data := "bar",
-        data.gurke := "franz")(data := "buh", data.tomate := "gisela").value.unsafeRunSync().asProxy
+        data.gurke := "franz")(data := "buh", data.tomate := "gisela").asProxy
 
     node.data.attrs.toList should contain theSameElementsAs List(
         "data" -> "buh",
@@ -49,7 +49,7 @@ class AttributeSpec extends UnitSpec {
     )(
       Style("color", "blue"),
       Style("border", "1px solid black")
-    ).value.unsafeRunSync().asProxy
+    ).asProxy
 
     node.data.style.toList should contain theSameElementsAs List(
       ("color", "blue"),
@@ -59,18 +59,18 @@ class AttributeSpec extends UnitSpec {
   }
 
   it should "correctly merge keys" in {
-    val node = input( dom.key := "bumm")( dom.key := "klapp").value.unsafeRunSync().asProxy
+    val node = input( dom.key := "bumm")( dom.key := "klapp").asProxy
     node.data.key.toList should contain theSameElementsAs List("klapp")
 
-    val node2 = input()( dom.key := "klapp").value.unsafeRunSync().asProxy
+    val node2 = input()( dom.key := "klapp").asProxy
     node2.data.key.toList should contain theSameElementsAs List("klapp")
 
-    val node3 = input( dom.key := "bumm")().value.unsafeRunSync().asProxy
+    val node3 = input( dom.key := "bumm")().asProxy
     node3.data.key.toList should contain theSameElementsAs List("bumm")
   }
 
   "style attribute" should "render correctly" in {
-    val node = input(Style("color", "red")).value.unsafeRunSync().asProxy
+    val node = input(Style("color", "red")).asProxy
 
     node.data.style.toList should contain theSameElementsAs List(
       "color" -> "red"

--- a/src/test/scala/outwatch/AttributeSpec.scala
+++ b/src/test/scala/outwatch/AttributeSpec.scala
@@ -1,11 +1,12 @@
 package outwatch
 
+import cats.effect.IO
 import outwatch.dom._
 
 class AttributeSpec extends UnitSpec {
 
   "data attribute" should "correctly render only data" in {
-    val node = input(data := "bar").asProxy
+    val node = input(data := "bar").map(_.asProxy).unsafeRunSync()
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data" -> "bar"
@@ -13,7 +14,7 @@ class AttributeSpec extends UnitSpec {
   }
 
   it should "correctly render expanded data with dynamic content" in {
-    val node = input(data.foo := "bar").asProxy
+    val node = input(data.foo := "bar").map(_.asProxy).unsafeRunSync()
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data-foo" -> "bar"
@@ -24,7 +25,7 @@ class AttributeSpec extends UnitSpec {
     val node = input(
       data.foo :=? Option("bar"),
       data.bar :=? Option.empty[String]
-    ).asProxy
+    ).map(_.asProxy).unsafeRunSync()
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data-foo" -> "bar"
@@ -33,7 +34,7 @@ class AttributeSpec extends UnitSpec {
 
   "apply on vtree" should "correctly merge attributes" in {
     val node = input(data := "bar",
-        data.gurke := "franz")(data := "buh", data.tomate := "gisela").asProxy
+        data.gurke := "franz")(data := "buh", data.tomate := "gisela").map(_.asProxy).unsafeRunSync()
 
     node.data.attrs.toList should contain theSameElementsAs List(
         "data" -> "buh",
@@ -42,14 +43,16 @@ class AttributeSpec extends UnitSpec {
     )
   }
 
+  def style_(title: String, value: String): IO[Style] = IO.pure(Style(title: String, value: String))
+
   it should "correctly merge styles" in {
     val node = input(
-      Style("color", "red"),
-      Style("font-size", "5px")
+      style_("color", "red"),
+      style_("font-size", "5px")
     )(
-      Style("color", "blue"),
-      Style("border", "1px solid black")
-    ).asProxy
+      style_("color", "blue"),
+      style_("border", "1px solid black")
+    ).map(_.asProxy).unsafeRunSync()
 
     node.data.style.toList should contain theSameElementsAs List(
       ("color", "blue"),
@@ -59,18 +62,18 @@ class AttributeSpec extends UnitSpec {
   }
 
   it should "correctly merge keys" in {
-    val node = input( dom.key := "bumm")( dom.key := "klapp").asProxy
+    val node = input( dom.key := "bumm")( dom.key := "klapp").map(_.asProxy).unsafeRunSync()
     node.data.key.toList should contain theSameElementsAs List("klapp")
 
-    val node2 = input()( dom.key := "klapp").asProxy
+    val node2 = input()( dom.key := "klapp").map(_.asProxy).unsafeRunSync()
     node2.data.key.toList should contain theSameElementsAs List("klapp")
 
-    val node3 = input( dom.key := "bumm")().asProxy
+    val node3 = input( dom.key := "bumm")().map(_.asProxy).unsafeRunSync()
     node3.data.key.toList should contain theSameElementsAs List("bumm")
   }
 
   "style attribute" should "render correctly" in {
-    val node = input(Style("color", "red")).asProxy
+    val node = input(style_("color", "red")).map(_.asProxy).unsafeRunSync()
 
     node.data.style.toList should contain theSameElementsAs List(
       "color" -> "red"

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -22,15 +22,16 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   "EventStreams" should "emit and receive events correctly" in {
     import outwatch.dom._
 
-    val vtree = for {
-      observable <- createMouseHandler()
-      buttonDisabled = observable.mapTo(true).startWith(false)
-    } yield div(id :="click", click --> observable,
+    val vtree = createMouseHandler().flatMap { observable =>
+
+      val buttonDisabled = observable.mapTo(true).startWith(false)
+      
+      div(id := "click", click --> observable,
         button(id := "btn", disabled <-- buttonDisabled)
       )
+    }
 
-
-    vtree.flatMap(vtree => OutWatch.render("#app", vtree)).unsafeRunSync()
+    OutWatch.render("#app", vtree).unsafeRunSync()
     document.getElementById("btn").hasAttribute("disabled") shouldBe false
 
     val event = document.createEvent("Events")
@@ -45,14 +46,14 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
 
     val message = "ad"
 
-    val vtree = for {
-      observable <- createStringHandler()
-    } yield div(id := "click", click(message) --> observable,
+    val vtree = createStringHandler().flatMap { observable =>
+      div(id := "click", click(message) --> observable,
         span(id := "child", child <-- observable)
       )
+    }
 
 
-    vtree.flatMap(vtree => OutWatch.render("#app", vtree)).unsafeRunSync()
+    OutWatch.render("#app", vtree).unsafeRunSync()
 
     document.getElementById("child").innerHTML shouldBe ""
 
@@ -75,14 +76,13 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
 
     val messages = createStringHandler().unsafeRunSync()
 
-    val vtree = for {
-      stream <- createStringHandler()
-    } yield div(id :="click", click(messages) --> stream,
+    val vtree = createStringHandler().flatMap { stream =>
+      div(id := "click", click(messages) --> stream,
         span(id := "child", child <-- stream)
       )
+    }
 
-
-    vtree.flatMap(vtree => OutWatch.render("#app", vtree)).unsafeRunSync()
+    OutWatch.render("#app", vtree).unsafeRunSync()
 
     document.getElementById("child").innerHTML shouldBe ""
 

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -25,13 +25,12 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
     val vtree = for {
       observable <- createMouseHandler()
       buttonDisabled = observable.mapTo(true).startWith(false)
-      root <- div(id :="click", click --> observable,
+    } yield div(id :="click", click --> observable,
         button(id := "btn", disabled <-- buttonDisabled)
       )
-    } yield root
 
 
-    OutWatch.render("#app", vtree).unsafeRunSync()
+    vtree.flatMap(vtree => OutWatch.render("#app", vtree)).unsafeRunSync()
     document.getElementById("btn").hasAttribute("disabled") shouldBe false
 
     val event = document.createEvent("Events")
@@ -48,14 +47,12 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
 
     val vtree = for {
       observable <- createStringHandler()
-
-      root <- div(id := "click", click(message) --> observable,
-       span(id := "child", child <-- observable)
+    } yield div(id := "click", click(message) --> observable,
+        span(id := "child", child <-- observable)
       )
-    } yield root
 
 
-    OutWatch.render("#app", vtree).unsafeRunSync()
+    vtree.flatMap(vtree => OutWatch.render("#app", vtree)).unsafeRunSync()
 
     document.getElementById("child").innerHTML shouldBe ""
 
@@ -76,18 +73,16 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   it should "be converted to a generic stream emitter correctly" in {
     import outwatch.dom._
 
-    val messages = createStringHandler().value.unsafeRunSync()
+    val messages = createStringHandler().unsafeRunSync()
 
     val vtree = for {
       stream <- createStringHandler()
-
-      root <- div(id :="click", click(messages) --> stream,
+    } yield div(id :="click", click(messages) --> stream,
         span(id := "child", child <-- stream)
       )
-    } yield root
 
 
-    OutWatch.render("#app", vtree).unsafeRunSync()
+    vtree.flatMap(vtree => OutWatch.render("#app", vtree)).unsafeRunSync()
 
     document.getElementById("child").innerHTML shouldBe ""
 
@@ -192,9 +187,9 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
     import outwatch.dom._
 
 
-    val first = createStringHandler().value.unsafeRunSync()
+    val first = createStringHandler().unsafeRunSync()
 
-    val second = createStringHandler().value.unsafeRunSync()
+    val second = createStringHandler().unsafeRunSync()
 
     val messages = ("Hello", "World")
 
@@ -219,7 +214,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   it should "be able to be transformed by a function in place" in {
     import outwatch.dom._
 
-    val stream = createHandler[(MouseEvent, Int)]().value.unsafeRunSync()
+    val stream = createHandler[(MouseEvent, Int)]().unsafeRunSync()
 
     val number = 42
 
@@ -244,7 +239,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   it should "be able to be transformed from strings" in {
     import outwatch.dom._
 
-    val stream = createHandler[Int]().value.unsafeRunSync()
+    val stream = createHandler[Int]().unsafeRunSync()
 
     val number = 42
 
@@ -268,7 +263,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
     import outwatch.dom._
     import outwatch.util.SyntaxSugar._
 
-    val stream = createBoolHandler().value.unsafeRunSync()
+    val stream = createBoolHandler().unsafeRunSync()
 
     val someClass = "some-class"
 

--- a/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -36,9 +36,9 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
 
   it should "be called correctly on merged nodes" in {
     var switch = false
-    val sink = Sink.create((_: Element) => IO(switch = true))
+    val sink = Sink.create((_: Element) => IO{switch = true})
     var switch2 = false
-    val sink2 = Sink.create((_: Element) => IO(switch2 = true))
+    val sink2 = Sink.create((_: Element) => IO{switch2 = true})
 
     val node = div(insert --> sink)(insert --> sink2)
 
@@ -55,9 +55,9 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
   "Destruction hooks" should "be called correctly on merged nodes" in {
 
     var switch = false
-    val sink = Sink.create((_: Element) => IO(switch = true))
+    val sink = Sink.create((_: Element) => IO{switch = true})
     var switch2 = false
-    val sink2 = Sink.create((_: Element) => IO(switch2 = true))
+    val sink2 = Sink.create((_: Element) => IO{switch2 = true})
 
     val node = div(child <-- Observable.of(span(destroy --> sink)(destroy --> sink2), "Hasdasd"))
 
@@ -88,9 +88,9 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
 
   "Update hooks" should "be called correctly on merged nodes" in {
     var switch1 = false
-    val sink1 = Sink.create((_: (Element, Element)) => IO(switch1 = true))
+    val sink1 = Sink.create((_: (Element, Element)) => IO{switch1 = true})
     var switch2 = false
-    val sink2 = Sink.create((_: (Element, Element)) => IO(switch2 = true))
+    val sink2 = Sink.create((_: (Element, Element)) => IO{switch2 = true})
 
     val message = Subject[String]()
     val node = div(child <-- message, update --> sink1)(update --> sink2)

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -60,7 +60,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
       Attribute("class", "red"),
       EmptyVDomModifier,
       EventEmitter("click", Subject()),
-      VDomIO(IO(new StringNode("Test"))),
+      new StringNode("Test"),
       div(),
       AttributeStreamReceiver("hidden",Observable.of())
     )
@@ -142,7 +142,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val attributes = List(Attribute("class", "red"), Attribute("id", "msg"))
     val message = "Hello"
     val child = span(message)
-    val vtree = div(attributes.head, attributes(1), child).value.unsafeRunSync()
+    val vtree = div(attributes.head, attributes(1), child)
 
     val proxy = fixture.proxy
 
@@ -154,7 +154,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val attributes = List(Attribute("class", "red"), Attribute("id", "msg"))
     val message = "Hello"
     val child = span(message)
-    val vtree = div(attributes.head, attributes(1), child).value.unsafeRunSync()
+    val vtree = div(attributes.head, attributes(1), child)
 
     JSON.stringify(vtree.asProxy) shouldBe JSON.stringify(fixture.proxy)
   }
@@ -185,7 +185,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
   it should "be replaced if they contain changeables" in {
 
     def page(num: Int): VNode = {
-      val pageNum = createHandler[Int](num).value.unsafeRunSync()
+      val pageNum = createHandler[Int](num).unsafeRunSync()
 
       div( id := "page",
         num match {
@@ -225,7 +225,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
 
     val vtree = div(cls := "red", id := "msg",
       span("Hello")
-    ).value.unsafeRunSync()
+    )
 
     JSON.stringify(vtree.asProxy) shouldBe JSON.stringify(fixture.proxy)
 
@@ -237,7 +237,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val vtree = div(cls := "red", id := "msg",
       Option(span("Hello")),
       Option.empty[VDomModifier]
-    ).value.unsafeRunSync()
+    )
 
     JSON.stringify(vtree.asProxy) shouldBe JSON.stringify(fixture.proxy)
 
@@ -254,7 +254,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
       boolBuilder("c") := false,
       anyBuilder("d") := true,
       anyBuilder("e") := false
-    ).value.unsafeRunSync()
+    )
 
     val attrs = js.Dictionary[String | Boolean]("a" -> true, "b" -> true, "c" -> false, "d" -> "true", "e" -> "false")
     val expected = h("div", DataObject(attrs, js.Dictionary()), js.Array[Any]())

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import org.scalajs.dom.raw.{HTMLElement, HTMLInputElement}
 import org.scalajs.dom.{Event, KeyboardEvent, document}
 import org.scalatest.BeforeAndAfterEach
-import outwatch.dom.VDomModifier.StringNode
+import outwatch.dom.StringNode
 import outwatch.dom._
 import outwatch.dom.helpers._
 import rxscalajs.{Observable, Subject}

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -426,7 +426,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
   it should "update merged node styles correctly" in {
     val messages = Subject[String]
     val otherMessages = Subject[String]
-    val vNode = div(new StyleBuilder("color") <-- messages)(new StyleBuilder("color") <-- otherMessages)
+    val vNode = div(stl("color") <-- messages)(stl("color") <-- otherMessages)
 
     val node = document.createElement("div")
     document.body.appendChild(node)

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -61,7 +61,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
       EmptyVDomModifier,
       EventEmitter("click", Subject()),
       new StringNode("Test"),
-      div(),
+      div().unsafeRunSync(),
       AttributeStreamReceiver("hidden",Observable.of())
     )
 
@@ -142,11 +142,11 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val attributes = List(Attribute("class", "red"), Attribute("id", "msg"))
     val message = "Hello"
     val child = span(message)
-    val vtree = div(attributes.head, attributes(1), child)
+    val vtree = div(IO.pure(attributes.head), IO.pure(attributes(1)), child)
 
     val proxy = fixture.proxy
 
-    JSON.stringify(vtree.asProxy) shouldBe JSON.stringify(proxy)
+    JSON.stringify(vtree.map(_.asProxy).unsafeRunSync()) shouldBe JSON.stringify(proxy)
 
   }
 
@@ -154,9 +154,9 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val attributes = List(Attribute("class", "red"), Attribute("id", "msg"))
     val message = "Hello"
     val child = span(message)
-    val vtree = div(attributes.head, attributes(1), child)
+    val vtree = div(IO.pure(attributes.head), IO.pure(attributes(1)), child)
 
-    JSON.stringify(vtree.asProxy) shouldBe JSON.stringify(fixture.proxy)
+    JSON.stringify(vtree.map(_.asProxy).unsafeRunSync()) shouldBe JSON.stringify(fixture.proxy)
   }
 
 
@@ -166,7 +166,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val attributes = List(Attribute("class", cls), Attribute("id", id))
     val message = "Hello"
     val child = span(message)
-    val vtree = div(attributes.head, attributes(1), child)
+    val vtree = div(IO.pure(attributes.head), IO.pure(attributes(1)), child)
 
 
     val node = document.createElement("div")
@@ -227,7 +227,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
       span("Hello")
     )
 
-    JSON.stringify(vtree.asProxy) shouldBe JSON.stringify(fixture.proxy)
+    JSON.stringify(vtree.map(_.asProxy).unsafeRunSync()) shouldBe JSON.stringify(fixture.proxy)
 
   }
 
@@ -239,7 +239,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
       Option.empty[VDomModifier]
     )
 
-    JSON.stringify(vtree.asProxy) shouldBe JSON.stringify(fixture.proxy)
+    JSON.stringify(vtree.map(_.asProxy).unsafeRunSync()) shouldBe JSON.stringify(fixture.proxy)
 
   }
 
@@ -249,7 +249,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     def boolBuilder(name: String) = new BoolAttributeBuilder(name)
     def anyBuilder(name: String) = new AttributeBuilder[Boolean](name)
     val vtree = div(
-      boolBuilder("a"),
+      IO.pure(boolBuilder("a")),
       boolBuilder("b") := true,
       boolBuilder("c") := false,
       anyBuilder("d") := true,
@@ -259,7 +259,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val attrs = js.Dictionary[String | Boolean]("a" -> true, "b" -> true, "c" -> false, "d" -> "true", "e" -> "false")
     val expected = h("div", DataObject(attrs, js.Dictionary()), js.Array[Any]())
 
-    JSON.stringify(vtree.asProxy) shouldBe JSON.stringify(expected)
+    JSON.stringify(vtree.map(_.asProxy).unsafeRunSync()) shouldBe JSON.stringify(expected)
 
   }
 

--- a/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -27,18 +27,20 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
       minusOne = handleMinus.mapTo(-1)
 
       count = plusOne.merge(minusOne).scan(0)(_ + _).startWith(0)
-    } yield div(
+
+      div <- div(
         div(
           button(id := "plus", "+", click --> handlePlus),
           button(id := "minus", "-", click --> handleMinus),
-          span(id:="counter",child <-- count)
+          span(id := "counter", child <-- count)
         )
       )
+    } yield div
 
     val root = document.createElement("div")
     document.body.appendChild(root)
 
-    node.flatMap(node => DomUtils.render(root, node)).unsafeRunSync()
+    DomUtils.render(root, node).unsafeRunSync()
 
     val event = document.createEvent("Events")
     event.initEvent("click", canBubbleArg = true, cancelableArg = false)
@@ -59,19 +61,19 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
   "A simple name application" should "work as intended" in {
     val greetStart = "Hello ,"
 
-    val node = for {
-      nameHandler <- createStringHandler()
-    } yield div(
+    val node = createStringHandler().flatMap { nameHandler =>
+      div(
         label("Name:"),
         input(id := "input", inputType := "text", inputString --> nameHandler),
         hr(),
-        h1(id :="greeting", greetStart, child <-- nameHandler)
+        h1(id := "greeting", greetStart, child <-- nameHandler)
       )
+    }
 
     val root = document.createElement("div")
     document.body.appendChild(root)
 
-    node.flatMap(node => DomUtils.render(root, node)).unsafeRunSync()
+    DomUtils.render(root, node).unsafeRunSync()
 
 
     val evt = document.createEvent("HTMLEvents")
@@ -148,11 +150,13 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
         .withLatestFromWith(textFieldStream)((_, input) => input)
 
       _ <- (outputStream <-- confirm)
-    } yield div(
+
+      div <- div(
         label(labelText),
         input(id:= "input", inputType := "text", inputString --> textFieldStream, keyup --> keyStream),
         button(id := "submit", click --> clickStream, disabled <-- buttonDisabled, "Submit")
       )
+    } yield div
 
 
 
@@ -177,16 +181,18 @@ class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
       state = adds.merge(deletes)
         .scan(Vector[String]())((state, modify) => modify(state))
         .map(_.map(n => TodoComponent(n, deleteHandler)))
-      textFieldComponent <- TextFieldComponent("Todo: ", inputHandler)
-    } yield div(
+      textFieldComponent = TextFieldComponent("Todo: ", inputHandler)
+
+      div <- div(
         textFieldComponent,
         ul(id:= "list", children <-- state)
       )
+    } yield div
 
     val root = document.createElement("div")
     document.body.appendChild(root)
 
-    vtree.flatMap(vtree => DomUtils.render(root, vtree)).unsafeRunSync()
+    DomUtils.render(root, vtree).unsafeRunSync()
 
     val inputEvt = document.createEvent("HTMLEvents")
     inputEvt.initEvent("input", false, true)

--- a/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -30,7 +30,7 @@ class SnabbdomSpec extends UnitSpec {
   it should "correctly patch nodes with keys" in {
     import outwatch.dom._
 
-    val clicks = createHandler[Int](1).value.unsafeRunSync()
+    val clicks = createHandler[Int](1).unsafeRunSync()
     val nodes = clicks.map { i =>
       div(
         dom.key := s"key-$i",


### PR DESCRIPTION
I refactored the referential transparent API proposed in #68 so that it keeps the client code mostly unchanged (similarly to what the current master API does) but without wrapping the IO monad.
