### PR TITLE
Extended styles

### DIFF
--- a/src/main/scala/outwatch/dom/DomTypes.scala
+++ b/src/main/scala/outwatch/dom/DomTypes.scala
@@ -136,10 +136,9 @@ abstract class DocumentEvents
 
 
 private[outwatch] trait SimpleStyleBuilder extends StyleBuilders[IO[Style]] {
-
   override protected def buildDoubleStyleSetter(style: keys.Style[Double], value: Double): IO[Style] = style := value
   override protected def buildIntStyleSetter(style: keys.Style[Int],value: Int): IO[Style] = style := value
-  override protected def buildStringStyleSetter(style: keys.Style[_],value: String): IO[Style] = new StyleBuilder[Any](style.cssName) := value
+  override protected def buildStringStyleSetter(style: keys.Style[_],value: String): IO[Style] = new BasicStyleBuilder[Any](style.cssName) := value
 }
 
 

--- a/src/main/scala/outwatch/dom/Implicits.scala
+++ b/src/main/scala/outwatch/dom/Implicits.scala
@@ -1,10 +1,10 @@
 package outwatch.dom
 
 import cats.effect.IO
+import cats.syntax.apply._
 import com.raquo.domtypes.generic.keys
 import outwatch.ValueModifier
-import cats.syntax.apply._
-import outwatch.dom.helpers.StyleBuilder
+import outwatch.dom.helpers.BasicStyleBuilder
 
 trait Implicits {
 
@@ -21,7 +21,7 @@ trait Implicits {
     } yield vnode(args: _*)
   }
 
-  implicit def StyleIsBuilder[T](style: keys.Style[T]): StyleBuilder[T] = new StyleBuilder[T](style.cssName)
+  implicit def StyleIsBuilder[T](style: keys.Style[T]): BasicStyleBuilder[T] = new BasicStyleBuilder[T](style.cssName)
 
   private[outwatch] implicit class SeqIOSequence[T](args: Seq[IO[T]]) {
     def sequence: IO[Seq[T]] = args.foldRight(IO.pure(List.empty[T]))((a, l) => a.map2(l)(_ :: _))

--- a/src/main/scala/outwatch/dom/OutwatchAttributes.scala
+++ b/src/main/scala/outwatch/dom/OutwatchAttributes.scala
@@ -88,7 +88,7 @@ trait AttributeHelpers { self: Attributes =>
 
   def attr[T](key: String, convert: T => Attr.Value = (t: T) => t.toString : Attr.Value) = new AttributeBuilder[T](key, convert)
   def prop[T](key: String, convert: T => Prop.Value = (t: T) => t) = new PropertyBuilder[T](key, convert)
-  def style[T](key: String) = new StyleBuilder[T](key)
+  def style[T](key: String) = new BasicStyleBuilder[T](key)
 }
 
 trait TagHelpers { self: Tags =>

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -19,6 +19,11 @@ VDomModifier_
           AccumAttr
         Prop
         Style
+          BasicStyle
+          DelayedStyle
+          RemoveStyle
+          DestroyStyle
+          AccumStyle
       EmptyAttribute
     Hook
       InsertHook
@@ -104,7 +109,19 @@ object Prop {
   type Value = DataObject.PropValue
 }
 
-final case class Style(title: String, value: String) extends TitledAttribute
+sealed trait Style extends TitledAttribute {
+  val value: String
+}
+object Style {
+  type Value = DataObject.StyleValue
+}
+
+final case class AccumStyle(title: String, value: String, accum: (String, String) => String) extends Style
+
+final case class BasicStyle(title: String, value: String) extends Style
+final case class DelayedStyle(title: String, value: String) extends Style
+final case class RemoveStyle(title: String, value: String) extends Style
+final case class DestroyStyle(title: String, value: String) extends Style
 
 // Hooks
 

--- a/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -97,10 +97,29 @@ private[outwatch] final case class SeparatedProperties(
   }
 }
 
+private[outwatch] final case class SeparatedStyles(
+  styles: List[Style] = Nil
+) extends SnabbdomStyles {
+  @inline def ::(s: Style): SeparatedStyles = copy(styles = s :: styles)
+}
+
+
 private[outwatch] final case class SeparatedAttributes(
-  attributes: List[Attribute] = Nil
+  attrs: List[Attr] = Nil,
+  props: List[Prop] = Nil,
+  styles: SeparatedStyles = SeparatedStyles()
 ) extends SnabbdomAttributes {
-  @inline def ::(a: Attribute): SeparatedAttributes = copy(attributes = a :: attributes)
+  @inline def ::(a: Attribute): SeparatedAttributes = a match {
+    case a : Attr => copy(attrs = a :: attrs)
+    case p : Prop => copy(props = p :: props)
+    case s : Style => copy(styles= s :: styles)
+    case EmptyAttribute => this
+  }
+}
+object SeparatedAttributes {
+  private[outwatch] def from(attributes: Seq[Attribute]): SeparatedAttributes = {
+    attributes.foldRight(SeparatedAttributes())((a, sa) => a :: sa)
+  }
 }
 
 private[outwatch] final case class SeparatedHooks(

--- a/src/main/scala/snabbdom/hFunction.scala
+++ b/src/main/scala/snabbdom/hFunction.scala
@@ -73,7 +73,7 @@ trait DataObject extends js.Object {
 
   val attrs: js.Dictionary[AttrValue]
   val props: js.Dictionary[PropValue]
-  val style: js.Dictionary[String]
+  val style: js.Dictionary[StyleValue]
   val on: js.Dictionary[js.Function1[Event, Unit]]
   val hook: Hooks
   val key: js.UndefOr[KeyValue]
@@ -83,6 +83,7 @@ object DataObject {
 
   type PropValue = Any
   type AttrValue = String | Boolean
+  type StyleValue = String | js.Dictionary[String]
   type KeyValue = String | Double  // https://github.com/snabbdom/snabbdom#key--string--number
 
   def apply(attrs: js.Dictionary[AttrValue],
@@ -93,7 +94,7 @@ object DataObject {
 
   def apply(attrs: js.Dictionary[AttrValue],
             props: js.Dictionary[PropValue],
-            style: js.Dictionary[String],
+            style: js.Dictionary[StyleValue],
             on: js.Dictionary[js.Function1[Event, Unit]],
             hook: Hooks,
             key: js.UndefOr[KeyValue]
@@ -109,7 +110,7 @@ object DataObject {
     new DataObject {
       val attrs: js.Dictionary[AttrValue] = _attrs
       val props: js.Dictionary[PropValue] = _props
-      val style: js.Dictionary[String] = _style
+      val style: js.Dictionary[StyleValue] = _style
       val on: js.Dictionary[js.Function1[Event, Unit]] = _on
       val hook: Hooks = _hook
       val key: UndefOr[KeyValue] = _key

--- a/src/test/scala/outwatch/AttributeSpec.scala
+++ b/src/test/scala/outwatch/AttributeSpec.scala
@@ -3,6 +3,8 @@ package outwatch
 import outwatch.dom._
 import outwatch.dom.dsl._
 
+import scala.scalajs.js
+
 class AttributeSpec extends JSDomSpec {
 
   "class attributes" should "be accumulated" in {
@@ -175,5 +177,29 @@ class AttributeSpec extends JSDomSpec {
     node.data.style.toList should contain theSameElementsAs List(
       "color" -> "red"
     )
+  }
+
+
+  "extended styles" should "convert correctly" in {
+    val node = div(
+      opacity := 0,
+      opacity.delayed := 1,
+      opacity.remove := 0,
+      opacity.destroy := 0
+    ).map(_.asProxy).unsafeRunSync()
+
+    node.data.style("opacity") shouldBe "0"
+    node.data.style("delayed").asInstanceOf[js.Dictionary[String]].toMap shouldBe Map("opacity" -> "1")
+    node.data.style("remove").asInstanceOf[js.Dictionary[String]].toMap shouldBe Map("opacity" -> "0")
+    node.data.style("destroy").asInstanceOf[js.Dictionary[String]].toMap shouldBe Map("opacity" -> "0")
+  }
+
+  "style accum" should "convert correctly" in {
+    val node = div(
+      transition := "transform .2s ease-in-out",
+      transition.accum(",") := "opacity .2s ease-in-out"
+    ).map(_.asProxy).unsafeRunSync()
+
+    node.data.style.toMap shouldBe Map("transition" -> "transform .2s ease-in-out,opacity .2s ease-in-out")
   }
 }

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -33,7 +33,7 @@ class OutWatchDomSpec extends JSDomSpec {
     hooks.updateHooks.length shouldBe 1
     hooks.postPatchHooks.length shouldBe 1
     hooks.destroyHooks.length shouldBe 1
-    att.attributes.length shouldBe 1
+    att.attrs.length shouldBe 1
     keys.length shouldBe 0
   }
 
@@ -60,7 +60,7 @@ class OutWatchDomSpec extends JSDomSpec {
 
     emitters.emitters.length shouldBe 2
     receivers.length shouldBe 2
-    properties.attributes.attributes.length shouldBe 2
+    properties.attributes.attrs.length shouldBe 2
     childNodes.length shouldBe 3
     streamStatus.numChild shouldBe 0
     streamStatus.numChildren shouldBe 0
@@ -84,7 +84,7 @@ class OutWatchDomSpec extends JSDomSpec {
 
     emitters.emitters.length shouldBe 3
     receivers.length shouldBe 2
-    properties.attributes.attributes.length shouldBe 1
+    properties.attributes.attrs.length shouldBe 1
     childNodes.length shouldBe 2
     streamStatus.numChild shouldBe 0
     streamStatus.numChildren shouldBe 0
@@ -108,7 +108,7 @@ class OutWatchDomSpec extends JSDomSpec {
 
     emitters.emitters.length shouldBe 3
     receivers.length shouldBe 2
-    properties.attributes.attributes.length shouldBe 1
+    properties.attributes.attrs.length shouldBe 1
     stringMods.map(_.string) should contain theSameElementsAs(List(
       "text", "text2"
     ))
@@ -141,7 +141,7 @@ class OutWatchDomSpec extends JSDomSpec {
     properties.hooks.updateHooks.length shouldBe 1
     properties.hooks.postPatchHooks.length shouldBe 1
     properties.hooks.destroyHooks.length shouldBe 0
-    properties.attributes.attributes.length shouldBe 1
+    properties.attributes.attrs.length shouldBe 1
     receivers.length shouldBe 2
     properties.keys.length shouldBe 0
     childNodes.length shouldBe 2


### PR DESCRIPTION
This PR adds support for the Snabbdom [`delayed`, `remove` and `destroy` styles](https://github.com/snabbdom/snabbdom#delayed-properties) which allow for easy CSS animations. It also adds support for accumulating styles in order to be able to write composable animations like so:
```scala
 val slideInOut = VDomModifier(
    transition.accum := "transform .2s ease-in-out",
    transform := "translateX(-50px)",
    transform.delayed := "translateX(0px)",
    transform.remove := "translateX(50px)",
  )

  val fadeInOut = VDomModifier(
    transition.accum :=  "opacity .2s ease-in-out",
    opacity := 0,
    opacity.delayed := 1,
    opacity.remove := 0
  )

  val moveInOut =  VDomModifier(slideInOut, fadeInOut)
```

You can see this animation in action [here](https://mariusmuja.github.io/outwatch-demo-spa/#todo) when adding or removing items from the todo list.

This PR is on top of #132.