### PR TITLE
Make Hooks and EmitterBuilder consistent

### DIFF
--- a/src/main/scala/outwatch/dom/DomTypes.scala
+++ b/src/main/scala/outwatch/dom/DomTypes.scala
@@ -17,6 +17,12 @@ import monix.reactive.OverflowStrategy.Unbounded
 
 import scala.scalajs.js
 
+private[outwatch] object Builders {
+  type Attribute[T, _] = helpers.ValueBuilder[T, Attr]
+  type Property[T, _] = helpers.PropertyBuilder[T]
+  type EventEmitter[E <: dom.Event] = SimpleEmitterBuilder[E, Emitter]
+}
+
 private[outwatch] object DomTypesBuilder {
   type VNode = IO[VTree]
   type GenericVNode[T] = VNode
@@ -27,9 +33,6 @@ private[outwatch] object DomTypesBuilder {
   }
 
   object CodecBuilder {
-    type Attribute[T, _] = ValueBuilder[T, Attr]
-    type Property[T, _] = PropertyBuilder[T]
-
     def encodeAttribute[V](codec: Codec[V, String]): V => Attr.Value = codec match {
       //The BooleanAsAttrPresenceCodec does not play well with snabbdom. it
       //encodes true as "" and false as null, whereas snabbdom needs true/false
@@ -92,8 +95,8 @@ trait Attrs
 // Reflected attrs
 
 trait ReflectedAttrs
-  extends reflectedAttrs.ReflectedAttrs[CodecBuilder.Attribute]
-  with ReflectedAttrBuilder[CodecBuilder.Attribute] {
+  extends reflectedAttrs.ReflectedAttrs[Builders.Attribute]
+  with ReflectedAttrBuilder[Builders.Attribute] {
 
   // super.className.accum(" ") would have been nicer, but we can't do super.className on a lazy val
   override lazy val className = new AccumAttributeBuilder[String]("class",
@@ -112,18 +115,18 @@ trait ReflectedAttrs
 
 // Props
 trait Props
-  extends props.Props[CodecBuilder.Property]
-  with PropBuilder[CodecBuilder.Property] {
+  extends props.Props[Builders.Property]
+  with PropBuilder[Builders.Property] {
 
   override protected def prop[V, DomV](key: String, codec: Codec[V, DomV]): PropertyBuilder[V] =
     new PropertyBuilder(key, codec.encode)
 }
 
 trait Events
-  extends HTMLElementEventProps[SimpleEmitterBuilder]
-  with EventPropBuilder[SimpleEmitterBuilder, dom.Event] {
+  extends HTMLElementEventProps[Builders.EventEmitter]
+  with EventPropBuilder[Builders.EventEmitter, dom.Event] {
 
-  override def eventProp[V <: dom.Event](key: String): SimpleEmitterBuilder[V] =  EmitterBuilder[V](key)
+  override def eventProp[V <: dom.Event](key: String): Builders.EventEmitter[V] =  EmitterBuilder[V](key)
 }
 
 abstract class WindowEvents

--- a/src/main/scala/outwatch/dom/OutwatchAttributes.scala
+++ b/src/main/scala/outwatch/dom/OutwatchAttributes.scala
@@ -31,20 +31,20 @@ trait OutWatchLifeCycleAttributes {
     * This hook is invoked once the DOM element for a vnode has been inserted into the document
     * and the rest of the patch cycle is done.
     */
-  lazy val onInsert   = InsertHookBuilder
+  lazy val onInsert   = SimpleEmitterBuilder(InsertHook)
 
   /** Lifecycle hook for component prepatch. */
-  lazy val onPrePatch   = PrePatchHookBuilder
+  lazy val onPrePatch   = SimpleEmitterBuilder(PrePatchHook)
 
   /** Lifecycle hook for component updates. */
-  lazy val onUpdate   = UpdateHookBuilder
+  lazy val onUpdate   = SimpleEmitterBuilder(UpdateHook)
 
   /**
     * Lifecycle hook for component postpatch.
     *
     *  This hook is invoked every time a node has been patched against an older instance of itself.
     */
-  lazy val onPostPatch   = PostPatchHookBuilder
+  lazy val onPostPatch   = SimpleEmitterBuilder(PostPatchHook)
 
   /**
     * Lifecycle hook for component destruction.
@@ -52,7 +52,7 @@ trait OutWatchLifeCycleAttributes {
     * This hook is invoked on a virtual node when its DOM element is removed from the DOM
     * or if its parent is being removed from the DOM.
     */
-  lazy val onDestroy  = DestroyHookBuilder
+  lazy val onDestroy  = SimpleEmitterBuilder(DestroyHook)
 }
 
 /** Snabbdom Key Attribute */

--- a/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
+++ b/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
@@ -1,84 +1,56 @@
 package outwatch.dom.helpers
 
 import cats.effect.IO
-import org.scalajs.dom._
+import monix.reactive.Observer
+import org.scalajs.dom.Event
 import outwatch.Sink
-import outwatch.dom.{DestroyHook, Emitter, Hook, InsertHook, Observable, PostPatchHook, PrePatchHook, UpdateHook}
+import outwatch.dom.{Emitter, Observable}
 
 
-trait EmitterBuilder[E <: Event, O] extends Any {
+trait EmitterBuilder[E, O, R] extends Any {
 
-  private[outwatch] def transform[T](tr: Observable[O] => Observable[T]): TransformingEmitterBuilder[E, T]
+  def transform[T](tr: Observable[O] => Observable[T]): EmitterBuilder[E, T, R]
 
-  def apply[T](value: T): TransformingEmitterBuilder[E, T] = map(_ => value)
+  def apply[T](value: T): EmitterBuilder[E, T, R] = map(_ => value)
 
-  def apply[T](latest: Observable[T]): TransformingEmitterBuilder[E, T] = transform(_.withLatestFrom(latest)((_, u) => u))
+  def apply[T](latest: Observable[T]): EmitterBuilder[E, T, R] = transform(_.withLatestFrom(latest)((_, u) => u))
 
   @deprecated("Deprecated, use '.map' instead", "0.11.0")
-  def apply[T](f: O => T): TransformingEmitterBuilder[E, T] = map(f)
+  def apply[T](f: O => T): EmitterBuilder[E, T, R] = map(f)
 
-  def map[T](f: O => T): TransformingEmitterBuilder[E, T] = transform(_.map(f))
+  def map[T](f: O => T): EmitterBuilder[E, T, R] = transform(_.map(f))
 
-  def filter(predicate: O => Boolean): TransformingEmitterBuilder[E, O] = transform(_.filter(predicate))
+  def filter(predicate: O => Boolean): EmitterBuilder[E, O, R] = transform(_.filter(predicate))
 
-  def collect[T](f: PartialFunction[O, T]): TransformingEmitterBuilder[E, T] = transform(_.collect(f))
+  def collect[T](f: PartialFunction[O, T]): EmitterBuilder[E, T, R] = transform(_.collect(f))
 
-  def -->(sink: Sink[_ >: O]): IO[Emitter]
+  def -->(sink: Sink[_ >: O]): IO[R]
 }
 
 object EmitterBuilder extends TargetOps {
-  def apply[E <: Event](eventType: String) = new SimpleEmitterBuilder[E](eventType)
+  def apply[E <: Event](eventType: String): SimpleEmitterBuilder[E, Emitter] =
+    SimpleEmitterBuilder[E, Emitter](observer => Emitter(eventType, event => observer.onNext(event.asInstanceOf[E])))
 }
 
-final case class TransformingEmitterBuilder[E <: Event, O] private[helpers] (
-  eventType: String,
-  transformer: Observable[E] => Observable[O]
-) extends EmitterBuilder[E, O] {
+final case class TransformingEmitterBuilder[E, O, R] private[helpers](
+  transformer: Observable[E] => Observable[O],
+  create: Observer[E] => R
+) extends EmitterBuilder[E, O, R] {
 
-  private[outwatch] def transform[T](tr: Observable[O] => Observable[T]): TransformingEmitterBuilder[E, T] = copy(
+  def transform[T](tr: Observable[O] => Observable[T]): EmitterBuilder[E, T, R] = copy(
     transformer = tr compose transformer
   )
 
-  def -->(sink: Sink[_ >: O]): IO[Emitter] = {
-    val observer = sink.redirect(transformer).observer
-    IO.pure(Emitter(eventType, event => observer.onNext(event.asInstanceOf[E])))
+  def -->(sink: Sink[_ >: O]): IO[R] = {
+    val redirected: Sink[E] = sink.redirect[E](transformer)
+    IO.pure(create(redirected.observer))
   }
 }
 
-final class SimpleEmitterBuilder[E <: Event] private[helpers](
-  val eventType: String
-) extends AnyVal with
-          EmitterBuilder[E, E] {
+final case class SimpleEmitterBuilder[E, R](create: Observer[E] => R) extends AnyVal with EmitterBuilder[E, E, R] {
 
-  private[outwatch] def transform[O](transformer: Observable[E] => Observable[O]) = new TransformingEmitterBuilder[E, O](eventType, transformer)
+  def transform[T](tr: Observable[E] => Observable[T]): EmitterBuilder[E, T, R] =
+    new TransformingEmitterBuilder[E, T, R](tr, create)
 
-  def -->(sink: Sink[_ >: E]): IO[Emitter] = {
-    IO.pure(Emitter(eventType, event => sink.observer.onNext(event.asInstanceOf[E])))
-  }
-}
-
-trait HookBuilder[E, H <: Hook[_]] {
-  def hook(sink: Sink[E]): H
-
-  def -->(sink: Sink[E]): IO[H] = IO.pure(hook(sink))
-}
-
-object InsertHookBuilder extends HookBuilder[Element, InsertHook] {
-  def hook(sink: Sink[Element]) = InsertHook(sink.observer)
-}
-
-object PrePatchHookBuilder extends HookBuilder[(Option[Element], Option[Element]), PrePatchHook] {
-  def hook(sink: Sink[(Option[Element], Option[Element])]) = PrePatchHook(sink.observer)
-}
-
-object UpdateHookBuilder extends HookBuilder[(Element, Element), UpdateHook] {
-  def hook(sink: Sink[(Element, Element)]) = UpdateHook(sink.observer)
-}
-
-object PostPatchHookBuilder extends HookBuilder[(Element, Element), PostPatchHook] {
-  def hook(sink: Sink[(Element, Element)]) = PostPatchHook(sink.observer)
-}
-
-object DestroyHookBuilder extends HookBuilder[Element, DestroyHook] {
-  def hook(sink: Sink[Element]) = DestroyHook(sink.observer)
+  def -->(sink: Sink[_ >: E]): IO[R] = IO.pure(create(sink.observer))
 }

--- a/src/main/scala/outwatch/dom/helpers/TargetOps.scala
+++ b/src/main/scala/outwatch/dom/helpers/TargetOps.scala
@@ -1,24 +1,25 @@
 package outwatch.dom.helpers
 
 import org.scalajs.dom.{Event, html}
+import outwatch.dom.Emitter
 
 trait TargetOps {
 
-  implicit class TargetAsInput[E <: Event, O <: Event](builder: EmitterBuilder[E, O]) {
+  implicit class TargetAsInput[E <: Event, O <: Event](builder: EmitterBuilder[E, O, Emitter]) {
 
     object target {
-      def value: EmitterBuilder[E, String] = builder.map(_.target.asInstanceOf[html.Input].value)
+      def value: EmitterBuilder[E, String, Emitter] = builder.map(_.target.asInstanceOf[html.Input].value)
 
-      def valueAsNumber: EmitterBuilder[E, Int] = builder.map(_.target.asInstanceOf[html.Input].valueAsNumber)
+      def valueAsNumber: EmitterBuilder[E, Int, Emitter] = builder.map(_.target.asInstanceOf[html.Input].valueAsNumber)
 
-      def checked: EmitterBuilder[E, Boolean] = builder.map(_.target.asInstanceOf[html.Input].checked)
+      def checked: EmitterBuilder[E, Boolean, Emitter] = builder.map(_.target.asInstanceOf[html.Input].checked)
     }
 
-    def value: EmitterBuilder[E, String] = builder.map(e => e.currentTarget.asInstanceOf[html.Input].value)
+    def value: EmitterBuilder[E, String, Emitter] = builder.map(e => e.currentTarget.asInstanceOf[html.Input].value)
 
-    def valueAsNumber: EmitterBuilder[E, Int] = builder.map(e => e.currentTarget.asInstanceOf[html.Input].valueAsNumber)
+    def valueAsNumber: EmitterBuilder[E, Int, Emitter] = builder.map(e => e.currentTarget.asInstanceOf[html.Input].valueAsNumber)
 
-    def checked: EmitterBuilder[E, Boolean] = builder.map(e => e.currentTarget.asInstanceOf[html.Input].checked)
+    def checked: EmitterBuilder[E, Boolean, Emitter] = builder.map(e => e.currentTarget.asInstanceOf[html.Input].checked)
   }
 
 }

--- a/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -408,4 +408,27 @@ class LifecycleHookSpec extends JSDomSpec {
   }
 
 
+  "Hooks" should "support emitter operations" in {
+
+    val operations = mutable.ArrayBuffer.empty[String]
+
+    val sink = Sink.create((op: String) => IO {
+      operations += op
+      Continue
+    })
+
+    val divTagName = onInsert.map(_.tagName.toLowerCase).filter(_ == "div")
+
+    val node = div(onInsert("insert") --> sink,
+      div(divTagName --> sink),
+      span(divTagName --> sink)
+    )
+
+    OutWatch.renderInto("#app", node).unsafeRunSync()
+
+    operations.toList shouldBe List("div", "insert")
+
+  }
+
+
 }


### PR DESCRIPTION
Makes `Hooks` and `EmitterBuilder` consistent, closes #152.