### PR TITLE
Combine observables using merge/scan

### DIFF
--- a/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -1,7 +1,6 @@
 package outwatch.dom.helpers
 
 import cats.effect.IO
-import monix.reactive.subjects.BehaviorSubject
 import outwatch.dom._
 
 import scala.collection.breakOut
@@ -47,7 +46,7 @@ object Children {
 
     override def ::(node: ChildVNode): Children = node match {
       case s: StringVNode => toModifier(s) :: this
-      case n => n :: VNodes(Nil, StreamStatus())
+      case n => n :: VNodes(Nil, hasStream = false)
     }
   }
 
@@ -56,32 +55,25 @@ object Children {
 
     override def ::(node: ChildVNode): Children = node match {
       case s: StringVNode => toModifier(s) :: this // this should never happen
-      case n => n :: VNodes(modifiers.map(toVNode), StreamStatus())
+      case n => n :: VNodes(modifiers.map(toVNode), hasStream = false)
     }
   }
 
-  private[outwatch] case class VNodes(nodes: List[ChildVNode], streamStatus: StreamStatus) extends Children {
+  private[outwatch] case class VNodes(nodes: List[ChildVNode], hasStream: Boolean) extends Children {
 
     private def ensureVNodeKey[N >: VTree](node: N): N = node match {
       case vtree: VTree => vtree.copy(modifiers = Key(vtree.hashCode) +: vtree.modifiers)
       case other => other
     }
 
-    override def ensureKey: Children = if (streamStatus.hasChildOrChildren) copy(nodes = nodes.map(ensureVNodeKey)) else this
+    override def ensureKey: Children = if (hasStream) copy(nodes = nodes.map(ensureVNodeKey)) else this
 
     override def ::(mod: StringModifier): Children = copy(toVNode(mod) :: nodes)
 
     override def ::(node: ChildVNode): Children = node match {
       case s: StaticVNode => copy(nodes = s :: nodes)
-      case s: ChildStreamReceiver => copy(s :: nodes, streamStatus.copy(numChild = streamStatus.numChild + 1))
-      case s: ChildrenStreamReceiver => copy(s :: nodes, streamStatus.copy(numChildren = streamStatus.numChildren + 1))
+      case s: StreamVNode => copy(nodes = s :: nodes, hasStream = true)
     }
-  }
-
-  private[outwatch] case class StreamStatus(numChild: Int = 0, numChildren: Int = 0) {
-    def hasChildOrChildren: Boolean = (numChild + numChildren) > 0
-
-    def hasMultipleChildOrChildren: Boolean = (numChild + numChildren) > 1
   }
 }
 
@@ -144,48 +136,48 @@ private[outwatch] final case class SeparatedEmitters(
   def ::(e: Emitter): SeparatedEmitters = copy(emitters = e :: emitters)
 }
 
+
+private[outwatch] case class VNodeState(
+  nodes: Array[Seq[IO[StaticVNode]]],
+  attributes: Map[String, Attribute] = Map.empty
+)
+
+private[outwatch] object VNodeState {
+  def from(nodes: List[ChildVNode]): VNodeState = VNodeState(
+    nodes.map {
+      case n: StaticVNode => List(IO.pure(n))
+      case _ => List.empty
+    }(breakOut)
+  )
+
+  type Updater = VNodeState => VNodeState
+}
+
 private[outwatch] final case class Receivers(
   children: Children,
   attributeStreamReceivers: List[AttributeStreamReceiver]
 ) {
-  private val (childNodes, childStreamStatus) = children match {
-    case Children.VNodes(nodes, streamStatus) => (nodes, streamStatus)
-    case _ => (Nil, Children.StreamStatus())
+  private val (nodes, hasNodeStreams) = children match {
+    case Children.VNodes(nodes, hasStream) => (nodes, hasStream)
+    case _ => (Nil, false)
   }
 
-  lazy val observable: Observable[(Seq[Attribute], Seq[IO[StaticVNode]])] = {
-    val childStreamReceivers = if (childStreamStatus.hasChildOrChildren) {
-      childNodes.foldRight(Observable(List.empty[IO[StaticVNode]])) {
-        case (vn: StaticVNode, obs) => obs.combineLatestMap(BehaviorSubject(IO.pure(vn)))((nodes, n) => n :: nodes)
-        case (csr: ChildStreamReceiver, obs) =>
-          obs.combineLatestMap(
-            if (childStreamStatus.hasMultipleChildOrChildren) csr.childStream.startWith(Seq(IO.pure(StaticVNode.empty))) else csr.childStream
-          )((nodes, n) => n :: nodes)
-        case (csr: ChildrenStreamReceiver, obs) =>
-          obs.combineLatestMap(
-            if (childStreamStatus.hasMultipleChildOrChildren) csr.childrenStream.startWith(Seq(Seq.empty)) else csr.childrenStream
-          )((nodes, n) => n.toList ++ nodes)
-      }
-    } else {
-      Observable(Seq.empty)
-    }
-
-    // only use last encountered observable per attribute
-    val attributeReceivers: Observable[Seq[Attribute]] = if (attributeStreamReceivers.isEmpty) {
-      Observable(Seq.empty)
-    } else {
-      Observable.combineLatestList(
-        attributeStreamReceivers
-          .groupBy(_.attribute)
-          .values
-          .map(_.last.attributeStream.startWith(Seq(Attribute.empty)))(breakOut): _*
-      )
-    }
-
-    attributeReceivers.combineLatest(childStreamReceivers)
+  private lazy val updaters: Seq[Observable[VNodeState.Updater]] = nodes.zipWithIndex.map {
+    case (_: StaticVNode, _) =>
+      Observable.empty
+    case (csr: ChildStreamReceiver, index) =>
+      csr.childStream.map[VNodeState.Updater](n => s => s.copy(nodes = s.nodes.updated(index, n :: Nil)))
+    case (csr: ChildrenStreamReceiver, index) =>
+      csr.childrenStream.map[VNodeState.Updater](n => s => s.copy(nodes = s.nodes.updated(index, n)))
+  } ++ attributeStreamReceivers.groupBy(_.attribute).values.map(_.last).map {
+    case AttributeStreamReceiver(name, attributeStream) =>
+      attributeStream.map[VNodeState.Updater](a => s => s.copy(attributes = s.attributes.updated(name, a)))
   }
+
+  lazy val observable: Observable[VNodeState] = Observable.merge(updaters: _*)
+    .scan(VNodeState.from(nodes))((state, updater) => updater(state))
 
   lazy val nonEmpty: Boolean = {
-    attributeStreamReceivers.nonEmpty || childStreamStatus.hasChildOrChildren
+    hasNodeStreams || attributeStreamReceivers.nonEmpty
   }
 }

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -443,8 +443,6 @@ class DomEventSpec extends JSDomSpec {
   "DomWindowEvents and DomDocumentEvents" should "trigger correctly" in {
     import outwatch.dom._
 
-    implicit val scheduler = trampolineScheduler
-
     var docClicked = false
     var winClicked = false
     events.window.onClick( ev => winClicked = true)

--- a/src/test/scala/outwatch/JSDomSpec.scala
+++ b/src/test/scala/outwatch/JSDomSpec.scala
@@ -62,8 +62,7 @@ trait LocalStorageMock {
 
 abstract class JSDomSpec extends FlatSpec with Matchers with BeforeAndAfterEach with EasySubscribe with LocalStorageMock {
 
-  implicit val scheduler = Scheduler.global
-  val trampolineScheduler = TrampolineScheduler(scheduler, SynchronousExecution)
+  implicit val scheduler = TrampolineScheduler(Scheduler.global, SynchronousExecution)
 
   override def beforeEach(): Unit = {
 

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -58,15 +58,14 @@ class OutWatchDomSpec extends JSDomSpec {
       AttributeStreamReceiver("hidden",Observable())
     )
 
-    val SeparatedModifiers(properties, emitters, receivers, Children.VNodes(childNodes, streamStatus)) =
+    val SeparatedModifiers(properties, emitters, receivers, Children.VNodes(nodes, hasStream)) =
       SeparatedModifiers.from(modifiers)
 
     emitters.emitters.length shouldBe 2
     receivers.length shouldBe 2
     properties.attributes.attrs.length shouldBe 2
-    childNodes.length shouldBe 3
-    streamStatus.numChild shouldBe 0
-    streamStatus.numChildren shouldBe 0
+    nodes.length shouldBe 3
+    hasStream shouldBe false
   }
 
   it should "be separated correctly with children" in {
@@ -82,15 +81,14 @@ class OutWatchDomSpec extends JSDomSpec {
       div().unsafeRunSync()
     )
 
-    val SeparatedModifiers(properties, emitters, receivers, Children.VNodes(childNodes, streamStatus)) =
+    val SeparatedModifiers(properties, emitters, receivers, Children.VNodes(nodes, hasStream)) =
       SeparatedModifiers.from(modifiers)
 
     emitters.emitters.length shouldBe 3
     receivers.length shouldBe 2
     properties.attributes.attrs.length shouldBe 1
-    childNodes.length shouldBe 2
-    streamStatus.numChild shouldBe 0
-    streamStatus.numChildren shouldBe 0
+    nodes.length shouldBe 2
+    hasStream shouldBe false
   }
 
   it should "be separated correctly with string children" in {
@@ -134,7 +132,7 @@ class OutWatchDomSpec extends JSDomSpec {
       StringModifier("text")
     )
 
-    val SeparatedModifiers(properties, emitters, receivers, Children.VNodes(childNodes, streamStatus)) =
+    val SeparatedModifiers(properties, emitters, receivers, Children.VNodes(nodes, hasStream)) =
       SeparatedModifiers.from(modifiers)
 
     emitters.emitters.map(_.eventType) shouldBe List("click", "input", "keyup")
@@ -147,9 +145,8 @@ class OutWatchDomSpec extends JSDomSpec {
     properties.attributes.attrs.length shouldBe 1
     receivers.length shouldBe 2
     properties.keys.length shouldBe 0
-    childNodes.length shouldBe 2
-    streamStatus.numChild shouldBe 0
-    streamStatus.numChildren shouldBe 1
+    nodes.length shouldBe 2
+    hasStream shouldBe true
   }
 
   val fixture = new {
@@ -163,11 +160,11 @@ class OutWatchDomSpec extends JSDomSpec {
 
     val vtree = div(
       IO {
-        list += "child2"
-        ChildStreamReceiver(Observable())
+        list += "child1"
+        ChildStreamReceiver(Observable(div()))
       },
       IO {
-        list += "child1"
+        list += "child2"
         ChildStreamReceiver(Observable())
       },
       IO {
@@ -213,11 +210,10 @@ class OutWatchDomSpec extends JSDomSpec {
     )
 
     val modifiers =  SeparatedModifiers.from(mods)
-    val Children.VNodes(childNodes, streamStatus) = modifiers.children
+    val Children.VNodes(nodes, hasStream) = modifiers.children
 
-    childNodes.size shouldBe 3
-    streamStatus.numChild shouldBe 0
-    streamStatus.numChildren shouldBe 1
+    nodes.length shouldBe 3
+    hasStream shouldBe true
 
     val proxy = modifiers.toSnabbdom("div")
     proxy.key.isDefined shouldBe true
@@ -240,11 +236,10 @@ class OutWatchDomSpec extends JSDomSpec {
     )
 
     val modifiers =  SeparatedModifiers.from(mods)
-    val Children.VNodes(childNodes, streamStatus) = modifiers.children
+    val Children.VNodes(nodes, hasStream) = modifiers.children
 
-    childNodes.size shouldBe 2
-    streamStatus.numChild shouldBe 0
-    streamStatus.numChildren shouldBe 1
+    nodes.length shouldBe 2
+    hasStream shouldBe true
 
     val proxy = modifiers.toSnabbdom("div")
     proxy.key.toOption  shouldBe Some(1234)
@@ -897,7 +892,6 @@ class OutWatchDomSpec extends JSDomSpec {
   }
 
   "LocalStorage" should "provide a handler" in {
-    implicit val scheduler = trampolineScheduler
 
     val key = "banana"
     val triggeredHandlerEvents = mutable.ArrayBuffer.empty[Option[String]]

--- a/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -8,7 +8,6 @@ import outwatch.dom.dsl._
 class ScenarioTestSpec extends JSDomSpec {
 
   "A simple counter application" should "work as intended" in {
-    implicit val scheduler = trampolineScheduler
 
     val node = for {
       handlePlus <- Handler.create[MouseEvent]
@@ -116,8 +115,6 @@ class ScenarioTestSpec extends JSDomSpec {
   }
 
   "A todo application" should "work with components" in {
-
-    implicit val scheduler = trampolineScheduler
 
     def TodoComponent(title: String, deleteStream: Sink[String]) =
       li(


### PR DESCRIPTION
This PR refactors the way the VNode observables are combined, using `merge` & `scan` (and explicit VNode state) instead of `combineLatest`.

I think it makes the code simpler and removes the need for workarounds such as keeping track if there's one or more child observables or making sure there's a `startWith` on the streams for partial rendering, avoiding issues such as #137, #134.

