### PR TITLE
build ChildStreamReceiver only from VNodes

### DIFF
--- a/src/main/scala/outwatch/VNodeRender.scala
+++ b/src/main/scala/outwatch/VNodeRender.scala
@@ -1,0 +1,24 @@
+package outwatch
+
+import cats.effect.IO
+import outwatch.dom.{StringNode, VNode}
+
+trait VNodeRender[T] {
+  def render(value: T): VNode
+}
+
+object VNodeRender {
+
+  implicit object StringRenderer extends VNodeRender[String] {
+    def render(value: String): VNode = IO.pure(StringNode(value))
+  }
+
+  implicit object IntRenderer extends VNodeRender[Int] {
+    def render(value: Int): VNode = IO.pure(StringNode(value.toString))
+  }
+
+  implicit object DoubleRenderer extends VNodeRender[Double] {
+    def render(value: Double): VNode = IO.pure(StringNode(value.toString))
+  }
+
+}

--- a/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -7,7 +7,6 @@ import outwatch.dom._
 import rxscalajs.Observable
 
 import scala.language.implicitConversions
-import outwatch.dom.StringNode
 
 trait ValueBuilder[T] extends Any {
   protected def attributeName: String
@@ -53,13 +52,8 @@ object KeyBuilder {
 }
 
 object ChildStreamReceiverBuilder {
-  def <--[T <: Any](valueStream: Observable[T]): IO[ChildStreamReceiver] = {
-    IO.pure(ChildStreamReceiver(valueStream.map(anyToVNode)))
-  }
-
-  private val anyToVNode: Any => VNode = {
-    case vn: IO[_] => vn.asInstanceOf[VNode]
-    case any => IO.pure(StringNode(any.toString))
+  def <--[T](valueStream: Observable[T])(implicit conv: T => VNode): IO[ChildStreamReceiver] = {
+    IO.pure(ChildStreamReceiver(valueStream.map(conv)))
   }
 }
 

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -22,7 +22,7 @@ package object dom extends Attributes with Tags with HandlerFactories {
   type Handler[T] = outwatch.Handler[T]
   val Handler = outwatch.Handler
 
-  implicit def stringNode(string: String): VDomModifier = IO.pure(StringNode(string))
+ implicit def renderVNode[T](value: T)(implicit vnr: VNodeRender[T]): VNode = vnr.render(value)
 
   implicit def optionIsEmptyModifier(opt: Option[VDomModifier]): VDomModifier = opt getOrElse IO.pure(EmptyVDomModifier)
 

--- a/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -59,7 +59,7 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
     var switch2 = false
     val sink2 = Sink.create((_: Element) => IO{switch2 = true})
 
-    val node = div(child <-- Observable.of(span(destroy --> sink)(destroy --> sink2), "Hasdasd"))
+    val node = div(child <-- Observable.of[VNode](span(destroy --> sink)(destroy --> sink2), "Hasdasd"))
 
     switch shouldBe false
     switch2 shouldBe false
@@ -76,7 +76,7 @@ class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
     var switch = false
     val sink = Sink.create((_: Element) => IO { switch = true })
 
-    val node = div(child <-- Observable.of(span(destroy --> sink), "Hasdasd"))
+    val node = div(child <-- Observable.of[VNode](span(destroy --> sink), "Hasdasd"))
 
     switch shouldBe false
 


### PR DESCRIPTION
The `ChildStreamReceiverBuilder` accepts `Observable[Any]` which removes type safety and introduces runtime suprises. By accident I can easily write Options, Futures, or other undesired things into the value. This feels like the java-inherited `+` and `any2stringadd` in scala.

I have changed the Builder to only accept types that have an implicit conversion defined. Currently, only strings are automatically converted to `VNode`. So some tests fail as they require `Int` to work, too. Should we define an implicit for primitive types or require an explicit `toString` or what do you expect?