### PR TITLE
Handler comap, contramap, imap and lens

### DIFF
--- a/src/main/scala/outwatch/Sink.scala
+++ b/src/main/scala/outwatch/Sink.scala
@@ -47,10 +47,10 @@ sealed trait Sink[-T] extends Any {
 }
 
 object Sink {
-  private final case class SubjectSink[T]() extends Subject[T](new SubjectFacade) with Sink[T] {
+  private[outwatch] final case class SubjectSink[T]() extends Subject[T](new SubjectFacade) with Sink[T] {
     override private[outwatch] def observer = this
   }
-  private final case class ObservableSink[T]
+  private[outwatch] final case class ObservableSink[T]
   (oldSink: Sink[T], stream: Observable[T]) extends Observable[T](stream.inner) with Sink[T] {
     override private[outwatch] def observer = oldSink.observer
   }
@@ -194,7 +194,6 @@ object Sink {
   def redirectMap[T, R](sink: Sink[T])(f: R => T): Sink[R] = {
     redirect(sink)(_.map(f))
   }
-
 }
 
 final case class ObserverSink[-T](observer: Observer[T]) extends AnyVal with Sink[T]

--- a/src/main/scala/outwatch/dom/Handlers.scala
+++ b/src/main/scala/outwatch/dom/Handlers.scala
@@ -23,6 +23,38 @@ trait Handlers {
   def createNumberHandler(defaultValues: Double*) = createHandler[Double](defaultValues: _*)
 
   def createHandler[T](defaultValues: T*): IO[Handler[T]] = Sink.createHandler[T](defaultValues: _*)
+
+  implicit class RichHandler[T](handler: Handler[T]) {
+    def comap(read: Observable[T] => Observable[T]): Handler[T] = {
+      Sink.ObservableSink(handler, read(handler))
+    }
+
+    def comapMap(read: T => T): Handler[T] = {
+      Sink.ObservableSink(handler, handler.map(read))
+    }
+
+    def contramap(write: Observable[T] => Observable[T]): Handler[T] = {
+      Sink.ObservableSink(handler.redirect[T](write), handler)
+    }
+
+    def contramapMap(write: T => T): Handler[T] = {
+      Sink.ObservableSink(handler.redirect[T](_.map(write)), handler)
+    }
+
+
+    def imap[S](read: Observable[T] => Observable[S])(write: Observable[S] => Observable[T]): Handler[S] = {
+      Sink.ObservableSink(handler.redirect[S](write), read(handler))
+    }
+
+    def imapMap[S](read: T => S)(write: S => T): Handler[S] = {
+      Sink.ObservableSink(handler.redirect[S](_.map(write)), handler.map(read))
+    }
+
+    def lens[S](seed: T)(read: T => S)(write: (T, S) => T): Handler[S] = {
+      val redirected = handler.redirect[S](_.withLatestFrom(handler.startWith(seed)).map { case (a,b) => write(b,a) })
+      Sink.ObservableSink(redirected, handler.map(read))
+    }
+  }
 }
 
 object Handlers extends Handlers

--- a/src/test/scala/outwatch/SinkSpec.scala
+++ b/src/test/scala/outwatch/SinkSpec.scala
@@ -1,0 +1,144 @@
+package outwatch
+
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.prop.PropertyChecks
+import outwatch.dom._
+
+class SinkSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks {
+  "Sink" should "lens" in {
+    val handler = createHandler[(String, Int)]().unsafeRunSync()
+    val lensed = handler.lens[Int](("harals", 0))(_._2)((tuple, num) => (tuple._1, num))
+
+    var handlerValue: (String, Int) = null
+    var lensedValue: Int = -100
+
+    handler(handlerValue = _)
+    lensed(lensedValue = _)
+
+    lensed.observer.next(15)
+    lensedValue shouldBe 15
+    handlerValue shouldBe (("harals", 15))
+
+    handler.observer.next(("peter", 12))
+    lensedValue shouldBe 12
+    handlerValue shouldBe (("peter", 12))
+
+    lensed.observer.next(-1)
+    lensedValue shouldBe -1
+    handlerValue shouldBe (("peter", -1))
+  }
+
+  it should "comapMap" in {
+    val handler = createHandler[Int]().unsafeRunSync()
+    val lensed = handler.comapMap(_ - 1)
+
+    var handlerValue: Int = -100
+    var lensedValue: Int = -100
+
+    handler(handlerValue = _)
+    lensed(lensedValue = _)
+
+    lensed.observer.next(15)
+    lensedValue shouldBe 14
+    handlerValue shouldBe 15
+
+    handler.observer.next(12)
+    lensedValue shouldBe 11
+    handlerValue shouldBe 12
+  }
+
+  it should "comap" in {
+    val handler = createHandler[Int]().unsafeRunSync()
+    val lensed = handler.comap(_.map(_ - 1))
+
+    var handlerValue: Int = -100
+    var lensedValue: Int = -100
+
+    handler(handlerValue = _)
+    lensed(lensedValue = _)
+
+    lensed.observer.next(15)
+    lensedValue shouldBe 14
+    handlerValue shouldBe 15
+
+    handler.observer.next(12)
+    lensedValue shouldBe 11
+    handlerValue shouldBe 12
+  }
+
+  it should "contramapMap" in {
+    val handler = createHandler[Int]().unsafeRunSync()
+    val lensed = handler.contramapMap(_ + 1)
+
+    var handlerValue: Int = -100
+    var lensedValue: Int = -100
+
+    handler(handlerValue = _)
+    lensed(lensedValue = _)
+
+    lensed.observer.next(15)
+    lensedValue shouldBe 16
+    handlerValue shouldBe 16
+
+    handler.observer.next(12)
+    lensedValue shouldBe 12
+    handlerValue shouldBe 12
+  }
+
+  it should "contramap" in {
+    val handler = createHandler[Int]().unsafeRunSync()
+    val lensed = handler.contramap(_.map(_ + 1))
+
+    var handlerValue: Int = -100
+    var lensedValue: Int = -100
+
+    handler(handlerValue = _)
+    lensed(lensedValue = _)
+
+    lensed.observer.next(15)
+    lensedValue shouldBe 16
+    handlerValue shouldBe 16
+
+    handler.observer.next(12)
+    lensedValue shouldBe 12
+    handlerValue shouldBe 12
+  }
+
+  it should "imapMap" in {
+    val handler = createHandler[Int]().unsafeRunSync()
+    val lensed = handler.imapMap[Int](_ - 1)(_ + 1)
+
+    var handlerValue: Int = -100
+    var lensedValue: Int = -100
+
+    handler(handlerValue = _)
+    lensed(lensedValue = _)
+
+    lensed.observer.next(15)
+    lensedValue shouldBe 15
+    handlerValue shouldBe 16
+
+    handler.observer.next(12)
+    lensedValue shouldBe 11
+    handlerValue shouldBe 12
+  }
+
+  it should "imap" in {
+    val handler = createHandler[Int]().unsafeRunSync()
+    val lensed = handler.imap[Int](_.map(_ - 1))(_.map(_ + 1))
+
+    var handlerValue: Int = -100
+    var lensedValue: Int = -100
+
+    handler(handlerValue = _)
+    lensed(lensedValue = _)
+
+    lensed.observer.next(15)
+    lensedValue shouldBe 15
+    handlerValue shouldBe 16
+
+    handler.observer.next(12)
+    lensedValue shouldBe 11
+    handlerValue shouldBe 12
+  }
+}


### PR DESCRIPTION
This is a draft for transforming handlers in the read and write direction.

1. `comap`, like `map` on `Observable`, but returns a `Handler` which can still be used for writing.
2. `contramap`, like `redirectMap` on `Observable` redirects the written values into the `Handler`, but still returns a `Handler` for reading.
3. `imap` defines an isomorphism and returns a `Handler` where reading and writing are transformed.
4. `lens` zooms into one part of the data where changes are written back to the original `Handler`.

See the tests for examples.

We could also think about accepting automatically generated lenses, Iso and other stuff from [Monocle](https://julien-truffaut.github.io/Monocle/optics.html).

For `imap` it could be useful to implement the `Invariant` type class from cats. For the `comap` and `contramap` it is sadly not possible to implement `Functor` or `Covariant`, since right now the type has to be the same. Ideas welcome!