### PR TITLE
Rename on{Pre,Post}patch to on{Pre,Post}Patch

### DIFF
--- a/src/main/scala/outwatch/dom/Compat.scala
+++ b/src/main/scala/outwatch/dom/Compat.scala
@@ -59,13 +59,13 @@ trait AttributesCompat { self: Attributes =>
   lazy val insert = onInsert
 
   @deprecated("Use onPrepatch instead", "0.11.0")
-  lazy val prepatch = onPrepatch
+  lazy val prepatch = onPrePatch
 
   @deprecated("Use onUpdate instead", "0.11.0")
   lazy val update = onUpdate
 
   @deprecated("Use onPostpatch instead", "0.11.0")
-  lazy val postpatch = onPostpatch
+  lazy val postpatch = onPostPatch
 
   @deprecated("Use onDestroy instead", "0.11.0")
   lazy val destroy = onDestroy

--- a/src/main/scala/outwatch/dom/OutwatchAttributes.scala
+++ b/src/main/scala/outwatch/dom/OutwatchAttributes.scala
@@ -34,7 +34,7 @@ trait OutWatchLifeCycleAttributes {
   lazy val onInsert   = InsertHookBuilder
 
   /** Lifecycle hook for component prepatch. */
-  lazy val onPrepatch   = PrePatchHookBuilder
+  lazy val onPrePatch   = PrePatchHookBuilder
 
   /** Lifecycle hook for component updates. */
   lazy val onUpdate   = UpdateHookBuilder
@@ -44,7 +44,7 @@ trait OutWatchLifeCycleAttributes {
     *
     *  This hook is invoked every time a node has been patched against an older instance of itself.
     */
-  lazy val onPostpatch   = PostPatchHookBuilder
+  lazy val onPostPatch   = PostPatchHookBuilder
 
   /**
     * Lifecycle hook for component destruction.

--- a/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -148,7 +148,7 @@ class LifecycleHookSpec extends JSDomSpec {
       Continue
     })
 
-    val node = div(child <-- Observable(span("Hello")), span(attributes.key := "1", onPrepatch --> sink, "Hey"))
+    val node = div(child <-- Observable(span("Hello")), span(attributes.key := "1", onPrePatch --> sink, "Hey"))
 
     switch shouldBe false
 
@@ -169,7 +169,7 @@ class LifecycleHookSpec extends JSDomSpec {
       Continue
     })
     val message = PublishSubject[String]()
-    val node = div(child <-- message, onPrepatch --> sink1)(onPrepatch --> sink2)
+    val node = div(child <-- message, onPrePatch --> sink1)(onPrePatch --> sink2)
 
     OutWatch.renderInto("#app", node).unsafeRunSync()
     switch1 shouldBe false
@@ -189,7 +189,7 @@ class LifecycleHookSpec extends JSDomSpec {
       Continue
     })
 
-    val node = div(child <-- Observable("message"), onPostpatch --> sink, "Hey")
+    val node = div(child <-- Observable("message"), onPostPatch --> sink, "Hey")
 
     switch shouldBe false
 
@@ -211,7 +211,7 @@ class LifecycleHookSpec extends JSDomSpec {
       Continue
     })
     val message = PublishSubject[String]()
-    val node = div(child <-- message, onPostpatch --> sink1)(onPostpatch --> sink2)
+    val node = div(child <-- message, onPostPatch --> sink1)(onPostPatch --> sink2)
 
     OutWatch.renderInto("#app", node).unsafeRunSync()
     switch1 shouldBe false
@@ -260,9 +260,9 @@ class LifecycleHookSpec extends JSDomSpec {
     val message = PublishSubject[String]()
     val node = div(child <-- message,
       onInsert --> insertSink,
-      onPrepatch --> prepatchSink,
+      onPrePatch --> prepatchSink,
       onUpdate --> updateSink,
-      onPostpatch --> postpatchSink,
+      onPostPatch --> postpatchSink,
       onDestroy --> destroySink
     )
 


### PR DESCRIPTION
This makes it more consistent with all the other camel-case identifiers.