### PR TITLE
Incorrect child order

### DIFF
--- a/src/main/scala/outwatch/dom/Compat.scala
+++ b/src/main/scala/outwatch/dom/Compat.scala
@@ -3,7 +3,6 @@ package outwatch.dom
 import cats.effect.IO
 import org.scalajs.dom.{ClipboardEvent, DragEvent, KeyboardEvent, MouseEvent}
 
-
 trait Handlers {
   @deprecated("Use Handler.mouseEvents instead", "0.11.0")
   def createMouseHandler() = Handler.create[MouseEvent]

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -36,14 +36,16 @@ final case class InsertHook(observer: Observer[Element]) extends Hook
 final case class DestroyHook(observer: Observer[Element]) extends Hook
 final case class UpdateHook(observer: Observer[(Element, Element)]) extends Hook
 
-sealed trait Receiver extends VDomModifier_
-final case class AttributeStreamReceiver(attribute: String, attributeStream: Observable[Attribute]) extends Receiver
-final case class ChildStreamReceiver(childStream: Observable[VNode]) extends Receiver
-final case class ChildrenStreamReceiver(childrenStream: Observable[Seq[VNode]]) extends Receiver
+final case class AttributeStreamReceiver(attribute: String, attributeStream: Observable[Attribute]) extends VDomModifier_
 
 case object EmptyVDomModifier extends VDomModifier_
 
-sealed trait VNode_ extends VDomModifier_ {
+sealed trait ChildVNode extends VDomModifier_
+
+final case class ChildStreamReceiver(childStream: Observable[VNode]) extends ChildVNode
+final case class ChildrenStreamReceiver(childrenStream: Observable[Seq[VNode]]) extends ChildVNode
+
+sealed trait VNode_ extends ChildVNode {
   // TODO: have apply() only on VTree?
   def apply(args: VDomModifier*): VNode = ???
   // TODO: rename asProxy to asSnabbdom?

--- a/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -2,7 +2,6 @@ package outwatch.dom.helpers
 
 import cats.effect.IO
 import org.scalajs.dom._
-import org.scalajs.dom.html
 import outwatch.dom._
 import rxscalajs.Observable
 import rxscalajs.subjects.BehaviorSubject
@@ -184,7 +183,8 @@ object DomUtils {
   )
   private def extractChildren(nodes: Seq[ChildVNode]): ChildrenNodes = nodes.foldRight(ChildrenNodes()) {
     case (vn: VNode_, cn) => cn.copy(children = vn :: cn.children)
-    case (_, cn) => cn.copy(hasStreams = true)
+    case (_: ChildStreamReceiver, cn) => cn.copy(hasStreams = true)
+    case (_: ChildrenStreamReceiver, cn) => cn.copy(hasStreams = true)
   }
 
   private[outwatch] def extractChildrenAndDataObject(args: Seq[VDomModifier_]): (Seq[VNode_], DataObject) = {


### PR DESCRIPTION
I noticed that when writing

```scala
    val vNode = div(
      "A",
      child <-- messagesA,
      "B",
      child <-- messagesB
    )
```

The order of the children is incorrect. You get `ABxx` instead. I already wrote tests, but don't have an idea for a fix yet.

The tests fail with:
```
[info] - should render child nodes in correct order *** FAILED ***
[info]   "...<span>A</span><span>[B</span><span>1]</span><span>2</span..." was not equal to "...<span>A</span><span>[1</span><span>B]</span><span>2</span..." (OutWatchDomSpec.scala:337)
[info] - should render child string-nodes in correct order *** FAILED ***
[info]   "<div>A[B1]2</div>" was not equal to "<div>A[1B]2</div>" (OutWatchDomSpec.scala:357)
```