### PR TITLE
custom snabbdom props module

### DIFF
--- a/src/main/resources/snabbdom-custom-props.js
+++ b/src/main/resources/snabbdom-custom-props.js
@@ -1,0 +1,33 @@
+"use strict";
+
+// original: https://github.com/snabbdom/snabbdom/blob/master/src/modules/props.ts
+
+function updateProps(oldVnode, vnode) {
+    var key, cur, old, elm = vnode.elm, oldProps = oldVnode.data.props, props = vnode.data.props;
+
+    if (!oldProps && !props) return;
+    if (oldProps === props) return;
+    oldProps = oldProps || {};
+    props = props || {};
+
+    for (key in oldProps) {
+        if (!props[key]) {
+            delete elm[key];
+        }
+    }
+
+    for (key in props) {
+        cur = props[key];
+        old = elm[key];
+        if (old !== cur) {
+            elm[key] = cur;
+        }
+    }
+}
+
+module.exports = {
+    default: {
+        create: updateProps,
+        update: updateProps
+    }
+};

--- a/src/main/scala/snabbdom/h.scala
+++ b/src/main/scala/snabbdom/h.scala
@@ -136,7 +136,7 @@ object patch {
     SnabbdomClass.default,
     SnabbdomEventListeners.default,
     SnabbdomAttributes.default,
-    SnabbdomProps.default,
+    SnabbdomCustomProps.default,
     SnabbdomStyle.default
   ))
 
@@ -183,11 +183,20 @@ object SnabbdomAttributes extends js.Object{
   val default: js.Any = js.native
 }
 
+// forked snabbdom-props module where the ground-thruth is the dom
 @js.native
-@JSImport("snabbdom/modules/props", JSImport.Namespace, globalFallback = "snabbdom_props")
-object SnabbdomProps extends js.Object{
+@JSImport("./snabbdom-custom-props", JSImport.Namespace)
+object SnabbdomCustomProps extends js.Object {
   val default: js.Any = js.native
 }
+
+// original snabbdom-props
+// @js.native
+// @JSImport("snabbdom/modules/props", JSImport.Namespace, globalFallback = "snabbdom_props")
+// object SnabbdomProps extends js.Object{
+//   val default: js.Any = js.native
+// }
+
 
 @js.native
 @JSImport("snabbdom/modules/style", JSImport.Namespace, globalFallback = "snabbdom_style")

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -132,6 +132,44 @@ class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks 
 
     patched.value shouldBe ""
   }
+  it should "preserve user input after setting defaultValue" in {
+    val defaultValues = Subject[String]
+
+    val vtree = input(id:= "input", outwatch.dom.defaultValue <-- defaultValues)
+    OutWatch.render("#app", vtree).unsafeRunSync()
+
+    val patched = document.getElementById("input").asInstanceOf[html.Input]
+    patched.value shouldBe ""
+
+    val value1 = "Hello"
+    defaultValues.next(value1)
+    patched.value shouldBe value1
+
+    val userInput = "user input"
+    patched.value = userInput
+
+    defaultValues.next("GoodByte")
+    patched.value shouldBe userInput
+  }
+
+  it should "set input value to the same value after user change" in {
+    val values = Subject[String]
+
+    val vtree = input(id:= "input", outwatch.dom.value <-- values)
+    OutWatch.render("#app", vtree).unsafeRunSync()
+
+    val patched = document.getElementById("input").asInstanceOf[html.Input]
+    patched.value shouldBe ""
+
+    val value1 = "Hello"
+    values.next(value1)
+    patched.value shouldBe value1
+
+    patched.value = "user input"
+
+    values.next("Hello")
+    patched.value shouldBe value1
+  }
 
   it should "be bindable to a list of children" in {
 


### PR DESCRIPTION
As discussed in #105, this adds a custom snabbdom props module, which compares against the actual element property.

**Please do not merge**, as I think, the generated code for scala-js is not as performant as a pure javascript implementation. So, we should implement this module in js and somehow include it with scalajs-bundler/webpack.

What do you think?