### PR TITLE
CurrentTarget / Target ops

### DIFF
--- a/src/main/scala/outwatch/dom/Compat.scala
+++ b/src/main/scala/outwatch/dom/Compat.scala
@@ -40,14 +40,14 @@ trait AttributesCompat { self: Attributes =>
   @deprecated("Use listId instead", "0.11.0")
   lazy val list = listId
 
-  @deprecated("Use onInputString instead", "0.11.0")
-  lazy val inputString = onInputString
+  @deprecated("Use onInput.value instead", "0.11.0")
+  lazy val inputString = onInput.value
 
-  @deprecated("Use onInputNumber instead", "0.11.0")
-  lazy val inputNumber = onInputNumber
+  @deprecated("Use onInput.valueAsNumber instead", "0.11.0")
+  lazy val inputNumber = onInput.valueAsNumber
 
-  @deprecated("Use onInputChecked instead", "0.11.0")
-  lazy val inputChecked = onInputChecked
+  @deprecated("Use onChange.checked instead", "0.11.0")
+  lazy val inputChecked = onChange.checked
 
   @deprecated("Use onClick instead", "0.11.0")
   lazy val click = onClick

--- a/src/main/scala/outwatch/dom/OutwatchAttributes.scala
+++ b/src/main/scala/outwatch/dom/OutwatchAttributes.scala
@@ -11,7 +11,8 @@ trait OutwatchAttributes
   extends OutWatchChildAttributes
   with SnabbdomKeyAttributes
   with OutWatchLifeCycleAttributes
-  with TypedInputEventProps
+
+object OutwatchAttributes extends OutwatchAttributes
 
 /** OutWatch specific attributes used to asign child nodes to a VNode. */
 trait OutWatchChildAttributes {
@@ -58,26 +59,6 @@ trait OutWatchLifeCycleAttributes {
 trait SnabbdomKeyAttributes {
   lazy val key = KeyBuilder
 }
-
-trait TypedInputEventProps {
-  import org.scalajs.dom
-  import dsl.attributes.events
-
-  /** The input event is fired when an element gets user input. */
-  lazy val onInputChecked = events.onChange.map(_.target.asInstanceOf[dom.html.Input].checked)
-
-  /** The input event is fired when an element gets user input. */
-  lazy val onInputNumber  = events.onInput.map(_.target.asInstanceOf[dom.html.Input].valueAsNumber)
-
-  /** The input event is fired when an element gets user input. */
-  lazy val onInputString  = events.onInput.map(_.target.asInstanceOf[dom.html.Input].value)
-}
-
-//trait AttributeExtras { self: Attributes =>
-//  lazy val `class` = className
-//
-//  lazy val `for` = forId
-//}
 
 trait AttributeHelpers { self: Attributes =>
   lazy val `class` = className

--- a/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
+++ b/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
@@ -26,11 +26,9 @@ trait EmitterBuilder[E <: Event, O] extends Any {
   def -->(sink: Sink[_ >: O]): IO[Emitter]
 }
 
-
-object EmitterBuilder {
+object EmitterBuilder extends TargetOps {
   def apply[E <: Event](eventType: String) = new SimpleEmitterBuilder[E](eventType)
 }
-
 
 final case class TransformingEmitterBuilder[E <: Event, O] private[helpers] (
   eventType: String,

--- a/src/main/scala/outwatch/dom/helpers/TargetOps.scala
+++ b/src/main/scala/outwatch/dom/helpers/TargetOps.scala
@@ -1,0 +1,24 @@
+package outwatch.dom.helpers
+
+import org.scalajs.dom.{Event, html}
+
+trait TargetOps {
+
+  implicit class TargetAsInput[E <: Event, O <: Event](builder: EmitterBuilder[E, O]) {
+
+    object target {
+      def value: EmitterBuilder[E, String] = builder.map(_.target.asInstanceOf[html.Input].value)
+
+      def valueAsNumber: EmitterBuilder[E, Int] = builder.map(_.target.asInstanceOf[html.Input].valueAsNumber)
+
+      def checked: EmitterBuilder[E, Boolean] = builder.map(_.target.asInstanceOf[html.Input].checked)
+    }
+
+    def value: EmitterBuilder[E, String] = builder.map(e => e.currentTarget.asInstanceOf[html.Input].value)
+
+    def valueAsNumber: EmitterBuilder[E, Int] = builder.map(e => e.currentTarget.asInstanceOf[html.Input].valueAsNumber)
+
+    def checked: EmitterBuilder[E, Boolean] = builder.map(e => e.currentTarget.asInstanceOf[html.Input].checked)
+  }
+
+}

--- a/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -54,7 +54,7 @@ class ScenarioTestSpec extends JSDomSpec {
     val node = Handler.create[String].flatMap { nameHandler =>
       div(
         label("Name:"),
-        input(id := "input", tpe := "text", onInputString --> nameHandler),
+        input(id := "input", tpe := "text", onInput.value --> nameHandler),
         hr(),
         h1(id := "greeting", greetStart, child <-- nameHandler)
       )
@@ -145,7 +145,7 @@ class ScenarioTestSpec extends JSDomSpec {
 
       div <- div(
         label(labelText),
-        input(id:= "input", tpe := "text", onInputString --> textFieldStream, onKeyUp --> keyStream),
+        input(id:= "input", tpe := "text", onInput.value --> textFieldStream, onKeyUp --> keyStream),
         button(id := "submit", onClick --> clickStream, disabled <-- buttonDisabled, "Submit")
       )
     } yield div


### PR DESCRIPTION
This PR is a result of the discussion we had in https://github.com/OutWatch/outwatch/pull/119#issuecomment-351861345. It still uses the non-typesafe cast for `currentTarget`, but allows for a nicer syntax and uses the `TagWith...` typeclasses for restricting the type the target can be cast to.

The syntax is the following:
 * `currentTarget` uses `html.Input` by default as the underlying event target:
```scala
input(
  onInput.value --> string,
  onClick.checked --> bool,
  onKeyDown.valueAsNumber --> number
)
```
The PR removes `onInputString`, `onInputNumber` and `onInputChecked` and updates the deprecation message on `inputString`, `inputNumber` and `inputChecked` to use  `onInput.value`, `onInput.valueAsNumber` and `onChange.checked` instead.

 *  it's possible to force a different event target for `currentTarget`, but only if the `TagWith...` typeclasses are implemented for it (`html.TextArea`, `html.Select` ).
 ```scala
textArea(
  onChange.value[html.TextArea] --> string,
)
```
* for `target`, the type from `TypedTargetEvent` is used by default
```scala
input(
  onSearch.target.value --> stringStream,
  onSearch.target.valueAsNumber --> doubleStream,
  onSearch.target.checked --> boolStream,
)
```
* in case the type of `TypedTargetEvent` is not specific enough it's possible to force a more specific type:
```scala
input(
  //onClick.target.value --> stringStream,   // does not compile because onClick is TypedTargetEvent[dom.Element], not specific enough
  onClick.target[html.Input].value --> stringStream,
  onClick.target[html.Input].valueAsNumber --> doubleStream,
  onChange.target[html.Input].checked --> boolStream,
)
```