### PR TITLE
Child/children node streams optimisations 

### DIFF
--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import org.scalajs.dom._
 import outwatch.dom.helpers.DomUtils
 import rxscalajs.Observer
-import snabbdom.{DataObject, VNodeProxy, h}
+import snabbdom.{DataObject, VNodeProxy, hFunction}
 
 import scala.scalajs.js
 import collection.breakOut
@@ -25,11 +25,21 @@ object Attribute {
 }
 
 final case class Attr(title: String, value: Attr.Value) extends Attribute
-object Attr { type Value = DataObject.AttrValue }
+object Attr {
+  type Value = DataObject.AttrValue
+}
+
 final case class Prop(title: String, value: Prop.Value) extends Attribute
-object Prop { type Value = DataObject.PropValue }
+object Prop {
+  type Value = DataObject.PropValue
+}
+
 final case class Style(title: String, value: String) extends Attribute
-final case class Key(value: String) extends Property
+
+final case class Key(value: Key.Value) extends Property
+object Key {
+  type Value = DataObject.KeyValue
+}
 
 sealed trait Hook extends Property
 final case class InsertHook(observer: Observer[Element]) extends Hook
@@ -53,8 +63,8 @@ sealed trait VNode_ extends ChildVNode {
 }
 
 //TODO: extends AnyVal
-private[outwatch] case class StringNode(string: String) extends VNode_ {
-  val asProxy: VNodeProxy = VNodeProxy.fromString(string)
+private[outwatch] final case class StringNode(string: String) extends VNode_ {
+  override val asProxy: VNodeProxy = VNodeProxy.fromString(string)
 }
 
 // TODO: instead of Seq[VDomModifier] use Vector or JSArray?
@@ -63,19 +73,19 @@ private[outwatch] case class StringNode(string: String) extends VNode_ {
 private[outwatch] final case class VTree(nodeType: String,
                        modifiers: Seq[VDomModifier]) extends VNode_ {
 
-  def asProxy = {
+  override def apply(args: VDomModifier*) = IO.pure(VTree(nodeType, modifiers ++ args))
+
+  override def asProxy = {
     val modifiers_ = modifiers.map(_.unsafeRunSync())
     val (children, attributeObject) = DomUtils.extractChildrenAndDataObject(modifiers_)
     //TODO: use .sequence instead of unsafeRunSync?
     // import cats.instances.list._
     // import cats.syntax.traverse._
     // for { childProxies <- children.map(_.value).sequence }
-    // yield h(nodeType, attributeObject, childProxies.map(_.apsProxy)(breakOut))
+    // yield hFunction(nodeType, attributeObject, childProxies.map(_.apsProxy)(breakOut))
     val childProxies: js.Array[VNodeProxy] = children.map(_.asProxy)(breakOut)
-    h(nodeType, attributeObject, childProxies)
+    hFunction(nodeType, attributeObject, childProxies)
   }
-
-  override def apply(args: VDomModifier*) = IO.pure(VTree(nodeType, modifiers ++ args))
 }
 
 

--- a/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -46,7 +46,7 @@ final class DynamicAttributeBuilder[T](parts: List[String]) extends Dynamic with
 }
 
 object KeyBuilder {
-  def :=(key: String) = IO.pure(Key(key))
+  def :=(key: Key.Value) = IO.pure(Key(key))
 }
 
 object ChildStreamReceiverBuilder {

--- a/src/main/scala/snabbdom/hFunction.scala
+++ b/src/main/scala/snabbdom/hFunction.scala
@@ -15,11 +15,15 @@ object hProvider extends js.Object {
 
 @js.native
 trait hFunction extends js.Any {
-  def apply(nodeType: String, dataObject: DataObject, children: String | js.Array[_ <: Any]): VNodeProxy = js.native
+  def apply(nodeType: String, dataObject: DataObject, text: String): VNodeProxy = js.native
+  def apply(nodeType: String, dataObject: DataObject, children: js.Array[VNodeProxy]): VNodeProxy = js.native
 }
 
-object h {
-  def apply(nodeType: String, dataObject: DataObject, children: String | js.Array[_ <: Any]): VNodeProxy = {
+object hFunction {
+  def apply(nodeType: String, dataObject: DataObject, text: String): VNodeProxy = {
+    hProvider.default.apply(nodeType, dataObject, text)
+  }
+  def apply(nodeType: String, dataObject: DataObject, children: js.Array[VNodeProxy]): VNodeProxy = {
     hProvider.default.apply(nodeType, dataObject, children)
   }
 }
@@ -57,13 +61,14 @@ trait DataObject extends js.Object {
   val style: js.Dictionary[String]
   val on: js.Dictionary[js.Function1[Event, Unit]]
   val hook: Hooks
-  val key: js.UndefOr[String | Int]
+  val key: js.UndefOr[KeyValue]
 }
 
 object DataObject {
 
   type PropValue = Any
   type AttrValue = String | Boolean
+  type KeyValue = String | Double  // https://github.com/snabbdom/snabbdom#key--string--number
 
   def apply(attrs: js.Dictionary[AttrValue],
             on: js.Dictionary[js.Function1[Event, Unit]]
@@ -75,7 +80,7 @@ object DataObject {
             style: js.Dictionary[String],
             on: js.Dictionary[js.Function1[Event, Unit]],
             hook: Hooks,
-            key: js.UndefOr[String | Int]
+            key: js.UndefOr[KeyValue]
            ): DataObject = {
 
     val _attrs = attrs
@@ -91,7 +96,7 @@ object DataObject {
       val style: js.Dictionary[String] = _style
       val on: js.Dictionary[js.Function1[Event, Unit]] = _on
       val hook: Hooks = _hook
-      val key: UndefOr[String | Int] = _key
+      val key: UndefOr[KeyValue] = _key
     }
   }
 
@@ -102,7 +107,7 @@ object DataObject {
              insert: js.Function1[VNodeProxy, Unit],
              destroy: js.Function1[VNodeProxy, Unit],
              update: js.Function2[VNodeProxy, VNodeProxy, Unit],
-             key: js.UndefOr[String | Int]
+             key: js.UndefOr[KeyValue]
             ): DataObject = {
 
     DataObject(

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.BeforeAndAfterEach
 import outwatch.dom.{StringNode, _}
 import outwatch.dom.helpers._
 import rxscalajs.{Observable, Subject}
-import snabbdom.{DataObject, h}
+import snabbdom.{DataObject, VNodeProxy, hFunction}
 
 import scala.collection.immutable.Seq
 import scala.scalajs.js
@@ -114,8 +114,8 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
   }
 
   val fixture = new {
-    val proxy = h("div", DataObject(js.Dictionary("class" -> "red", "id" -> "msg"), js.Dictionary()), js.Array(
-      h("span", DataObject(js.Dictionary(), js.Dictionary()), js.Array("Hello"))
+    val proxy = hFunction("div", DataObject(js.Dictionary("class" -> "red", "id" -> "msg"), js.Dictionary()), js.Array(
+      hFunction("span", DataObject(js.Dictionary(), js.Dictionary()), js.Array(VNodeProxy.fromString("Hello")))
     ))
   }
 
@@ -240,7 +240,7 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
     )
 
     val attrs = js.Dictionary[dom.Attr.Value]("a" -> true, "b" -> true, "c" -> false, "d" -> "true", "e" -> "true", "f" -> "false")
-    val expected = h("div", DataObject(attrs, js.Dictionary()), js.Array[Any]())
+    val expected = hFunction("div", DataObject(attrs, js.Dictionary()), js.Array[VNodeProxy]())
 
     JSON.stringify(vtree.map(_.asProxy).unsafeRunSync()) shouldBe JSON.stringify(expected)
 

--- a/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -1,6 +1,6 @@
 package outwatch
 
-import snabbdom.{DataObject, h, patch}
+import snabbdom.{DataObject, hFunction, patch}
 
 import scalajs.js
 import org.scalajs.dom.document
@@ -11,7 +11,7 @@ import Deprecated.IgnoreWarnings.initEvent
 class SnabbdomSpec extends UnitSpec {
   "The Snabbdom Facade" should "correctly patch the DOM" in {
     val message = "Hello World"
-    val vNode = h("span#msg", DataObject(js.Dictionary(), js.Dictionary()), message)
+    val vNode = hFunction("span#msg", DataObject(js.Dictionary(), js.Dictionary()), message)
 
     val node = document.createElement("div")
     document.body.appendChild(node)
@@ -21,7 +21,7 @@ class SnabbdomSpec extends UnitSpec {
     document.getElementById("msg").innerHTML shouldBe message
 
     val newMessage = "Hello Snabbdom!"
-    val newNode = h("div#new", DataObject(js.Dictionary(), js.Dictionary()), newMessage)
+    val newNode = hFunction("div#new", DataObject(js.Dictionary(), js.Dictionary()), newMessage)
 
     patch(vNode, newNode)
 
@@ -65,7 +65,7 @@ class SnabbdomSpec extends UnitSpec {
   it should "correctly handle boolean attributes" in {
     val message = "Hello World"
     val attributes = js.Dictionary[dom.Attr.Value]("bool1" -> true, "bool0" -> false, "string1" -> "true", "string0" -> "false")
-    val vNode = h("span#msg", DataObject(attributes, js.Dictionary()), message)
+    val vNode = hFunction("span#msg", DataObject(attributes, js.Dictionary()), message)
 
     val node = document.createElement("div")
     document.body.appendChild(node)


### PR DESCRIPTION
This PR fixes an issue that caused static nodes to be destroyed/re-inserted when the first `child`/`children` element was emitted.

It also ensures that no `Seq.empty[VNode]` is emitted at the beginning of the `children` stream  when a single `children` stream is present in the node (the common case).

