### PR TITLE
Add unsafeOnNext to Sink

### DIFF
--- a/src/main/scala/outwatch/Sink.scala
+++ b/src/main/scala/outwatch/Sink.scala
@@ -24,6 +24,8 @@ sealed trait Sink[-T] extends Any {
 
   private[outwatch] def observer: Subscriber[T]
 
+  def unsafeOnNext(value:T):Future[Ack] = observer.onNext(value)
+
   /**
     * Creates a new sink. That sink will transform the values it receives and then forward them along to this sink.
     * The transformation is described by a function from an Observable to another Observable, i.e. an operator on Observable.

--- a/src/test/scala/outwatch/HandlerSpec.scala
+++ b/src/test/scala/outwatch/HandlerSpec.scala
@@ -1,6 +1,14 @@
 package outwatch
 
 class HandlerSpec extends JSDomSpec {
+  "Sink" should "have unsafeOnNext" in {
+    val handler = Handler.create[Int].unsafeRunSync()
+    var handlerValue: Int = 0
+    handler(handlerValue = _)
+    handler.unsafeOnNext(5)
+    handlerValue shouldBe 5
+  }
+
   "Handler" should "lens" in {
     val handler = Handler.create[(String, Int)].unsafeRunSync()
     val lensed = handler.lens[Int](("harals", 0))(_._2)((tuple, num) => (tuple._1, num))


### PR DESCRIPTION
Another controversial feature! 😆 

I'm interfacing a lot with `d3`, so this and #146 are important to me. Implementing this function directly on `Sink` is way more efficient than implementing it using `unsafeSink` from #76.