### PR TITLE
Add support for accumulated attributes (className in particular)

### DIFF
--- a/src/main/scala/outwatch/dom/Compat.scala
+++ b/src/main/scala/outwatch/dom/Compat.scala
@@ -27,6 +27,7 @@ trait Handlers {
 object Handlers extends Handlers
 
 trait AttributesCompat { self: Attributes =>
+
   @deprecated("Use `type`, tpe or typ instead", "0.11.0")
   lazy val inputType = tpe
 

--- a/src/main/scala/outwatch/dom/DomTypes.scala
+++ b/src/main/scala/outwatch/dom/DomTypes.scala
@@ -27,7 +27,7 @@ private[outwatch] object DomTypesBuilder {
   }
 
   object CodecBuilder {
-    type Attribute[T, _] = AttributeBuilder[T]
+    type Attribute[T, _] = ValueBuilder[T, Attr]
     type Property[T, _] = PropertyBuilder[T]
 
     def encodeAttribute[V](codec: Codec[V, String]): V => Attr.Value = codec match {
@@ -95,13 +95,18 @@ trait ReflectedAttrs
   extends reflectedAttrs.ReflectedAttrs[CodecBuilder.Attribute]
   with ReflectedAttrBuilder[CodecBuilder.Attribute] {
 
+  // super.className.accum(" ") would have been nicer, but we can't do super.className on a lazy val
+  override lazy val className = new AccumAttributeBuilder[String]("class",
+    stringReflectedAttr(attrKey = "class", propKey = "className"),
+    _ + " " + _
+  )
+
   override protected def reflectedAttr[V, DomPropV](
     attrKey: String,
     propKey: String,
     attrCodec: Codec[V, String],
     propCodec: Codec[V, DomPropV]
-  ): AttributeBuilder[V] =
-    new AttributeBuilder(attrKey, CodecBuilder.encodeAttribute(attrCodec))
+  ) = new AttributeBuilder(attrKey, CodecBuilder.encodeAttribute(attrCodec))
     //or: new PropertyBuilder(propKey, propCodec.encode)
 }
 

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -15,6 +15,8 @@ VDomModifier_
     Attribute
       TitledAttribute
         Attr
+          BasicAttr
+          AccumAttr
         Prop
         Style
       EmptyAttribute
@@ -66,7 +68,7 @@ object Key {
 
 sealed trait Attribute extends Property
 object Attribute {
-  def apply(title: String, value: Attr.Value) = Attr(title, value)
+  def apply(title: String, value: Attr.Value): Attribute = BasicAttr(title, value)
 }
 
 
@@ -82,10 +84,20 @@ sealed trait TitledAttribute extends Attribute {
   val title: String
 }
 
-final case class Attr(title: String, value: Attr.Value) extends TitledAttribute
+
+sealed trait Attr extends TitledAttribute {
+  val value: Attr.Value
+}
 object Attr {
   type Value = DataObject.AttrValue
 }
+
+final case class BasicAttr(title: String, value: Attr.Value) extends Attr
+
+/**
+  * Attribute that accumulates the previous value in the same VNode with it's value
+  */
+final case class AccumAttr(title: String, value: Attr.Value, accum: (Attr.Value, Attr.Value)=> Attr.Value) extends Attr
 
 final case class Prop(title: String, value: Prop.Value) extends TitledAttribute
 object Prop {

--- a/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
+++ b/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
@@ -5,7 +5,8 @@ import monix.execution.Ack.Continue
 import monix.execution.Scheduler
 import monix.execution.cancelables.SingleAssignmentCancelable
 import org.scalajs.dom
-import outwatch.dom.{Attr, Attribute, DestroyHook, Emitter, EmptyAttribute, Hook, InsertHook, Key, Prop, StaticVNode, Style}
+
+import outwatch.dom._
 import snabbdom._
 
 import scala.scalajs.js.JSConverters._
@@ -22,7 +23,8 @@ private[outwatch] trait SnabbdomAttributes { self: SeparatedAttributes =>
     val styleDict = js.Dictionary[String]()
 
     attributes.foreach {
-      case a: Attr => attrsDict(a.title) = a.value
+      case a: BasicAttr => attrsDict(a.title) = a.value
+      case a: AccumAttr => attrsDict(a.title) = attrsDict.get(a.title).map(a.accum(_, a.value)).getOrElse(a.value)
       case p: Prop => propsDict(p.title) = p.value
       case s: Style => styleDict(s.title) = s.value
       case EmptyAttribute =>

--- a/src/test/scala/outwatch/AttributeSpec.scala
+++ b/src/test/scala/outwatch/AttributeSpec.scala
@@ -5,6 +5,36 @@ import outwatch.dom.dsl._
 
 class AttributeSpec extends JSDomSpec {
 
+  "class attributes" should "be accumulated" in {
+
+    val node = input(
+      className := "class1",
+      cls := "class2"
+    ).map(_.asProxy).unsafeRunSync()
+
+    node.data.attrs.toList shouldBe List("class" -> "class1 class2")
+  }
+
+  "custom attributes" should "be able to be accumulated" in {
+
+    val node = input(
+      attr("id").accum(",") := "foo1",
+      attr("id").accum(",") := "foo2"
+    ).map(_.asProxy).unsafeRunSync()
+
+    node.data.attrs.toList shouldBe List("id" -> "foo1,foo2")
+  }
+
+  "data attributes" should "be able to be accumulated" in {
+
+    val node = input(
+      data.foo.accum(",") := "foo1",
+      data.foo.accum(",") := "foo2"
+    ).map(_.asProxy).unsafeRunSync()
+
+    node.data.attrs.toList shouldBe List("data-foo" -> "foo1,foo2")
+  }
+
   "data attribute" should "correctly render only Data" in {
     val node = input(
       data.geul := "bar",

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -732,4 +732,21 @@ class OutWatchDomSpec extends JSDomSpec {
 
     node.innerHTML shouldBe "<div><main></main></div>"
   }
+
+  it should "work with un-assigned booleans attributes and props" in {
+
+    val vNode = option(selected, disabled)
+
+    val node = document.createElement("option").asInstanceOf[html.Option]
+    document.body.appendChild(node)
+
+    node.selected shouldBe false
+    node.disabled shouldBe false
+
+    OutWatch.renderReplace(node, vNode).unsafeRunSync()
+
+    node.selected shouldBe true
+    node.disabled shouldBe true
+  }
+
 }


### PR DESCRIPTION
This PR adds support for attributes that can be accumulated within the same `VNode`, in particular for accumulating `className`s within a `VNode`.

I often find this useful when I'm using some component and I want to pass in some additional `className` modifier to the component without overriding the class(es) that the component already uses.

For example:

```scala

def component(modifiers: VDomModifier*): VNode

val disabled = classAccum := "disabled-class"

if (someCondition) component(modifiers: _*) else component( (disabled +: modifiers) : _*)
```

