### PR TITLE
Hooks optimisations and refactorings

### DIFF
--- a/src/main/scala/outwatch/dom/OutwatchAttributes.scala
+++ b/src/main/scala/outwatch/dom/OutwatchAttributes.scala
@@ -26,13 +26,33 @@ trait OutWatchChildAttributes {
 
 /** Outwatch component life cycle hooks. */
 trait OutWatchLifeCycleAttributes {
-  /** Lifecycle hook for component insertion. */
+  /**
+    * Lifecycle hook for component insertion.
+    *
+    * This hook is invoked once the DOM element for a vnode has been inserted into the document
+    * and the rest of the patch cycle is done.
+    */
   lazy val insert   = InsertHookBuilder
+
+  /** Lifecycle hook for component prepatch. */
+  lazy val prepatch   = PrePatchHookBuilder
 
   /** Lifecycle hook for component updates. */
   lazy val update   = UpdateHookBuilder
 
-  /** Lifecycle hook for component destruction. */
+  /**
+    * Lifecycle hook for component postpatch.
+    *
+    *  This hook is invoked every time a node has been patched against an older instance of itself.
+    */
+  lazy val postpatch   = PostPatchHookBuilder
+
+  /**
+    * Lifecycle hook for component destruction.
+    *
+    * This hook is invoked on a virtual node when its DOM element is removed from the DOM
+    * or if its parent is being removed from the DOM.
+    */
   lazy val destroy  = DestroyHookBuilder
 }
 

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -41,10 +41,17 @@ object Key {
   type Value = DataObject.KeyValue
 }
 
-sealed trait Hook extends Property
-final case class InsertHook(observer: Observer[Element]) extends Hook
-final case class DestroyHook(observer: Observer[Element]) extends Hook
-final case class UpdateHook(observer: Observer[(Element, Element)]) extends Hook
+sealed trait Hook[T] extends Property {
+  def observer: Observer[T]
+}
+
+private[outwatch] final case class InsertHook(observer: Observer[Element]) extends Hook[Element]
+private[outwatch] final case class PrePatchHook(observer: Observer[(Option[Element], Option[Element])])
+  extends Hook[(Option[Element], Option[Element])]
+private[outwatch] final case class UpdateHook(observer: Observer[(Element, Element)]) extends Hook[(Element, Element)]
+private[outwatch] final case class PostPatchHook(observer: Observer[(Element, Element)]) extends Hook[(Element, Element)]
+private[outwatch] final case class DestroyHook(observer: Observer[Element]) extends Hook[Element]
+
 
 final case class AttributeStreamReceiver(attribute: String, attributeStream: Observable[Attribute]) extends VDomModifier_
 

--- a/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
+++ b/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
@@ -3,7 +3,7 @@ package outwatch.dom.helpers
 import cats.effect.IO
 import org.scalajs.dom._
 import outwatch.Sink
-import outwatch.dom.{DestroyHook, Emitter, Hook, InsertHook, UpdateHook}
+import outwatch.dom.{DestroyHook, Emitter, Hook, InsertHook, PostPatchHook, PrePatchHook, UpdateHook}
 import rxscalajs.Observable
 
 
@@ -58,7 +58,7 @@ final class SimpleEmitterBuilder[E <: Event] private[helpers](
   }
 }
 
-trait HookBuilder[E, H <: Hook] {
+trait HookBuilder[E, H <: Hook[_]] {
   def hook(sink: Sink[E]): H
 
   def -->(sink: Sink[E]): IO[H] = IO.pure(hook(sink))
@@ -68,10 +68,18 @@ object InsertHookBuilder extends HookBuilder[Element, InsertHook] {
   def hook(sink: Sink[Element]) = InsertHook(sink.observer)
 }
 
-object DestroyHookBuilder extends HookBuilder[Element, DestroyHook] {
-  def hook(sink: Sink[Element]) = DestroyHook(sink.observer)
+object PrePatchHookBuilder extends HookBuilder[(Option[Element], Option[Element]), PrePatchHook] {
+  def hook(sink: Sink[(Option[Element], Option[Element])]) = PrePatchHook(sink.observer)
 }
 
 object UpdateHookBuilder extends HookBuilder[(Element, Element), UpdateHook] {
   def hook(sink: Sink[(Element, Element)]) = UpdateHook(sink.observer)
+}
+
+object PostPatchHookBuilder extends HookBuilder[(Element, Element), PostPatchHook] {
+  def hook(sink: Sink[(Element, Element)]) = PostPatchHook(sink.observer)
+}
+
+object DestroyHookBuilder extends HookBuilder[Element, DestroyHook] {
+  def hook(sink: Sink[Element]) = DestroyHook(sink.observer)
 }

--- a/src/main/scala/snabbdom/hFunction.scala
+++ b/src/main/scala/snabbdom/hFunction.scala
@@ -31,23 +31,35 @@ object hFunction {
 
 @ScalaJSDefined
 trait Hooks extends js.Object {
-  val insert: js.UndefOr[js.Function1[VNodeProxy, Unit]]
-  val destroy: js.UndefOr[js.Function1[VNodeProxy, Unit]]
-  val update: js.UndefOr[js.Function2[VNodeProxy, VNodeProxy, Unit]]
+  val insert: js.UndefOr[Hooks.HookSingleFn]
+  val prepatch: js.UndefOr[Hooks.HookPairFn]
+  val update: js.UndefOr[Hooks.HookPairFn]
+  val postpatch: js.UndefOr[Hooks.HookPairFn]
+  val destroy: js.UndefOr[Hooks.HookSingleFn]
 }
 
 object Hooks {
-  def apply(insert: js.UndefOr[js.Function1[VNodeProxy, Unit]] = js.undefined,
-            destroy: js.UndefOr[js.Function1[VNodeProxy, Unit]] = js.undefined,
-            update: js.UndefOr[js.Function2[VNodeProxy, VNodeProxy, Unit]] = js.undefined
-           ): Hooks = {
+  type HookSingleFn = js.Function1[VNodeProxy, Unit]
+  type HookPairFn = js.Function2[VNodeProxy, VNodeProxy, Unit]
+
+  def apply(
+    insert: js.UndefOr[HookSingleFn] = js.undefined,
+    prepatch: js.UndefOr[HookPairFn] = js.undefined,
+    update: js.UndefOr[HookPairFn] = js.undefined,
+    postpatch: js.UndefOr[HookPairFn] = js.undefined,
+    destroy: js.UndefOr[HookSingleFn] = js.undefined
+  ): Hooks = {
     val _insert = insert
-    val _destroy = destroy
+    val _prepatch = prepatch
     val _update = update
+    val _postpatch = postpatch
+    val _destroy = destroy
     new Hooks {
       val insert = _insert
-      val destroy = _destroy
+      val prepatch = _prepatch
       val update = _update
+      val postpatch = _postpatch
+      val destroy = _destroy
     }
   }
 }
@@ -71,8 +83,9 @@ object DataObject {
   type KeyValue = String | Double  // https://github.com/snabbdom/snabbdom#key--string--number
 
   def apply(attrs: js.Dictionary[AttrValue],
-            on: js.Dictionary[js.Function1[Event, Unit]]
-           ): DataObject = apply(attrs, js.Dictionary.empty, js.Dictionary.empty, on, Hooks(), js.undefined)
+            on: js.Dictionary[js.Function1[Event, Unit]],
+            hooks : Hooks = Hooks()
+           ): DataObject = apply(attrs, js.Dictionary.empty, js.Dictionary.empty, on, hooks, js.undefined)
 
 
   def apply(attrs: js.Dictionary[AttrValue],
@@ -98,26 +111,6 @@ object DataObject {
       val hook: Hooks = _hook
       val key: UndefOr[KeyValue] = _key
     }
-  }
-
-  def create(attrs: js.Dictionary[AttrValue],
-             props: js.Dictionary[PropValue],
-             style: js.Dictionary[String],
-             on: js.Dictionary[js.Function1[Event, Unit]],
-             insert: js.Function1[VNodeProxy, Unit],
-             destroy: js.Function1[VNodeProxy, Unit],
-             update: js.Function2[VNodeProxy, VNodeProxy, Unit],
-             key: js.UndefOr[KeyValue]
-            ): DataObject = {
-
-    DataObject(
-      attrs = attrs,
-      props = props,
-      style = style,
-      on = on,
-      hook = Hooks(insert = insert, destroy = destroy, update = update),
-      key = key
-    )
   }
 
   implicit class DataObjectExt(val obj: DataObject) extends AnyVal {

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -25,14 +25,18 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
       InsertHook(Subject()),
       UpdateHook(Subject()),
       InsertHook(Subject()),
-      DestroyHook(Subject())
+      DestroyHook(Subject()),
+      PrePatchHook(Subject()),
+      PostPatchHook(Subject())
     )
 
-    val DomUtils.SeparatedProperties(inserts, deletes, updates, attributes, keys) = DomUtils.separateProperties(properties)
+    val DomUtils.SeparatedProperties(inserts, prepatch, updates, postpatch, deletes, attributes, keys) = DomUtils.separateProperties(properties)
 
     inserts.length shouldBe 2
-    deletes.length shouldBe 1
+    prepatch.length shouldBe 1
     updates.length shouldBe 1
+    postpatch.length shouldBe 1
+    deletes.length shouldBe 1
     attributes.length shouldBe 1
     keys.length shouldBe 0
   }
@@ -94,18 +98,22 @@ class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
       AttributeStreamReceiver("disabled",Observable.of()),
       ChildrenStreamReceiver(Observable.of()),
       Emitter("keyup", _ => ()),
-      InsertHook(Subject())
+      InsertHook(Subject()),
+      PrePatchHook(Subject()),
+      PostPatchHook(Subject())
     )
 
     val DomUtils.SeparatedModifiers(emitters, receivers, properties, children) = DomUtils.separateModifiers(modifiers)
 
+    val DomUtils.SeparatedProperties(inserts, prepatch, updates, postpatch, deletes, attributes, keys) = DomUtils.separateProperties(properties)
 
-    val DomUtils.SeparatedProperties(inserts, deletes, updates, attributes, keys) = DomUtils.separateProperties(properties)
-
+    emitters.map(_.eventType) shouldBe List("click", "input", "keyup")
     emitters.length shouldBe 3
     inserts.length shouldBe 1
-    deletes.length shouldBe 0
+    prepatch.length shouldBe 1
     updates.length shouldBe 1
+    postpatch.length shouldBe 1
+    deletes.length shouldBe 0
     attributes.length shouldBe 1
     receivers.length shouldBe 2
     children.length shouldBe 1


### PR DESCRIPTION
Currently, even if there are no hook sinks present on a `VNode`, there are empty insert/update/create hooks created for all the `VNode`s. This PR leaves the hooks as `undefined` in case there are no hook sinks present.

The PR also adds support for the `prepatch`/`postpatch` hooks. I needed `postpatch` for frameworks such [Material Design Lite](https://getmdl.io/) and [Materialize](http://materializecss.com/) that require dynamic components to be "upgraded" after they are inserted in the DOM (using the `update` hooks did not work, the "upgrading" has to happen after the snabbdom patch is completed).