### PR TITLE
Fix cleanup of jsdom environment

### DIFF
--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -1,25 +1,11 @@
 package outwatch
 
 import org.scalajs.dom._
-import org.scalatest.BeforeAndAfterEach
-import org.scalatest.prop.PropertyChecks
-import rxscalajs.Subject
+import outwatch.Deprecated.IgnoreWarnings.initEvent
 import outwatch.dom._
+import rxscalajs.Subject
 
-import Deprecated.IgnoreWarnings.initEvent
-
-class DomEventSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks {
-
-  override def beforeEach(): Unit = {
-    val root = document.createElement("div")
-    root.id = "app"
-    document.body.appendChild(root)
-    ()
-  }
-
-  override def afterEach(): Unit = {
-    document.body.innerHTML = ""
-  }
+class DomEventSpec extends JSDomSpec {
 
   "EventStreams" should "emit and receive events correctly" in {
 

--- a/src/test/scala/outwatch/HandlerSpec.scala
+++ b/src/test/scala/outwatch/HandlerSpec.scala
@@ -1,9 +1,6 @@
 package outwatch
 
-import org.scalatest.BeforeAndAfterEach
-import org.scalatest.prop.PropertyChecks
-
-class HandlerSpec extends UnitSpec with BeforeAndAfterEach with PropertyChecks {
+class HandlerSpec extends UnitSpec {
   "Handler" should "lens" in {
     val handler = Handler.create[(String, Int)].unsafeRunSync()
     val lensed = handler.lens[Int](("harals", 0))(_._2)((tuple, num) => (tuple._1, num))

--- a/src/test/scala/outwatch/JSDomSpec.scala
+++ b/src/test/scala/outwatch/JSDomSpec.scala
@@ -1,0 +1,16 @@
+package outwatch
+
+
+import org.scalajs.dom._
+import org.scalatest.BeforeAndAfterEach
+
+
+abstract class JSDomSpec extends UnitSpec with BeforeAndAfterEach {
+  override def beforeEach(): Unit = {
+    document.body.innerHTML = ""
+
+    val root = document.createElement("div")
+    root.id = "app"
+    document.body.appendChild(root)
+  }
+}

--- a/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -2,24 +2,12 @@ package outwatch
 
 import cats.effect.IO
 import org.scalajs.dom._
-import org.scalatest.BeforeAndAfterEach
 import outwatch.dom._
 import rxscalajs.{Observable, Subject}
 
 import scala.collection.mutable
 
-class LifecycleHookSpec extends UnitSpec with BeforeAndAfterEach {
-
-  override def beforeEach(): Unit = {
-    val root = document.createElement("div")
-    root.id = "app"
-    document.body.appendChild(root)
-    ()
-  }
-
-  override def afterEach(): Unit = {
-    document.body.innerHTML = ""
-  }
+class LifecycleHookSpec extends JSDomSpec {
 
   "Insertion hooks" should "be called correctly" in {
 

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -2,7 +2,6 @@ package outwatch
 
 import cats.effect.IO
 import org.scalajs.dom.{document, html}
-import org.scalatest.BeforeAndAfterEach
 import outwatch.dom.helpers._
 import outwatch.dom.{StringModifier, _}
 import rxscalajs.{Observable, Subject}
@@ -12,11 +11,7 @@ import scala.collection.immutable.Seq
 import scala.scalajs.js
 import scala.scalajs.js.JSON
 
-class OutWatchDomSpec extends UnitSpec with BeforeAndAfterEach {
-
-  override def afterEach(): Unit = {
-    document.body.innerHTML = ""
-  }
+class OutWatchDomSpec extends JSDomSpec {
 
   "Properties" should "be separated correctly" in {
     val properties = Seq(

--- a/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -1,23 +1,10 @@
 package outwatch
 
-import org.scalajs.dom._
-import org.scalajs.dom.html
-import org.scalatest.BeforeAndAfterEach
+import org.scalajs.dom.{html, _}
+import outwatch.Deprecated.IgnoreWarnings.initEvent
 import outwatch.dom._
 
-import Deprecated.IgnoreWarnings.initEvent
-
-class ScenarioTestSpec extends UnitSpec with BeforeAndAfterEach {
-  override def afterEach(): Unit = {
-    document.body.innerHTML = ""
-  }
-
-  override def beforeEach(): Unit = {
-    val root = document.createElement("div")
-    root.id = "app"
-    document.body.appendChild(root)
-    ()
-  }
+class ScenarioTestSpec extends JSDomSpec {
 
   "A simple counter application" should "work as intended" in {
     val node = for {

--- a/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -1,14 +1,12 @@
 package outwatch
 
+import org.scalajs.dom.{document, html}
+import outwatch.Deprecated.IgnoreWarnings.initEvent
 import snabbdom.{DataObject, hFunction, patch}
 
-import scalajs.js
-import org.scalajs.dom.document
-import org.scalajs.dom.html
+import scala.scalajs.js
 
-import Deprecated.IgnoreWarnings.initEvent
-
-class SnabbdomSpec extends UnitSpec {
+class SnabbdomSpec extends JSDomSpec {
   "The Snabbdom Facade" should "correctly patch the DOM" in {
     val message = "Hello World"
     val vNode = hFunction("span#msg", DataObject(js.Dictionary(), js.Dictionary()), message)


### PR DESCRIPTION
The problem was that dom nodes of previous tests leaked into later tests. This was problematic if the previous test used the same id, in this case `id="btn"`. The nondeterminism came from the nondeterministic test execution order. Some test classes didn't clean up the dom which was problematic, if executed in a certain order.

fixes #59 