### PR TITLE
disable scalaJSUseMainModuleInitializer option in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,6 +91,4 @@ pomExtra :=
   </developers>
 
 
-scalaJSUseMainModuleInitializer := true
-
 pomIncludeRepository := { _ => false }


### PR DESCRIPTION
we can remove this, because we do not have a main function.