### PR TITLE
Make Handler and Pipe factory public

### DIFF
--- a/src/main/scala/outwatch/Handler.scala
+++ b/src/main/scala/outwatch/Handler.scala
@@ -5,7 +5,7 @@ import monix.execution.Scheduler
 import outwatch.dom.Observable
 
 object Handler {
-  private[outwatch] def apply[T](sink: Sink[T], source: Observable[T]): Handler[T] = Pipe(sink, source)
+  def apply[T](sink: Sink[T], source: Observable[T]): Handler[T] = Pipe(sink, source)
 
   /**
     * This function also allows you to create initial values for your newly created Handler.

--- a/src/main/scala/outwatch/Pipe.scala
+++ b/src/main/scala/outwatch/Pipe.scala
@@ -7,7 +7,7 @@ import outwatch.dom.Observable
 
 
 object Pipe {
-  private[outwatch] def apply[I, O](sink: Sink[I], source: Observable[O]): Pipe[I, O] =
+  def apply[I, O](sink: Sink[I], source: Observable[O]): Pipe[I, O] =
     new ObservableSink[I, O](sink, source)
 
   /**


### PR DESCRIPTION
By making the `Pipe` and `Handler` factories public, it is possible to self-compose `Handler` or `Pipe` providing a `Sink` and an `Observable`. This offers much more flexibility.

Tests run without an issue.


@doofin Does that solve your issue, too?

fixes #143 