### PR TITLE
DOM dsl refactor

### DIFF
--- a/src/main/scala/outwatch/dom/Compat.scala
+++ b/src/main/scala/outwatch/dom/Compat.scala
@@ -24,14 +24,9 @@ trait Handlers {
   @deprecated("Use Handler.create[T] instead", "0.11.0")
   def createHandler[T](defaultValues: T*)(implicit s: Scheduler): IO[Pipe[T, T]] = Handler.create[T](defaultValues: _*)
 }
-
 object Handlers extends Handlers
 
-trait AttributesCompat {
-  lazy val `class` = className
-
-  lazy val `for` = forId
-
+trait AttributesCompat { self: Attributes =>
   @deprecated("Use `type`, tpe or typ instead", "0.11.0")
   lazy val inputType = tpe
 
@@ -75,7 +70,7 @@ trait AttributesCompat {
   lazy val destroy = onDestroy
 }
 
-trait TagsCompat {
+trait TagsCompat { self: Tags =>
   @deprecated("Use textArea instead", "0.11.0")
   lazy val textarea = textArea
 }

--- a/src/main/scala/outwatch/dom/Implicits.scala
+++ b/src/main/scala/outwatch/dom/Implicits.scala
@@ -1,0 +1,29 @@
+package outwatch.dom
+
+import cats.effect.IO
+import com.raquo.domtypes.generic.keys
+import outwatch.ValueModifier
+import cats.syntax.apply._
+import outwatch.dom.helpers.StyleBuilder
+
+trait Implicits {
+
+  implicit def valueModifier[T](value: T)(implicit mr: ValueModifier[T]): VDomModifier = mr.asModifier(value)
+
+  implicit def optionIsEmptyModifier(opt: Option[VDomModifier]): VDomModifier = opt getOrElse VDomModifier.empty
+
+  implicit def compositeModifier(modifiers: Seq[VDomModifier]): VDomModifier = VDomModifier.apply(modifiers : _*)
+
+  implicit class ioVTreeMerge(vnode: VNode) {
+    def apply(args: VDomModifier*): VNode = for {
+      vnode <- vnode
+      args <- args.sequence
+    } yield vnode(args: _*)
+  }
+
+  implicit def StyleIsBuilder[T](style: keys.Style[T]): StyleBuilder[T] = new StyleBuilder[T](style.cssName)
+
+  private[outwatch] implicit class SeqIOSequence[T](args: Seq[IO[T]]) {
+    def sequence: IO[Seq[T]] = args.foldRight(IO.pure(List.empty[T]))((a, l) => a.map2(l)(_ :: _))
+  }
+}

--- a/src/main/scala/outwatch/dom/OutwatchAttributes.scala
+++ b/src/main/scala/outwatch/dom/OutwatchAttributes.scala
@@ -12,9 +12,6 @@ trait OutwatchAttributes
   with SnabbdomKeyAttributes
   with OutWatchLifeCycleAttributes
   with TypedInputEventProps
-  with AttributeHelpers
-
-object OutwatchAttributes extends OutwatchAttributes
 
 /** OutWatch specific attributes used to asign child nodes to a VNode. */
 trait OutWatchChildAttributes {
@@ -64,18 +61,29 @@ trait SnabbdomKeyAttributes {
 
 trait TypedInputEventProps {
   import org.scalajs.dom
+  import dsl.attributes.events
 
   /** The input event is fired when an element gets user input. */
-  lazy val onInputChecked = Events.onChange.map(_.target.asInstanceOf[dom.html.Input].checked)
+  lazy val onInputChecked = events.onChange.map(_.target.asInstanceOf[dom.html.Input].checked)
 
   /** The input event is fired when an element gets user input. */
-  lazy val onInputNumber  = Events.onInput.map(_.target.asInstanceOf[dom.html.Input].valueAsNumber)
+  lazy val onInputNumber  = events.onInput.map(_.target.asInstanceOf[dom.html.Input].valueAsNumber)
 
   /** The input event is fired when an element gets user input. */
-  lazy val onInputString  = Events.onInput.map(_.target.asInstanceOf[dom.html.Input].value)
+  lazy val onInputString  = events.onInput.map(_.target.asInstanceOf[dom.html.Input].value)
 }
 
-trait AttributeHelpers {
+//trait AttributeExtras { self: Attributes =>
+//  lazy val `class` = className
+//
+//  lazy val `for` = forId
+//}
+
+trait AttributeHelpers { self: Attributes =>
+  lazy val `class` = className
+
+  lazy val `for` = forId
+
   lazy val data = new DynamicAttributeBuilder[Any]("data" :: Nil)
 
   def attr[T](key: String, convert: T => Attr.Value = (t: T) => t.toString : Attr.Value) = new AttributeBuilder[T](key, convert)
@@ -83,6 +91,6 @@ trait AttributeHelpers {
   def style[T](key: String) = new StyleBuilder[T](key)
 }
 
-trait TagHelpers {
+trait TagHelpers { self: Tags =>
   def tag(name: String): VNode= IO.pure(VTree(name, Seq.empty))
 }

--- a/src/main/scala/outwatch/dom/dsl.scala
+++ b/src/main/scala/outwatch/dom/dsl.scala
@@ -3,7 +3,6 @@ package outwatch.dom
 object dsl extends Attributes with Tags with Styles {
   object tags extends Tags {
     object extra extends TagsExtra
-    object all extends Tags with TagsExtra
   }
   object attributes extends Attributes {
     object attrs extends Attrs
@@ -15,7 +14,6 @@ object dsl extends Attributes with Tags with Styles {
   }
   object styles extends Styles {
     object extra extends StylesExtra
-    object all extends Styles with StylesExtra
   }
   object events {
     object window extends WindowEvents

--- a/src/main/scala/outwatch/dom/dsl.scala
+++ b/src/main/scala/outwatch/dom/dsl.scala
@@ -1,0 +1,24 @@
+package outwatch.dom
+
+object dsl extends Attributes with Tags with Styles {
+  object tags extends Tags {
+    object extra extends TagsExtra
+    object all extends Tags with TagsExtra
+  }
+  object attributes extends Attributes {
+    object attrs extends Attrs
+    object reflected extends ReflectedAttrs
+    object props extends Props
+    object events extends Events
+    object outwatch extends OutwatchAttributes
+    object lifecycle extends OutWatchLifeCycleAttributes
+  }
+  object styles extends Styles {
+    object extra extends StylesExtra
+    object all extends Styles with StylesExtra
+  }
+  object events {
+    object window extends WindowEvents
+    object document extends DocumentEvents
+  }
+}

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -1,14 +1,15 @@
 package outwatch
 
 import cats.effect.IO
-import cats.syntax.apply._
 
-package object dom extends Attributes with Tags {
+package object dom extends Implicits {
 
   type VNode = IO[VTree]
   type VDomModifier = IO[VDomModifier_]
   object VDomModifier {
-    val empty = IO.pure(EmptyModifier)
+    val empty: VDomModifier = IO.pure(EmptyModifier)
+
+    def apply(modifiers: VDomModifier*): VDomModifier = modifiers.sequence.map(CompositeModifier)
   }
 
   type Observable[+A] = monix.reactive.Observable[A]
@@ -22,21 +23,4 @@ package object dom extends Attributes with Tags {
 
   type Handler[T] = outwatch.Handler[T]
   val Handler = outwatch.Handler
-
-  implicit def valueModifier[T](value: T)(implicit mr: ValueModifier[T]): VDomModifier = mr.asModifier(value)
-
-  implicit def optionIsEmptyModifier(opt: Option[VDomModifier]): VDomModifier = opt getOrElse VDomModifier.empty
-
-  implicit def compositeModifier(modifiers: Seq[VDomModifier]): VDomModifier = modifiers.sequence.map(CompositeModifier)
-
-  implicit class ioVTreeMerge(vnode: VNode) {
-    def apply(args: VDomModifier*): VNode = for {
-      vnode <- vnode
-      args <- args.sequence
-    } yield vnode(args: _*)
-  }
-
-  private[outwatch] implicit class SeqIOSequence[T](args: Seq[IO[T]]) {
-    def sequence: IO[Seq[T]] = args.foldRight(IO.pure(List.empty[T]))((a, l) => a.map2(l)(_ :: _))
-  }
 }

--- a/src/test/scala/outwatch/AttributeSpec.scala
+++ b/src/test/scala/outwatch/AttributeSpec.scala
@@ -1,6 +1,7 @@
 package outwatch
 
 import outwatch.dom._
+import outwatch.dom.dsl._
 
 class AttributeSpec extends JSDomSpec {
 
@@ -127,13 +128,14 @@ class AttributeSpec extends JSDomSpec {
   }
 
   it should "correctly merge keys" in {
-    val node = input( dom.key := "bumm")( dom.key := "klapp").map(_.asProxy).unsafeRunSync()
+
+    val node = input( attributes.key := "bumm")( attributes.key := "klapp").map(_.asProxy).unsafeRunSync()
     node.data.key.toList should contain theSameElementsAs List("klapp")
 
-    val node2 = input()( dom.key := "klapp").map(_.asProxy).unsafeRunSync()
+    val node2 = input()( attributes.key := "klapp").map(_.asProxy).unsafeRunSync()
     node2.data.key.toList should contain theSameElementsAs List("klapp")
 
-    val node3 = input( dom.key := "bumm")().map(_.asProxy).unsafeRunSync()
+    val node3 = input( attributes.key := "bumm")().map(_.asProxy).unsafeRunSync()
     node3.data.key.toList should contain theSameElementsAs List("bumm")
   }
 

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -5,6 +5,7 @@ import monix.reactive.subjects.PublishSubject
 import org.scalajs.dom.{html, _}
 import outwatch.Deprecated.IgnoreWarnings.initEvent
 import outwatch.dom._
+import outwatch.dom.dsl._
 
 class DomEventSpec extends JSDomSpec {
 
@@ -97,7 +98,7 @@ class DomEventSpec extends JSDomSpec {
 
     val values = PublishSubject[String]
 
-    val vtree = input(id:= "input", outwatch.dom.value <-- values)
+    val vtree = input(id:= "input", attributes.value <-- values)
 
     OutWatch.renderInto("#app", vtree).unsafeRunSync()
 
@@ -122,7 +123,7 @@ class DomEventSpec extends JSDomSpec {
   it should "preserve user input after setting defaultValue" in {
     val defaultValues = PublishSubject[String]
 
-    val vtree = input(id:= "input", outwatch.dom.defaultValue <-- defaultValues)
+    val vtree = input(id:= "input", attributes.defaultValue <-- defaultValues)
     OutWatch.renderInto("#app", vtree).unsafeRunSync()
 
     val patched = document.getElementById("input").asInstanceOf[html.Input]
@@ -142,7 +143,7 @@ class DomEventSpec extends JSDomSpec {
   it should "set input value to the same value after user change" in {
     val values = PublishSubject[String]
 
-    val vtree = input(id:= "input", outwatch.dom.value <-- values)
+    val vtree = input(id:= "input", attributes.value <-- values)
     OutWatch.renderInto("#app", vtree).unsafeRunSync()
 
     val patched = document.getElementById("input").asInstanceOf[html.Input]
@@ -406,8 +407,8 @@ class DomEventSpec extends JSDomSpec {
 
     var docClicked = false
     var winClicked = false
-    WindowEvents.onClick(ev => winClicked = true)
-    DocumentEvents.onClick(ev => docClicked = true)
+    events.window.onClick( ev => winClicked = true)
+    events.document.onClick( ev => docClicked = true)
 
     val node =
       div(

--- a/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -6,6 +6,7 @@ import monix.reactive.Observable
 import monix.reactive.subjects.PublishSubject
 import org.scalajs.dom._
 import outwatch.dom._
+import outwatch.dom.dsl._
 
 import scala.collection.mutable
 
@@ -147,7 +148,7 @@ class LifecycleHookSpec extends JSDomSpec {
       Continue
     })
 
-    val node = div(child <-- Observable(span("Hello")), span(outwatch.dom.key := "1", onPrepatch --> sink, "Hey"))
+    val node = div(child <-- Observable(span("Hello")), span(attributes.key := "1", onPrepatch --> sink, "Hey"))
 
     switch shouldBe false
 

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -5,7 +5,8 @@ import monix.execution.Ack.Continue
 import monix.reactive.subjects.PublishSubject
 import org.scalajs.dom.{document, html}
 import outwatch.dom.helpers._
-import outwatch.dom.{StringModifier, _}
+import outwatch.dom._
+import outwatch.dom.dsl._
 import snabbdom.{DataObject, hFunction}
 
 import scala.collection.immutable.Seq
@@ -46,9 +47,9 @@ class OutWatchDomSpec extends JSDomSpec {
       CompositeModifier(
         Seq(
           div(),
-          Attributes.`class` := "blue",
-          Attributes.onClick(1) --> Sink.create[Int](_ => IO.pure{(); Continue}),
-          Attributes.hidden <-- Observable(false)
+          attributes.`class` := "blue",
+          attributes.onClick(1) --> Sink.create[Int](_ => IO.pure{(); Continue}),
+          attributes.hidden <-- Observable(false)
         ).map(_.unsafeRunSync())
       ),
       AttributeStreamReceiver("hidden",Observable())
@@ -467,7 +468,7 @@ class OutWatchDomSpec extends JSDomSpec {
   it should "change the value of a textfield" in {
     val messages = PublishSubject[String]
     val vtree = div(
-      input(outwatch.dom.value <-- messages, id := "input")
+      input(attributes.value <-- messages, id := "input")
     )
 
     val node = document.createElement("div")

--- a/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -3,6 +3,7 @@ package outwatch
 import org.scalajs.dom.{html, _}
 import outwatch.Deprecated.IgnoreWarnings.initEvent
 import outwatch.dom._
+import outwatch.dom.dsl._
 
 class ScenarioTestSpec extends JSDomSpec {
 

--- a/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -28,11 +28,12 @@ class SnabbdomSpec extends JSDomSpec {
 
   it should "correctly patch nodes with keys" in {
     import outwatch.dom._
+    import outwatch.dom.dsl._
 
     val clicks = Handler.create[Int](1).unsafeRunSync()
     val nodes = clicks.map { i =>
       div(
-        dom.key := s"key-$i",
+        attributes.key := s"key-$i",
         span(onClick(if (i == 1) 2 else 1) --> clicks,  s"This is number $i", id := "btn"),
         input(id := "input")
       )


### PR DESCRIPTION
I did some refactoring to make the DOM DSL imports more consistent and work better with IDE auto-completion.

To import all the DOM DSL identifiers (except for `TagsExtra` and `StylesExtra`) the following import needs to be used:
```
import outwatch.dom.dsl._
```

It's also possible to import just parts of the DSL, and IDE auto-completion helps with this:
```scala
import outwatch.dom.dsl.tags._
import outwatch.dom.dsl.attributes._
import outwatch.dom.dsl.styles._
```

This also addresses #124 by removing `Attributes` and `Tags` from the `outwatch.dom` namespace. Most existing code bases that use `import outwatch.dom._` can be upgraded with:
```bash
find src -name '*.scala' | xargs sed -i -e 's/^\([ \t]*\)import outwatch.dom._/\1import outwatch.dom._\n\1import outwatch.dom.dsl._/'
```

This PR is on top of #130.