### PR TITLE
Adding Composite VDomModifier

### DIFF
--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -12,9 +12,12 @@ import collection.breakOut
 
 sealed trait VDomModifier_ extends Any
 
+case class CompositeVDomModifier(modifiers: Seq[VDomModifier]) extends VDomModifier_
+
 case class Emitter(eventType: String, trigger: Event => Unit) extends VDomModifier_
 
 sealed trait Property extends VDomModifier_
+
 sealed trait Attribute extends Property {
   val title: String
 }

--- a/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -158,6 +158,15 @@ object DomUtils {
     case (rc: Receiver, sf) => sf.copy(receivers = rc :: sf.receivers)
     case (pr: Property, sf) => sf.copy(properties = pr :: sf.properties)
     case (vn: VNode_, sf) => sf.copy(vNodes = vn :: sf.vNodes)
+    case (vn: CompositeVDomModifier, sf) =>
+      val modifiers = vn.modifiers.map(_.unsafeRunSync())
+      val sm = separateModifiers(modifiers)
+      sf.copy(
+        emitters = sm.emitters ++ sf.emitters,
+        receivers = sm.receivers ++ sf.receivers,
+        properties = sm.properties ++ sf.properties,
+        vNodes = sm.vNodes ++ sf.vNodes,
+      )
     case (EmptyVDomModifier, sf) => sf
   }
 

--- a/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -165,7 +165,7 @@ object DomUtils {
         emitters = sm.emitters ++ sf.emitters,
         receivers = sm.receivers ++ sf.receivers,
         properties = sm.properties ++ sf.properties,
-        vNodes = sm.vNodes ++ sf.vNodes,
+        vNodes = sm.vNodes ++ sf.vNodes
       )
     case (EmptyVDomModifier, sf) => sf
   }

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -26,6 +26,8 @@ package object dom extends Attributes with Tags with HandlerFactories {
 
   implicit def optionIsEmptyModifier(opt: Option[VDomModifier]): VDomModifier = opt getOrElse IO.pure(EmptyVDomModifier)
 
+  implicit def compositeModifier(modifiers: Seq[VDomModifier]): VDomModifier = IO.pure(CompositeVDomModifier(modifiers))
+
   implicit class ioVTreeMerge(vnode: VNode) {
     def apply(args: VDomModifier*): VNode = {
       vnode.flatMap(vnode_ => vnode_(args:_*))

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -61,15 +61,23 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
       Emitter("click", _ => ()),
       new StringNode("Test"),
       div().unsafeRunSync(),
+      CompositeVDomModifier(
+        Seq(
+          div(),
+          Attributes.`class` := "blue",
+          Attributes.click(1) --> Sink.create[Int](_ => IO.pure(())),
+          Attributes.hidden <-- Observable.of(false)
+        )
+      ),
       AttributeStreamReceiver("hidden",Observable.of())
     )
 
     val DomUtils.SeparatedModifiers(emitters, receivers, properties, vNodes) = DomUtils.separateModifiers(modifiers)
 
-    emitters.length shouldBe 1
-    receivers.length shouldBe 1
-    vNodes.length shouldBe 2
-    properties.length shouldBe 1
+    emitters.length shouldBe 2
+    receivers.length shouldBe 2
+    vNodes.length shouldBe 3
+    properties.length shouldBe 2
   }
 
   it should "be separated correctly with children" in {


### PR DESCRIPTION
In some situations I find it useful to have a composite VDomModifier to be able to easily add multiple `VDomModifiers` to a `VNode`. 

In most cases using the varargs `:_*` syntax works fine, but there are cases where a composite `VDomModifier` is useful. For example, consider the case of some component accepting a label as argument. Normally, one would pass in a string `VNode`, but with a composite `VDomModifier` it would be possible to pass in a string `VNode` plus some additional modifiers to apply (change the class of the component containing the label for example).