### PR TITLE
Handle boolean properties

### DIFF
--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -25,8 +25,9 @@ object Attribute {
 
 
 final case class Attr(title: String, value: String | Boolean) extends Attribute
-final case class Prop(title: String, value: String) extends Attribute
+final case class Prop(title: String, value: String | Boolean) extends Attribute
 final case class Style(title: String, value: String) extends Attribute
+
 final case class Key(value: String) extends Property
 
 sealed trait Hook extends Property

--- a/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -28,6 +28,11 @@ final class PropertyBuilder[T](val attributeName: String) extends AnyVal with Va
   @inline protected def assign(value: T) = Prop(attributeName, value.toString)
 }
 
+
+final class BoolPropertyBuilder(val attributeName: String) extends AnyVal with ValueBuilder[Boolean] {
+  @inline protected def assign(value: Boolean) = Prop(attributeName, value)
+}
+
 final class StyleBuilder(val attributeName: String) extends AnyVal with ValueBuilder[String] {
   @inline protected def assign(value: String) = Style(attributeName, value)
 }

--- a/src/main/scala/snabbdom/VDomProxy.scala
+++ b/src/main/scala/snabbdom/VDomProxy.scala
@@ -10,9 +10,9 @@ object VDomProxy {
 
   import js.JSConverters._
 
-  def attrsToSnabbDom(attributes: Seq[Attribute]): (js.Dictionary[String | Boolean], js.Dictionary[String], js.Dictionary[String]) = {
+  def attrsToSnabbDom(attributes: Seq[Attribute]): (js.Dictionary[String | Boolean], js.Dictionary[String | Boolean], js.Dictionary[String]) = {
     val attrsDict = js.Dictionary[String | Boolean]()
-    val propsDict = js.Dictionary[String]()
+    val propsDict = js.Dictionary[String | Boolean]()
     val styleDict = js.Dictionary[String]()
 
     attributes.foreach {

--- a/src/main/scala/snabbdom/h.scala
+++ b/src/main/scala/snabbdom/h.scala
@@ -51,7 +51,7 @@ object Hooks {
 @ScalaJSDefined
 trait DataObject extends js.Object {
   val attrs: js.Dictionary[String | Boolean]
-  val props: js.Dictionary[String]
+  val props: js.Dictionary[String | Boolean]
   val style: js.Dictionary[String]
   val on: js.Dictionary[js.Function1[Event, Unit]]
   val hook: Hooks
@@ -66,7 +66,7 @@ object DataObject {
 
 
   def apply(attrs: js.Dictionary[String | Boolean],
-            props: js.Dictionary[String],
+            props: js.Dictionary[String | Boolean],
             style: js.Dictionary[String],
             on: js.Dictionary[js.Function1[Event, Unit]],
             hook: Hooks,
@@ -82,7 +82,7 @@ object DataObject {
 
     new DataObject {
       val attrs: js.Dictionary[String | Boolean] = _attrs
-      val props: js.Dictionary[String] = _props
+      val props: js.Dictionary[String | Boolean] = _props
       val style: js.Dictionary[String] = _style
       val on: js.Dictionary[js.Function1[Event, Unit]] = _on
       val hook: Hooks = _hook
@@ -91,7 +91,7 @@ object DataObject {
   }
 
   def create(attrs: js.Dictionary[String | Boolean],
-             props: js.Dictionary[String],
+             props: js.Dictionary[String | Boolean],
              style: js.Dictionary[String],
              on: js.Dictionary[js.Function1[Event, Unit]],
              insert: js.Function1[VNodeProxy, Unit],


### PR DESCRIPTION
Same as for attributes, boolean properties must be handled correctly. For example, in the Chrome console:
```
> elem
<input type=​"checkbox" name=​"collab_privs" class=​"js-collab-option" checked>​
> elem.checked
true
> elem.checked = "false"
"false"
> elem.checked
true
> elem.checked = false
false
> elem.checked
false
```