### PR TITLE
Emitter accept side-effecting functions

### DIFF
--- a/src/main/scala/outwatch/SideEffects.scala
+++ b/src/main/scala/outwatch/SideEffects.scala
@@ -1,0 +1,11 @@
+package outwatch
+
+import monix.execution.Scheduler
+import monix.execution.Ack.Continue
+import cats.effect.IO
+
+trait SideEffects {
+  def sideEffect[T](f: T => Unit)(implicit s: Scheduler): Sink[T] = Sink.create[T] { e => IO { f(e); Continue } }(s)
+  def sideEffect[S,T](f: (S,T) => Unit)(implicit s: Scheduler): Sink[(S,T)] = Sink.create[(S,T)] { e => IO { f(e._1, e._2); Continue } }(s)
+  def sideEffect(f: => Unit)(implicit s: Scheduler): Sink[Any] = Sink.create[Any] { e => IO { f; Continue } }(s)
+}

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -2,7 +2,7 @@ package outwatch
 
 import cats.effect.IO
 
-package object dom extends Implicits with ManagedSubscriptions {
+package object dom extends Implicits with ManagedSubscriptions with SideEffects {
 
   type VNode = IO[VTree]
   type VDomModifier = IO[VDomModifier_]


### PR DESCRIPTION
One can now write things like:

```scala
button(
  onClick --> (event => handleEvent(event)),
  onClick(1) --> (counter += _),
  onClick --> (() => counter += 1),
)
```