### PR TITLE
Refactor EmitterBuilder

### DIFF
--- a/src/main/scala/outwatch/dom/Attributes.scala
+++ b/src/main/scala/outwatch/dom/Attributes.scala
@@ -39,13 +39,13 @@ trait Attributes
 /** Clipboard Events */
 trait ClipBoardEventAttributes {
   /** Fires when the user copies the content of an element. */
-  lazy val copy   = new EventEmitterBuilder[ClipboardEvent]("copy")
+  lazy val copy   = EmitterBuilder.event[ClipboardEvent]("copy")
 
   /** Fires when the user cuts the content of an element. */
-  lazy val cut    = new EventEmitterBuilder[ClipboardEvent]("cut")
+  lazy val cut    = EmitterBuilder.event[ClipboardEvent]("cut")
 
   /** Fires when the user pastes some content in an element. */
-  lazy val paste  = new EventEmitterBuilder[ClipboardEvent]("paste")
+  lazy val paste  = EmitterBuilder.event[ClipboardEvent]("paste")
 }
 
 /** Form Events that are triggered by actions inside an HTML form. However,
@@ -57,60 +57,60 @@ trait FormEventAttributes {
     *
     * MDN
     */
-  lazy val blur         = new EventEmitterBuilder[InputEvent]("blur")
+  lazy val blur         = EmitterBuilder.event[InputEvent]("blur")
 
   /** The change event is fired for input, select, and textarea elements
     * when a change to the element's value is committed by the user.
     *
     * MDN
     */
-  lazy val change       = new EventEmitterBuilder[InputEvent]("change")
+  lazy val change       = EmitterBuilder.event[InputEvent]("change")
 
   /** The focus event is raised when the user sets focus on the given element.
     *
     * MDN
     */
-  lazy val focus        = new EventEmitterBuilder[InputEvent]("focus")
+  lazy val focus        = EmitterBuilder.event[InputEvent]("focus")
 
   /** The input event is fired when an element gets user input. */
-  lazy val input        = new EventEmitterBuilder[InputEvent]("input")
+  lazy val input        = EmitterBuilder.event[InputEvent]("input")
 
 
   @deprecated("Deprecated, use 'inputChecked' instead", "0.8.0")
-  lazy val inputBool    = new BoolEventEmitterBuilder("change")
+  lazy val inputBool    = EmitterBuilder.inputCheckedAsBool("change")
 
 
   /** The input event is fired when an element gets user input. */
-  lazy val inputChecked = new BoolEventEmitterBuilder("change")
+  lazy val inputChecked = EmitterBuilder.inputCheckedAsBool("change")
 
 
   /** The input event is fired when an element gets user input. */
-  lazy val inputNumber  = new NumberEventEmitterBuilder("input")
+  lazy val inputNumber  = EmitterBuilder.inputValueAsNumber("input")
 
 
   /** The input event is fired when an element gets user input. */
-  lazy val inputString  = new StringEventEmitterBuilder("input")
+  lazy val inputString  = EmitterBuilder.inputValueAsString("input")
 
   /** This event is fired when an element becomes invalid. */
-  lazy val invalid      = new BoolEventEmitterBuilder("invalid")
+  lazy val invalid      = EmitterBuilder.inputCheckedAsBool("invalid")
 
   /** The reset event is fired when a form is reset.
     *
     * MDN
     */
-  lazy val reset        = new EventEmitterBuilder("reset")
+  lazy val reset        = EmitterBuilder.event("reset")
 
   /** Fires when the user writes something in a search field
     * (for `&lt;input="search"&gt;`).
     */
-  lazy val search       = new EventEmitterBuilder("search")
+  lazy val search       = EmitterBuilder.event("search")
 
   /** The submit event is raised when the user clicks a submit button in a form
     * (`&lt;input type="submit"/&gt;`).
     *
     * MDN
     */
-  lazy val submit       = new EventEmitterBuilder[Event]("submit")
+  lazy val submit       = EmitterBuilder.event[Event]("submit")
 }
 
 /** Global attributes are attributes common to all HTML elements; they can be
@@ -1045,7 +1045,7 @@ trait KeyboardEventAttributes {
     *
     * MDN
     */
-  lazy val keydown  = new EventEmitterBuilder[KeyboardEvent]("keydown")
+  lazy val keydown  = EmitterBuilder.event[KeyboardEvent]("keydown")
 
   /** The keypress event should be raised when the user presses a key on the
     * keyboard. However, not all browsers fire keypress events for certain keys.
@@ -1056,13 +1056,13 @@ trait KeyboardEventAttributes {
     *
     * MDN
     */
-  lazy val keypress = new EventEmitterBuilder[KeyboardEvent]("keypress")
+  lazy val keypress = EmitterBuilder.event[KeyboardEvent]("keypress")
 
   /** The keyup event is raised when the user releases a key that's been pressed.
     *
     * MDN
     */
-  lazy val keyup    = new EventEmitterBuilder[KeyboardEvent]("keyup")
+  lazy val keyup    = EmitterBuilder.event[KeyboardEvent]("keyup")
 }
 
 /** Attributes applicable to media elements like `&lt;audio&gt;`,
@@ -1226,7 +1226,7 @@ trait MediaAttributes extends SharedEventAttributes {
  * `&lt;embed&gt;`, `&lt;img&gt;`, `&lt;object&gt;`, and `&lt;video&gt;`.
  */
 trait MediaEventAttributes {
-  private def event(name: String) = new EventEmitterBuilder[Event](name)
+  private def event(name: String) = EmitterBuilder.event[Event](name)
 
   /** Script to be run on abort. */
   lazy val abort = event("abort")
@@ -1680,7 +1680,7 @@ trait MiscellaneousAttributes {
 
 /** Miscellaneous Events. */
 trait MiscellaneousEventAttributes extends SharedEventAttributes {
-  private def event(name: String) = new EventEmitterBuilder[Event](name)
+  private def event(name: String) = EmitterBuilder.event[Event](name)
 
   /** Fires when a `&lt;menu&gt;` element is shown as a context menu. */
   lazy val show = event("show")
@@ -1696,11 +1696,11 @@ trait MouseEventAttributes {
     *
     * MDN
     */
-  lazy val click              = new EventEmitterBuilder[MouseEvent]("click")
+  lazy val click              = EmitterBuilder.event[MouseEvent]("click")
 
   /** Script to be run when a context menu is triggered
     */
-  lazy val contextmenu        = new EventEmitterBuilder[MouseEvent]("contextmenu")
+  lazy val contextmenu        = EmitterBuilder.event[MouseEvent]("contextmenu")
   @deprecated("Deprecated, use 'contextmenu' instead", "0.9.0")
   lazy val contextMenu        = contextmenu
 
@@ -1709,73 +1709,73 @@ trait MouseEventAttributes {
     *
     * MDN
     */
-  lazy val dblclick           = new EventEmitterBuilder[MouseEvent]("dblclick")
+  lazy val dblclick           = EmitterBuilder.event[MouseEvent]("dblclick")
 
   /** Script to be run when an element is dragged. */
-  lazy val drag               = new EventEmitterBuilder[DragEvent]("drag")
+  lazy val drag               = EmitterBuilder.event[DragEvent]("drag")
 
   /** Script to be run at the end of a drag operation. */
-  lazy val dragend            = new EventEmitterBuilder[DragEvent]("dragend")
+  lazy val dragend            = EmitterBuilder.event[DragEvent]("dragend")
   @deprecated("Deprecated, use 'dragend' instead", "0.9.0")
   lazy val dragEnd            = dragend
 
   /** Script to be run when an element has been dragged to a valid drop target. */
-  lazy val dragenter          = new EventEmitterBuilder[DragEvent]("dragenter")
+  lazy val dragenter          = EmitterBuilder.event[DragEvent]("dragenter")
   @deprecated("Deprecated, use 'dragenter' instead", "0.9.0")
   lazy val dragEnter          = dragenter
 
   /** Script to be run when an element leaves a valid drop target. */
-  lazy val dragleave          = new EventEmitterBuilder[DragEvent]("dragleave")
+  lazy val dragleave          = EmitterBuilder.event[DragEvent]("dragleave")
   @deprecated("Deprecated, use 'dragleave' instead", "0.9.0")
   lazy val dragLeave          = dragleave
 
   /** Script to be run when an element is being dragged over a valid drop target. */
-  lazy val dragover           = new EventEmitterBuilder[DragEvent]("dragover")
+  lazy val dragover           = EmitterBuilder.event[DragEvent]("dragover")
   @deprecated("Deprecated, use 'dragover' instead", "0.9.0")
   lazy val dragOver           = dragover
 
 
   /** Script to be run at the start of a drag operation. */
-  lazy val dragstart          = new EventEmitterBuilder[DragEvent]("dragstart")
+  lazy val dragstart          = EmitterBuilder.event[DragEvent]("dragstart")
   @deprecated("Deprecated, use 'dragstart' instead", "0.9.0")
   lazy val dragStart          = dragstart
 
 
   /** Script to be run when dragged element is being dropped. */
-  lazy val drop               = new EventEmitterBuilder[DragEvent]("drop")
+  lazy val drop               = EmitterBuilder.event[DragEvent]("drop")
 
   /** The mousedown event is raised when the user presses the mouse button.
     *
     * MDN
     */
-  lazy val mousedown          = new EventEmitterBuilder[MouseEvent]("mousedown")
+  lazy val mousedown          = EmitterBuilder.event[MouseEvent]("mousedown")
 
   /** The mouseenter event is fired when a pointing device (usually a mouse) is
     * moved over the element that has the listener attached.
     *
     * MDN
     */
-  lazy val mouseenter         = new EventEmitterBuilder[MouseEvent]("mouseenter")
+  lazy val mouseenter         = EmitterBuilder.event[MouseEvent]("mouseenter")
 
   /** The mouseleave event is fired when a pointing device (usually a mouse) is
     * moved off the element that has the listener attached.
     *
     * MDN
     */
-  lazy val mouseleave         = new EventEmitterBuilder[MouseEvent]("mouseleave")
+  lazy val mouseleave         = EmitterBuilder.event[MouseEvent]("mouseleave")
 
   /** The mousemove event is raised when the user moves the mouse.
     *
     * MDN
     */
-  lazy val mousemove          = new EventEmitterBuilder[MouseEvent]("mousemove")
+  lazy val mousemove          = EmitterBuilder.event[MouseEvent]("mousemove")
 
   /** The mouseover event is raised when the user moves the mouse over a
     * particular element.
     *
     * MDN
     */
-  lazy val mouseover          = new EventEmitterBuilder[MouseEvent]("mouseover")
+  lazy val mouseover          = EmitterBuilder.event[MouseEvent]("mouseover")
 
 
   /** The mouseout event is fired when a pointing device (usually a mouse) is
@@ -1785,20 +1785,20 @@ trait MouseEventAttributes {
     *
     * MDN
     */
-  lazy val mouseout           = new EventEmitterBuilder[MouseEvent]("mouseout")
+  lazy val mouseout           = EmitterBuilder.event[MouseEvent]("mouseout")
 
   /** The mouseup event is raised when the user releases the mouse button.
     *
     * MDN
     */
-  lazy val mouseup            = new EventEmitterBuilder[MouseEvent]("mouseup")
+  lazy val mouseup            = EmitterBuilder.event[MouseEvent]("mouseup")
 
 
   /** The pointerlockchange event is fired when the pointer is locked/unlocked.
     *
     * MDN
     */
-  lazy val pointerlockchange  = new EventEmitterBuilder[MouseEvent]("pointerlockchange")
+  lazy val pointerlockchange  = EmitterBuilder.event[MouseEvent]("pointerlockchange")
   @deprecated("Deprecated, use 'pointerlockchange' instead", "0.9.0")
   lazy val pointerLockChange  = pointerlockchange
 
@@ -1808,7 +1808,7 @@ trait MouseEventAttributes {
     *
     * MDN
     */
-  lazy val pointerlockerror   = new EventEmitterBuilder[MouseEvent]("pointerlockerror")
+  lazy val pointerlockerror   = EmitterBuilder.event[MouseEvent]("pointerlockerror")
   @deprecated("Deprecated, use 'pointerlockerror' instead", "0.9.0")
   lazy val pointerLockError   = pointerlockerror
 
@@ -1817,7 +1817,7 @@ trait MouseEventAttributes {
     *
     * MDN
     */
-  lazy val scroll             = new EventEmitterBuilder[MouseEvent]("scroll")
+  lazy val scroll             = EmitterBuilder.event[MouseEvent]("scroll")
 
   /**
     * The select event only fires when text inside a text input or textarea is
@@ -1825,7 +1825,7 @@ trait MouseEventAttributes {
     *
     * MDN
     */
-  lazy val select             = new EventEmitterBuilder[MouseEvent]("select")
+  lazy val select             = EmitterBuilder.event[MouseEvent]("select")
 
   /** The wheel event is fired when a wheel button of a pointing device (usually
     * a mouse) is rotated. This event replaces the non-standard deprecated
@@ -1833,7 +1833,7 @@ trait MouseEventAttributes {
     *
     * MDN
     */
-  lazy val wheel              = new EventEmitterBuilder[WheelEvent]("wheel")
+  lazy val wheel              = EmitterBuilder.event[WheelEvent]("wheel")
 }
 
 /** OutWatch specific attributes used to asign child nodes to a VNode. */
@@ -1866,7 +1866,7 @@ trait SnabbdomKeyAttributes {
 
 trait SharedEventAttributes {
   /** Script to be run when an error occurs when the file is being loaded. */
-  lazy val error = new EventEmitterBuilder("error")
+  lazy val error = EmitterBuilder.event("error")
 }
 
 /** Attributes applicable to the table element and its children. */
@@ -1938,28 +1938,28 @@ trait TouchEventAttributes {
     *
     * MDN
     */
-  lazy val touchcancel = new EventEmitterBuilder[TouchEvent]("touchcancel")
+  lazy val touchcancel = EmitterBuilder.event[TouchEvent]("touchcancel")
 
   /** The touchend event is fired when a touch point is removed from the touch
     * surface.
     *
     * MDN
     */
-  lazy val touchend    = new EventEmitterBuilder[TouchEvent]("touchend")
+  lazy val touchend    = EmitterBuilder.event[TouchEvent]("touchend")
 
   /** The touchmove event is fired when a touch point is moved along the touch
     * surface.
     *
     * MDN
     */
-  lazy val touchmove   = new EventEmitterBuilder[TouchEvent]("touchmove")
+  lazy val touchmove   = EmitterBuilder.event[TouchEvent]("touchmove")
 
   /** The touchstart event is fired when a touch point is placed on the touch
     * surface.
     *
     * MDN
     */
-  lazy val touchstart  = new EventEmitterBuilder[TouchEvent]("touchstart")
+  lazy val touchstart  = EmitterBuilder.event[TouchEvent]("touchstart")
 }
 
 /** Window events. */
@@ -1973,7 +1973,7 @@ trait WindowEventAttrs extends SharedEventAttributes {
     *
     * MDN
     */
-  lazy val offline = new EventEmitterBuilder("offline")
+  lazy val offline = EmitterBuilder.event("offline")
 
   /** Firefox 3 introduces two new events: "online" and "offline". These two
     * events are fired on the `&lt;body&gt;` of each page when the browser switches
@@ -1984,10 +1984,10 @@ trait WindowEventAttrs extends SharedEventAttributes {
     *
     * MDN
     */
-  lazy val online  = new EventEmitterBuilder("online")
+  lazy val online  = EmitterBuilder.event("online")
 
   /** The resize event is fired when the document view has been resized. */
-  lazy val resize  = new EventEmitterBuilder("resize")
+  lazy val resize  = EmitterBuilder.event("resize")
 }
 
 object Attributes extends Attributes

--- a/src/main/scala/outwatch/dom/Attributes.scala
+++ b/src/main/scala/outwatch/dom/Attributes.scala
@@ -39,13 +39,13 @@ trait Attributes
 /** Clipboard Events */
 trait ClipBoardEventAttributes {
   /** Fires when the user copies the content of an element. */
-  lazy val copy   = EmitterBuilder.event[ClipboardEvent]("copy")
+  lazy val copy   = EmitterBuilder[ClipboardEvent]("copy")
 
   /** Fires when the user cuts the content of an element. */
-  lazy val cut    = EmitterBuilder.event[ClipboardEvent]("cut")
+  lazy val cut    = EmitterBuilder[ClipboardEvent]("cut")
 
   /** Fires when the user pastes some content in an element. */
-  lazy val paste  = EmitterBuilder.event[ClipboardEvent]("paste")
+  lazy val paste  = EmitterBuilder[ClipboardEvent]("paste")
 }
 
 /** Form Events that are triggered by actions inside an HTML form. However,
@@ -57,60 +57,60 @@ trait FormEventAttributes {
     *
     * MDN
     */
-  lazy val blur         = EmitterBuilder.event[InputEvent]("blur")
+  lazy val blur         = EmitterBuilder[InputEvent]("blur")
 
   /** The change event is fired for input, select, and textarea elements
     * when a change to the element's value is committed by the user.
     *
     * MDN
     */
-  lazy val change       = EmitterBuilder.event[InputEvent]("change")
+  lazy val change       = EmitterBuilder[InputEvent]("change")
 
   /** The focus event is raised when the user sets focus on the given element.
     *
     * MDN
     */
-  lazy val focus        = EmitterBuilder.event[InputEvent]("focus")
+  lazy val focus        = EmitterBuilder[InputEvent]("focus")
 
   /** The input event is fired when an element gets user input. */
-  lazy val input        = EmitterBuilder.event[InputEvent]("input")
+  lazy val input        = EmitterBuilder[InputEvent]("input")
 
 
   @deprecated("Deprecated, use 'inputChecked' instead", "0.8.0")
-  lazy val inputBool    = EmitterBuilder.inputCheckedAsBool("change")
+  lazy val inputBool    = inputChecked
 
 
   /** The input event is fired when an element gets user input. */
-  lazy val inputChecked = EmitterBuilder.inputCheckedAsBool("change")
+  lazy val inputChecked = change.map(_.target.checked)
 
 
   /** The input event is fired when an element gets user input. */
-  lazy val inputNumber  = EmitterBuilder.inputValueAsNumber("input")
+  lazy val inputNumber  = input.map(_.target.valueAsNumber)
 
 
   /** The input event is fired when an element gets user input. */
-  lazy val inputString  = EmitterBuilder.inputValueAsString("input")
+  lazy val inputString  = input.map(_.target.value)
 
   /** This event is fired when an element becomes invalid. */
-  lazy val invalid      = EmitterBuilder.inputCheckedAsBool("invalid")
+  lazy val invalid      = EmitterBuilder[Event]("invalid")
 
   /** The reset event is fired when a form is reset.
     *
     * MDN
     */
-  lazy val reset        = EmitterBuilder.event("reset")
+  lazy val reset        = EmitterBuilder[Event]("reset")
 
   /** Fires when the user writes something in a search field
     * (for `&lt;input="search"&gt;`).
     */
-  lazy val search       = EmitterBuilder.event("search")
+  lazy val search       = EmitterBuilder[Event]("search")
 
   /** The submit event is raised when the user clicks a submit button in a form
     * (`&lt;input type="submit"/&gt;`).
     *
     * MDN
     */
-  lazy val submit       = EmitterBuilder.event[Event]("submit")
+  lazy val submit       = EmitterBuilder[Event]("submit")
 }
 
 /** Global attributes are attributes common to all HTML elements; they can be
@@ -1045,7 +1045,7 @@ trait KeyboardEventAttributes {
     *
     * MDN
     */
-  lazy val keydown  = EmitterBuilder.event[KeyboardEvent]("keydown")
+  lazy val keydown  = EmitterBuilder[KeyboardEvent]("keydown")
 
   /** The keypress event should be raised when the user presses a key on the
     * keyboard. However, not all browsers fire keypress events for certain keys.
@@ -1056,13 +1056,13 @@ trait KeyboardEventAttributes {
     *
     * MDN
     */
-  lazy val keypress = EmitterBuilder.event[KeyboardEvent]("keypress")
+  lazy val keypress = EmitterBuilder[KeyboardEvent]("keypress")
 
   /** The keyup event is raised when the user releases a key that's been pressed.
     *
     * MDN
     */
-  lazy val keyup    = EmitterBuilder.event[KeyboardEvent]("keyup")
+  lazy val keyup    = EmitterBuilder[KeyboardEvent]("keyup")
 }
 
 /** Attributes applicable to media elements like `&lt;audio&gt;`,
@@ -1226,7 +1226,7 @@ trait MediaAttributes extends SharedEventAttributes {
  * `&lt;embed&gt;`, `&lt;img&gt;`, `&lt;object&gt;`, and `&lt;video&gt;`.
  */
 trait MediaEventAttributes {
-  private def event(name: String) = EmitterBuilder.event[Event](name)
+  private def event(name: String) = EmitterBuilder[Event](name)
 
   /** Script to be run on abort. */
   lazy val abort = event("abort")
@@ -1680,7 +1680,7 @@ trait MiscellaneousAttributes {
 
 /** Miscellaneous Events. */
 trait MiscellaneousEventAttributes extends SharedEventAttributes {
-  private def event(name: String) = EmitterBuilder.event[Event](name)
+  private def event(name: String) = EmitterBuilder[Event](name)
 
   /** Fires when a `&lt;menu&gt;` element is shown as a context menu. */
   lazy val show = event("show")
@@ -1696,11 +1696,11 @@ trait MouseEventAttributes {
     *
     * MDN
     */
-  lazy val click              = EmitterBuilder.event[MouseEvent]("click")
+  lazy val click              = EmitterBuilder[MouseEvent]("click")
 
   /** Script to be run when a context menu is triggered
     */
-  lazy val contextmenu        = EmitterBuilder.event[MouseEvent]("contextmenu")
+  lazy val contextmenu        = EmitterBuilder[MouseEvent]("contextmenu")
   @deprecated("Deprecated, use 'contextmenu' instead", "0.9.0")
   lazy val contextMenu        = contextmenu
 
@@ -1709,73 +1709,73 @@ trait MouseEventAttributes {
     *
     * MDN
     */
-  lazy val dblclick           = EmitterBuilder.event[MouseEvent]("dblclick")
+  lazy val dblclick           = EmitterBuilder[MouseEvent]("dblclick")
 
   /** Script to be run when an element is dragged. */
-  lazy val drag               = EmitterBuilder.event[DragEvent]("drag")
+  lazy val drag               = EmitterBuilder[DragEvent]("drag")
 
   /** Script to be run at the end of a drag operation. */
-  lazy val dragend            = EmitterBuilder.event[DragEvent]("dragend")
+  lazy val dragend            = EmitterBuilder[DragEvent]("dragend")
   @deprecated("Deprecated, use 'dragend' instead", "0.9.0")
   lazy val dragEnd            = dragend
 
   /** Script to be run when an element has been dragged to a valid drop target. */
-  lazy val dragenter          = EmitterBuilder.event[DragEvent]("dragenter")
+  lazy val dragenter          = EmitterBuilder[DragEvent]("dragenter")
   @deprecated("Deprecated, use 'dragenter' instead", "0.9.0")
   lazy val dragEnter          = dragenter
 
   /** Script to be run when an element leaves a valid drop target. */
-  lazy val dragleave          = EmitterBuilder.event[DragEvent]("dragleave")
+  lazy val dragleave          = EmitterBuilder[DragEvent]("dragleave")
   @deprecated("Deprecated, use 'dragleave' instead", "0.9.0")
   lazy val dragLeave          = dragleave
 
   /** Script to be run when an element is being dragged over a valid drop target. */
-  lazy val dragover           = EmitterBuilder.event[DragEvent]("dragover")
+  lazy val dragover           = EmitterBuilder[DragEvent]("dragover")
   @deprecated("Deprecated, use 'dragover' instead", "0.9.0")
   lazy val dragOver           = dragover
 
 
   /** Script to be run at the start of a drag operation. */
-  lazy val dragstart          = EmitterBuilder.event[DragEvent]("dragstart")
+  lazy val dragstart          = EmitterBuilder[DragEvent]("dragstart")
   @deprecated("Deprecated, use 'dragstart' instead", "0.9.0")
   lazy val dragStart          = dragstart
 
 
   /** Script to be run when dragged element is being dropped. */
-  lazy val drop               = EmitterBuilder.event[DragEvent]("drop")
+  lazy val drop               = EmitterBuilder[DragEvent]("drop")
 
   /** The mousedown event is raised when the user presses the mouse button.
     *
     * MDN
     */
-  lazy val mousedown          = EmitterBuilder.event[MouseEvent]("mousedown")
+  lazy val mousedown          = EmitterBuilder[MouseEvent]("mousedown")
 
   /** The mouseenter event is fired when a pointing device (usually a mouse) is
     * moved over the element that has the listener attached.
     *
     * MDN
     */
-  lazy val mouseenter         = EmitterBuilder.event[MouseEvent]("mouseenter")
+  lazy val mouseenter         = EmitterBuilder[MouseEvent]("mouseenter")
 
   /** The mouseleave event is fired when a pointing device (usually a mouse) is
     * moved off the element that has the listener attached.
     *
     * MDN
     */
-  lazy val mouseleave         = EmitterBuilder.event[MouseEvent]("mouseleave")
+  lazy val mouseleave         = EmitterBuilder[MouseEvent]("mouseleave")
 
   /** The mousemove event is raised when the user moves the mouse.
     *
     * MDN
     */
-  lazy val mousemove          = EmitterBuilder.event[MouseEvent]("mousemove")
+  lazy val mousemove          = EmitterBuilder[MouseEvent]("mousemove")
 
   /** The mouseover event is raised when the user moves the mouse over a
     * particular element.
     *
     * MDN
     */
-  lazy val mouseover          = EmitterBuilder.event[MouseEvent]("mouseover")
+  lazy val mouseover          = EmitterBuilder[MouseEvent]("mouseover")
 
 
   /** The mouseout event is fired when a pointing device (usually a mouse) is
@@ -1785,20 +1785,20 @@ trait MouseEventAttributes {
     *
     * MDN
     */
-  lazy val mouseout           = EmitterBuilder.event[MouseEvent]("mouseout")
+  lazy val mouseout           = EmitterBuilder[MouseEvent]("mouseout")
 
   /** The mouseup event is raised when the user releases the mouse button.
     *
     * MDN
     */
-  lazy val mouseup            = EmitterBuilder.event[MouseEvent]("mouseup")
+  lazy val mouseup            = EmitterBuilder[MouseEvent]("mouseup")
 
 
   /** The pointerlockchange event is fired when the pointer is locked/unlocked.
     *
     * MDN
     */
-  lazy val pointerlockchange  = EmitterBuilder.event[MouseEvent]("pointerlockchange")
+  lazy val pointerlockchange  = EmitterBuilder[MouseEvent]("pointerlockchange")
   @deprecated("Deprecated, use 'pointerlockchange' instead", "0.9.0")
   lazy val pointerLockChange  = pointerlockchange
 
@@ -1808,7 +1808,7 @@ trait MouseEventAttributes {
     *
     * MDN
     */
-  lazy val pointerlockerror   = EmitterBuilder.event[MouseEvent]("pointerlockerror")
+  lazy val pointerlockerror   = EmitterBuilder[MouseEvent]("pointerlockerror")
   @deprecated("Deprecated, use 'pointerlockerror' instead", "0.9.0")
   lazy val pointerLockError   = pointerlockerror
 
@@ -1817,7 +1817,7 @@ trait MouseEventAttributes {
     *
     * MDN
     */
-  lazy val scroll             = EmitterBuilder.event[MouseEvent]("scroll")
+  lazy val scroll             = EmitterBuilder[MouseEvent]("scroll")
 
   /**
     * The select event only fires when text inside a text input or textarea is
@@ -1825,7 +1825,7 @@ trait MouseEventAttributes {
     *
     * MDN
     */
-  lazy val select             = EmitterBuilder.event[MouseEvent]("select")
+  lazy val select             = EmitterBuilder[MouseEvent]("select")
 
   /** The wheel event is fired when a wheel button of a pointing device (usually
     * a mouse) is rotated. This event replaces the non-standard deprecated
@@ -1833,7 +1833,7 @@ trait MouseEventAttributes {
     *
     * MDN
     */
-  lazy val wheel              = EmitterBuilder.event[WheelEvent]("wheel")
+  lazy val wheel              = EmitterBuilder[WheelEvent]("wheel")
 }
 
 /** OutWatch specific attributes used to asign child nodes to a VNode. */
@@ -1866,7 +1866,7 @@ trait SnabbdomKeyAttributes {
 
 trait SharedEventAttributes {
   /** Script to be run when an error occurs when the file is being loaded. */
-  lazy val error = EmitterBuilder.event("error")
+  lazy val error = EmitterBuilder[Event]("error")
 }
 
 /** Attributes applicable to the table element and its children. */
@@ -1938,28 +1938,28 @@ trait TouchEventAttributes {
     *
     * MDN
     */
-  lazy val touchcancel = EmitterBuilder.event[TouchEvent]("touchcancel")
+  lazy val touchcancel = EmitterBuilder[TouchEvent]("touchcancel")
 
   /** The touchend event is fired when a touch point is removed from the touch
     * surface.
     *
     * MDN
     */
-  lazy val touchend    = EmitterBuilder.event[TouchEvent]("touchend")
+  lazy val touchend    = EmitterBuilder[TouchEvent]("touchend")
 
   /** The touchmove event is fired when a touch point is moved along the touch
     * surface.
     *
     * MDN
     */
-  lazy val touchmove   = EmitterBuilder.event[TouchEvent]("touchmove")
+  lazy val touchmove   = EmitterBuilder[TouchEvent]("touchmove")
 
   /** The touchstart event is fired when a touch point is placed on the touch
     * surface.
     *
     * MDN
     */
-  lazy val touchstart  = EmitterBuilder.event[TouchEvent]("touchstart")
+  lazy val touchstart  = EmitterBuilder[TouchEvent]("touchstart")
 }
 
 /** Window events. */
@@ -1973,7 +1973,7 @@ trait WindowEventAttrs extends SharedEventAttributes {
     *
     * MDN
     */
-  lazy val offline = EmitterBuilder.event("offline")
+  lazy val offline = EmitterBuilder[Event]("offline")
 
   /** Firefox 3 introduces two new events: "online" and "offline". These two
     * events are fired on the `&lt;body&gt;` of each page when the browser switches
@@ -1984,10 +1984,10 @@ trait WindowEventAttrs extends SharedEventAttributes {
     *
     * MDN
     */
-  lazy val online  = EmitterBuilder.event("online")
+  lazy val online  = EmitterBuilder[Event]("online")
 
   /** The resize event is fired when the document view has been resized. */
-  lazy val resize  = EmitterBuilder.event("resize")
+  lazy val resize  = EmitterBuilder[Event]("resize")
 }
 
 object Attributes extends Attributes

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -12,11 +12,7 @@ import collection.breakOut
 
 sealed trait VDomModifier_ extends Any
 
-case class Emitter[T](
-                       eventType: String,
-                       observer:Observer[T],
-                       trigger:Event => Unit
-                     ) extends VDomModifier_
+case class Emitter(eventType: String, trigger: Event => Unit) extends VDomModifier_
 
 sealed trait Property extends VDomModifier_
 sealed trait Attribute extends Property {

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -12,19 +12,13 @@ import collection.breakOut
 
 sealed trait VDomModifier_ extends Any
 
-sealed trait Emitter extends VDomModifier_ {
-  val eventType: String
-}
+case class Emitter[T](
+                       eventType: String,
+                       observer:Observer[T],
+                       trigger:Event => Unit
+                     ) extends VDomModifier_
 
 sealed trait Property extends VDomModifier_
-
-sealed trait Receiver extends VDomModifier_
-
-final case class EventEmitter[E <: Event](eventType: String, sink: Observer[E]) extends Emitter
-final case class StringEventEmitter(eventType: String, sink: Observer[String]) extends Emitter
-final case class BoolEventEmitter(eventType: String, sink: Observer[Boolean]) extends Emitter
-final case class NumberEventEmitter(eventType: String, sink: Observer[Double]) extends Emitter
-
 sealed trait Attribute extends Property {
   val title: String
 }
@@ -33,14 +27,18 @@ object Attribute {
   def apply(title: String, value: String | Boolean) = Attr(title, value)
 }
 
+
 final case class Attr(title: String, value: String | Boolean) extends Attribute
 final case class Prop(title: String, value: String) extends Attribute
 final case class Style(title: String, value: String) extends Attribute
-final case class InsertHook(sink: Observer[Element]) extends Property
-final case class DestroyHook(sink: Observer[Element]) extends Property
-final case class UpdateHook(sink: Observer[(Element, Element)]) extends Property
 final case class Key(value: String) extends Property
 
+sealed trait Hook extends Property
+final case class InsertHook(observer: Observer[Element]) extends Hook
+final case class DestroyHook(observer: Observer[Element]) extends Hook
+final case class UpdateHook(observer: Observer[(Element, Element)]) extends Hook
+
+sealed trait Receiver extends VDomModifier_
 final case class AttributeStreamReceiver(attribute: String, attributeStream: Observable[Attribute]) extends Receiver
 final case class ChildStreamReceiver(childStream: Observable[VNode]) extends Receiver
 final case class ChildrenStreamReceiver(childrenStream: Observable[Seq[VNode]]) extends Receiver

--- a/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -144,7 +144,7 @@ object DomUtils {
 
 
   private[outwatch] final case class SeparatedModifiers(
-    emitters: List[Emitter[_]] = Nil,
+    emitters: List[Emitter] = Nil,
     receivers: List[Receiver] = Nil,
     properties: List[Property] = Nil,
     vNodes: List[VNode_] = Nil
@@ -154,7 +154,7 @@ object DomUtils {
   }
 
   private[outwatch] def separatorFn(mod: VDomModifier_, res: SeparatedModifiers): SeparatedModifiers = (mod, res) match {
-    case (em: Emitter[_], sf) => sf.copy(emitters = em :: sf.emitters)
+    case (em: Emitter, sf) => sf.copy(emitters = em :: sf.emitters)
     case (rc: Receiver, sf) => sf.copy(receivers = rc :: sf.receivers)
     case (pr: Property, sf) => sf.copy(properties = pr :: sf.properties)
     case (vn: VNode_, sf) => sf.copy(vNodes = vn :: sf.vNodes)

--- a/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
+++ b/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
@@ -2,52 +2,44 @@ package outwatch.dom.helpers
 
 import cats.effect.IO
 import org.scalajs.dom._
-import org.scalajs.dom.raw.HTMLInputElement
 import outwatch.Sink
 import outwatch.dom.{DestroyHook, Emitter, Hook, InsertHook, UpdateHook}
 import rxscalajs.{Observable, Observer}
 
-case class EmitterBuilder[E, O](
-  private val eventType: String,
-  private val transform: Observable[E] => Observable[O],
-  private val trigger: (Event, Observer[E]) => Unit
+final case class EmitterBuilder[E, O] private (
+  eventType: String,
+  transform: Observable[E] => Observable[O],
+  trigger: (Event, Observer[E]) => Unit
 ) {
-  def apply[T](mapping: O => T): EmitterBuilder[E, T] = copy(transform = obs => transform(obs).map(mapping))
-  def apply[T](value: T): EmitterBuilder[E, T] = apply(_ => value)
-  def apply[T](latest: Observable[T]): EmitterBuilder[E, T] = copy(transform = obs => transform(obs).withLatestFromWith(latest)((_, u) => u))
+
+  def apply[T](value: T): EmitterBuilder[E, T] = map(_ => value)
+
+  def apply[T](latest: Observable[T]): EmitterBuilder[E, T] = copy(
+    transform = obs => transform(obs).withLatestFromWith(latest)((_, u) => u)
+  )
+
+  @deprecated("Deprecated, use '.map' instead", "0.11.0")
+  def apply[T](f: O => T): EmitterBuilder[E, T] = map(f)
+
+  def map[T](f: O => T): EmitterBuilder[E, T] = copy(transform = obs => transform(obs).map(f))
+
   def filter(predicate: O => Boolean): EmitterBuilder[E, O] = copy(transform = obs => transform(obs).filter(predicate))
 
-  def -->(sink: Sink[_ >: O]): IO[Emitter[E]] = {
+  def -->(sink: Sink[_ >: O]): IO[Emitter] = {
     val observer = sink.redirect(transform).observer
-    IO.pure(Emitter(eventType, observer, event => trigger(event, observer)))
+    IO.pure(Emitter(eventType, event => trigger(event, observer)))
   }
 }
 
 object EmitterBuilder {
-  def apply[E](eventType:String, trigger:(Event,Observer[_ >: E]) => Unit) = {
-    new EmitterBuilder[E,E](eventType, identity, trigger)
-  }
-
-  def event[E <: Event](eventType:String) = apply[E](
-    eventType,
-   (e: Event, o:Observer[_ >: E]) => o.asInstanceOf[Observer[Event]].next(e)
-  )
-  def inputValueAsString(eventType:String) = apply(
-    eventType,
-    (e: Event, o:Observer[_ >: String]) => o.next(e.target.asInstanceOf[HTMLInputElement].value)
-  )
-  def inputCheckedAsBool(eventType:String) = apply(
-    eventType,
-    (e: Event, o:Observer[_ >: Boolean]) => o.next(e.target.asInstanceOf[HTMLInputElement].checked)
-  )
-  def inputValueAsNumber(eventType:String) = apply(
-    eventType,
-    (e: Event, o:Observer[_ >: Double]) => o.next(e.target.asInstanceOf[HTMLInputElement].valueAsNumber)
+  def apply[E <: Event](eventType: String): EmitterBuilder[E, E] = new EmitterBuilder[E, E](
+    eventType, identity, (e, o) => o.next(e.asInstanceOf[E])
   )
 }
 
 trait HookBuilder[E, H <: Hook] {
   def hook(sink: Sink[E]): H
+
   def -->(sink: Sink[E]): IO[H] = IO.pure(hook(sink))
 }
 

--- a/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
+++ b/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
@@ -6,23 +6,23 @@ import outwatch.Sink
 import outwatch.dom.{DestroyHook, Emitter, Hook, InsertHook, UpdateHook}
 import rxscalajs.Observable
 
-final case class EmitterBuilder[E <: Event, O] private (
+final case class TransformingEmitterBuilder[E <: Event, O] private[helpers] (
   eventType: String,
   transform: Observable[E] => Observable[O]
 ) {
 
-  def apply[T](value: T): EmitterBuilder[E, T] = map(_ => value)
+  def apply[T](value: T): TransformingEmitterBuilder[E, T] = map(_ => value)
 
-  def apply[T](latest: Observable[T]): EmitterBuilder[E, T] = copy(
+  def apply[T](latest: Observable[T]): TransformingEmitterBuilder[E, T] = copy(
     transform = obs => transform(obs).withLatestFromWith(latest)((_, u) => u)
   )
 
   @deprecated("Deprecated, use '.map' instead", "0.11.0")
-  def apply[T](f: O => T): EmitterBuilder[E, T] = map(f)
+  def apply[T](f: O => T): TransformingEmitterBuilder[E, T] = map(f)
 
-  def map[T](f: O => T): EmitterBuilder[E, T] = copy(transform = obs => transform(obs).map(f))
+  def map[T](f: O => T): TransformingEmitterBuilder[E, T] = copy(transform = obs => transform(obs).map(f))
 
-  def filter(predicate: O => Boolean): EmitterBuilder[E, O] = copy(transform = obs => transform(obs).filter(predicate))
+  def filter(predicate: O => Boolean): TransformingEmitterBuilder[E, O] = copy(transform = obs => transform(obs).filter(predicate))
 
   def -->(sink: Sink[_ >: O]): IO[Emitter] = {
     val observer = sink.redirect(transform).observer
@@ -30,8 +30,31 @@ final case class EmitterBuilder[E <: Event, O] private (
   }
 }
 
+
+final class EmitterBuilder[E <: Event] private(val eventType: String) extends AnyVal {
+
+  @inline private def create[O](transform: Observable[E] => Observable[O]) = new TransformingEmitterBuilder[E, O](
+    eventType, transform
+  )
+
+  def apply[T](value: T): TransformingEmitterBuilder[E, T] = map(_ => value)
+
+  def apply[T](latest: Observable[T]): TransformingEmitterBuilder[E, T] = create(_.withLatestFromWith(latest)((_, u) => u))
+
+  @deprecated("Deprecated, use '.map' instead", "0.11.0")
+  def apply[T](f: E => T): TransformingEmitterBuilder[E, T] = map(f)
+
+  def map[T](f: E => T): TransformingEmitterBuilder[E, T] = create(_.map(f))
+
+  def filter(predicate: E => Boolean): TransformingEmitterBuilder[E, E] = create(_.filter(predicate))
+
+  def -->(sink: Sink[_ >: E]): IO[Emitter] = {
+    IO.pure(Emitter(eventType, event => sink.observer.next(event.asInstanceOf[E])))
+  }
+}
+
 object EmitterBuilder {
-  def apply[E <: Event](eventType: String) = new EmitterBuilder[E, E]( eventType, identity )
+  def apply[E <: Event](eventType: String) = new EmitterBuilder[E](eventType)
 }
 
 trait HookBuilder[E, H <: Hook] {

--- a/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
+++ b/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
@@ -6,55 +6,54 @@ import outwatch.Sink
 import outwatch.dom.{DestroyHook, Emitter, Hook, InsertHook, UpdateHook}
 import rxscalajs.Observable
 
-final case class TransformingEmitterBuilder[E <: Event, O] private[helpers] (
-  eventType: String,
-  transform: Observable[E] => Observable[O]
-) {
+
+trait EmitterBuilder[E <: Event, O] extends Any {
+
+  def transform[T](tr: Observable[O] => Observable[T]): TransformingEmitterBuilder[E, T]
 
   def apply[T](value: T): TransformingEmitterBuilder[E, T] = map(_ => value)
 
-  def apply[T](latest: Observable[T]): TransformingEmitterBuilder[E, T] = copy(
-    transform = obs => transform(obs).withLatestFromWith(latest)((_, u) => u)
-  )
+  def apply[T](latest: Observable[T]): TransformingEmitterBuilder[E, T] = transform(_.withLatestFromWith(latest)((_, u) => u))
 
   @deprecated("Deprecated, use '.map' instead", "0.11.0")
   def apply[T](f: O => T): TransformingEmitterBuilder[E, T] = map(f)
 
-  def map[T](f: O => T): TransformingEmitterBuilder[E, T] = copy(transform = obs => transform(obs).map(f))
+  def map[T](f: O => T): TransformingEmitterBuilder[E, T] = transform(_.map(f))
 
-  def filter(predicate: O => Boolean): TransformingEmitterBuilder[E, O] = copy(transform = obs => transform(obs).filter(predicate))
+  def filter(predicate: O => Boolean): TransformingEmitterBuilder[E, O] = transform(_.filter(predicate))
+
+  def -->(sink: Sink[_ >: O]): IO[Emitter]
+}
+
+
+object EmitterBuilder {
+  def apply[E <: Event](eventType: String) = new SimpleEmitterBuilder[E](eventType)
+}
+
+
+final case class TransformingEmitterBuilder[E <: Event, O] private[helpers] (
+  eventType: String,
+  transformer: Observable[E] => Observable[O]
+) extends EmitterBuilder[E, O] {
+
+  def transform[T](tr: Observable[O] => Observable[T]): TransformingEmitterBuilder[E, T] = copy(
+    transformer = tr compose transformer
+  )
 
   def -->(sink: Sink[_ >: O]): IO[Emitter] = {
-    val observer = sink.redirect(transform).observer
+    val observer = sink.redirect(transformer).observer
     IO.pure(Emitter(eventType, event => observer.next(event.asInstanceOf[E])))
   }
 }
 
+final class SimpleEmitterBuilder[E <: Event] private[helpers](val eventType: String) extends AnyVal with
+                                                                                             EmitterBuilder[E, E] {
 
-final class EmitterBuilder[E <: Event] private(val eventType: String) extends AnyVal {
-
-  @inline private def create[O](transform: Observable[E] => Observable[O]) = new TransformingEmitterBuilder[E, O](
-    eventType, transform
-  )
-
-  def apply[T](value: T): TransformingEmitterBuilder[E, T] = map(_ => value)
-
-  def apply[T](latest: Observable[T]): TransformingEmitterBuilder[E, T] = create(_.withLatestFromWith(latest)((_, u) => u))
-
-  @deprecated("Deprecated, use '.map' instead", "0.11.0")
-  def apply[T](f: E => T): TransformingEmitterBuilder[E, T] = map(f)
-
-  def map[T](f: E => T): TransformingEmitterBuilder[E, T] = create(_.map(f))
-
-  def filter(predicate: E => Boolean): TransformingEmitterBuilder[E, E] = create(_.filter(predicate))
+  def transform[O](transformer: Observable[E] => Observable[O]) = new TransformingEmitterBuilder[E, O](eventType, transformer)
 
   def -->(sink: Sink[_ >: E]): IO[Emitter] = {
     IO.pure(Emitter(eventType, event => sink.observer.next(event.asInstanceOf[E])))
   }
-}
-
-object EmitterBuilder {
-  def apply[E <: Event](eventType: String) = new EmitterBuilder[E](eventType)
 }
 
 trait HookBuilder[E, H <: Hook] {

--- a/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
+++ b/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
@@ -33,7 +33,7 @@ final case class EmitterBuilder[E, O] private (
 
 object EmitterBuilder {
   def apply[E <: Event](eventType: String): EmitterBuilder[E, E] = new EmitterBuilder[E, E](
-    eventType, identity, (e, o) => o.next(e.asInstanceOf[E])
+    eventType, identity, (e, o) => o.asInstanceOf[Observer[Event]].next(e)
   )
 }
 

--- a/src/main/scala/snabbdom/VDomProxy.scala
+++ b/src/main/scala/snabbdom/VDomProxy.scala
@@ -25,14 +25,14 @@ object VDomProxy {
   }
 
 
-  def emittersToSnabbDom(eventEmitters: Seq[Emitter[_]]): js.Dictionary[js.Function1[Event,Unit]] = {
+  def emittersToSnabbDom(eventEmitters: Seq[Emitter]): js.Dictionary[js.Function1[Event,Unit]] = {
     eventEmitters
       .groupBy(_.eventType)
       .mapValues(emittersToFunction)
       .toJSDictionary
   }
 
-  private def emittersToFunction(emitters: Seq[Emitter[_]]): js.Function1[Event, Unit] = {
+  private def emittersToFunction(emitters: Seq[Emitter]): js.Function1[Event, Unit] = {
     (event: Event) => emitters.foreach(_.trigger(event))
   }
 }

--- a/src/main/scala/snabbdom/VDomProxy.scala
+++ b/src/main/scala/snabbdom/VDomProxy.scala
@@ -1,13 +1,10 @@
 package snabbdom
 
 import org.scalajs.dom._
-import org.scalajs.dom.raw.HTMLInputElement
-import scala.scalajs.js.|
-import outwatch.dom._
-import outwatch.dom.{Attr, Prop}
-import rxscalajs.Observer
+import outwatch.dom.{Attr, Prop, _}
 
 import scala.scalajs.js
+import scala.scalajs.js.|
 
 object VDomProxy {
 
@@ -28,23 +25,14 @@ object VDomProxy {
   }
 
 
-  def emittersToSnabbDom(eventEmitters: Seq[Emitter]): js.Dictionary[js.Function1[Event,Unit]] = {
+  def emittersToSnabbDom(eventEmitters: Seq[Emitter[_]]): js.Dictionary[js.Function1[Event,Unit]] = {
     eventEmitters
       .groupBy(_.eventType)
       .mapValues(emittersToFunction)
       .toJSDictionary
   }
 
-  private def emittersToFunction(emitters: Seq[Emitter]): js.Function1[Event, Unit] = {
-    (e: Event) => emitters.map(emitterToFunction).foreach(_.apply(e))
+  private def emittersToFunction(emitters: Seq[Emitter[_]]): js.Function1[Event, Unit] = {
+    (event: Event) => emitters.foreach(_.trigger(event))
   }
-
-  private def emitterToFunction(emitter: Emitter): Event => Unit = emitter match {
-    case se: StringEventEmitter => (e: Event) => se.sink.next(e.target.asInstanceOf[HTMLInputElement].value)
-    case be: BoolEventEmitter => (e: Event) => be.sink.next(e.target.asInstanceOf[HTMLInputElement].checked)
-    case ne: NumberEventEmitter => (e: Event) => ne.sink.next(e.target.asInstanceOf[HTMLInputElement].valueAsNumber)
-    case ee: EventEmitter[_] => (e: Event) => ee.sink.asInstanceOf[Observer[Event]].next(e)
-  }
-
-
 }

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -214,16 +214,16 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   it should "be able to be transformed by a function in place" in {
     import outwatch.dom._
 
-    val stream = createHandler[(MouseEvent, Int)]().unsafeRunSync()
-
     val number = 42
 
     val toTuple = (e: MouseEvent) => (e, number)
 
-    val node = div(
-      button(id := "click", click.map(toTuple) --> stream),
-      span(id:="num",child <-- stream.map(_._2))
-    )
+    val node = createHandler[(MouseEvent, Int)]().flatMap { stream =>
+      div(
+        button(id := "click", click.map(toTuple) --> stream),
+        span(id := "num", child <-- stream.map(_._2))
+      )
+    }
 
     OutWatch.render("#app", node).unsafeRunSync()
 
@@ -239,14 +239,14 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
   it should "be able to be transformed from strings" in {
     import outwatch.dom._
 
-    val stream = createHandler[Int]().unsafeRunSync()
-
     val number = 42
+    val node = createHandler[Int]().flatMap { stream =>
 
-    val node = div(
-      button(id := "input", inputString(number) --> stream),
-      span(id:="num",child <-- stream)
-    )
+      div(
+        button(id := "input", inputString(number) --> stream),
+        span(id := "num", child <-- stream)
+      )
+    }
 
     OutWatch.render("#app", node).unsafeRunSync()
 
@@ -263,14 +263,13 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
     import outwatch.dom._
     import outwatch.util.SyntaxSugar._
 
-    val stream = createBoolHandler().unsafeRunSync()
-
     val someClass = "some-class"
-
-    val node = div(
-      button(id := "input", tpe := "checkbox", click(true) --> stream),
-      span(id:="toggled", stream ?= (className := someClass))
-    )
+    val node = createBoolHandler().flatMap { stream =>
+      div(
+        button(id := "input", tpe := "checkbox", click(true) --> stream),
+        span(id := "toggled", stream ?= (className := someClass))
+      )
+    }
 
     OutWatch.render("#app", node).unsafeRunSync()
 

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -244,7 +244,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
     val number = 42
 
     val node = div(
-      button(id := "input", inputString(_ => number) --> stream),
+      button(id := "input", inputString((_:String) => number) --> stream),
       span(id:="num",child <-- stream)
     )
 

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -218,10 +218,10 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
 
     val number = 42
 
-    val mapToTuple = (e: MouseEvent) => (e, number)
+    val toTuple = (e: MouseEvent) => (e, number)
 
     val node = div(
-      button(id := "click", click(mapToTuple) --> stream),
+      button(id := "click", click.map(toTuple) --> stream),
       span(id:="num",child <-- stream.map(_._2))
     )
 
@@ -244,7 +244,7 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
     val number = 42
 
     val node = div(
-      button(id := "input", inputString((_:String) => number) --> stream),
+      button(id := "input", inputString(number) --> stream),
       span(id:="num",child <-- stream)
     )
 

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -1,11 +1,10 @@
 package outwatch
 
 import cats.effect.IO
+import org.scalajs.dom.document
 import org.scalajs.dom.raw.{HTMLElement, HTMLInputElement}
-import org.scalajs.dom.{Event, KeyboardEvent, document}
 import org.scalatest.BeforeAndAfterEach
-import outwatch.dom.StringNode
-import outwatch.dom._
+import outwatch.dom.{StringNode, _}
 import outwatch.dom.helpers._
 import rxscalajs.{Observable, Subject}
 import snabbdom.{DataObject, h}
@@ -59,7 +58,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val modifiers = Seq(
       Attribute("class", "red"),
       EmptyVDomModifier,
-      Emitter("click", Subject(), _ => ()),
+      Emitter("click", _ => ()),
       new StringNode("Test"),
       div().unsafeRunSync(),
       AttributeStreamReceiver("hidden",Observable.of())
@@ -77,12 +76,12 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val modifiers = Seq(
       Attribute("class","red"),
       EmptyVDomModifier,
-      Emitter[Event]("click",Subject(), _ => ()),
-      Emitter[InputEvent]("input", Subject(), _ => ()),
+      Emitter("click", _ => ()),
+      Emitter("input",  _ => ()),
       AttributeStreamReceiver("hidden",Observable.of()),
       AttributeStreamReceiver("disabled",Observable.of()),
       ChildrenStreamReceiver(Observable.of()),
-      Emitter[KeyboardEvent]("keyup", Subject(), _ => ())
+      Emitter("keyup",  _ => ())
     )
 
     val DomUtils.SeparatedModifiers(emitters, receivers, properties, children) = DomUtils.separateModifiers(modifiers)
@@ -102,13 +101,13 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val modifiers = Seq(
       Attribute("class","red"),
       EmptyVDomModifier,
-      Emitter[Event]("click",Subject(), _ => ()),
-      Emitter[InputEvent]("input", Subject(), _ => ()),
+      Emitter("click", _ => ()),
+      Emitter("input", _ => ()),
       UpdateHook(Subject()),
       AttributeStreamReceiver("hidden",Observable.of()),
       AttributeStreamReceiver("disabled",Observable.of()),
       ChildrenStreamReceiver(Observable.of()),
-      Emitter[KeyboardEvent]("keyup", Subject(), _ => ()),
+      Emitter("keyup", _ => ()),
       InsertHook(Subject())
     )
 

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -59,7 +59,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val modifiers = Seq(
       Attribute("class", "red"),
       EmptyVDomModifier,
-      EventEmitter("click", Subject()),
+      Emitter("click", Subject(), _ => ()),
       new StringNode("Test"),
       div().unsafeRunSync(),
       AttributeStreamReceiver("hidden",Observable.of())
@@ -77,12 +77,12 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val modifiers = Seq(
       Attribute("class","red"),
       EmptyVDomModifier,
-      EventEmitter[Event]("click",Subject()),
-      EventEmitter[InputEvent]("input", Subject()),
+      Emitter[Event]("click",Subject(), _ => ()),
+      Emitter[InputEvent]("input", Subject(), _ => ()),
       AttributeStreamReceiver("hidden",Observable.of()),
       AttributeStreamReceiver("disabled",Observable.of()),
       ChildrenStreamReceiver(Observable.of()),
-      EventEmitter[KeyboardEvent]("keyup", Subject())
+      Emitter[KeyboardEvent]("keyup", Subject(), _ => ())
     )
 
     val DomUtils.SeparatedModifiers(emitters, receivers, properties, children) = DomUtils.separateModifiers(modifiers)
@@ -102,13 +102,13 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     val modifiers = Seq(
       Attribute("class","red"),
       EmptyVDomModifier,
-      EventEmitter[Event]("click",Subject()),
-      EventEmitter[InputEvent]("input", Subject()),
+      Emitter[Event]("click",Subject(), _ => ()),
+      Emitter[InputEvent]("input", Subject(), _ => ()),
       UpdateHook(Subject()),
       AttributeStreamReceiver("hidden",Observable.of()),
       AttributeStreamReceiver("disabled",Observable.of()),
       ChildrenStreamReceiver(Observable.of()),
-      EventEmitter[KeyboardEvent]("keyup", Subject()),
+      Emitter[KeyboardEvent]("keyup", Subject(), _ => ()),
       InsertHook(Subject())
     )
 


### PR DESCRIPTION
I made `EmitterBuilder` simpler and at the same time more powerful (arbitrarily composable). This allowed me to remove many helper classes like `GenericMappedEmitterBuilder`, `StringEventEmitterBuilder` and `StringEventEmitter` (+ similar ones).

One thing I was not able to resolve yet: More possibilities made the type inference a bit worse, for example:
```scala
button(inputString(_ => number) --> stream), // _ cannot be inferred anymore,
// since arbitrary values are allowed, so the compiler does not know if you want
// to emit a function or transform the event. Therefore you have to write:
button(inputString((_:String) => number) --> stream),
```

Any ideas on the type inference? We could insert values like `inputString.as(number)`.