### PR TITLE
Remove stringmodifier (work in progress)

### DIFF
--- a/src/main/scala/outwatch/AsVDomModifier.scala
+++ b/src/main/scala/outwatch/AsVDomModifier.scala
@@ -1,7 +1,7 @@
 package outwatch
 
 import cats.effect.IO
-import outwatch.dom.{CompositeModifier, StringModifier, VDomModifier}
+import outwatch.dom.{CompositeModifier, StringVNode, VDomModifier}
 
 trait AsVDomModifier[-T] {
   def asVDomModifier(value: T): VDomModifier
@@ -20,14 +20,14 @@ object AsVDomModifier {
   }
 
   implicit object StringAsVDomModifier extends AsVDomModifier[String] {
-    def asVDomModifier(value: String): VDomModifier = IO.pure(StringModifier(value))
+    def asVDomModifier(value: String): VDomModifier = IO.pure(StringVNode(value))
   }
 
   implicit object IntAsVDomModifier extends AsVDomModifier[Int] {
-    def asVDomModifier(value: Int): VDomModifier = IO.pure(StringModifier(value.toString))
+    def asVDomModifier(value: Int): VDomModifier = IO.pure(StringVNode(value.toString))
   }
 
   implicit object DoubleAsVDomModifier extends AsVDomModifier[Double] {
-    def asVDomModifier(value: Double): VDomModifier = IO.pure(StringModifier(value.toString))
+    def asVDomModifier(value: Double): VDomModifier = IO.pure(StringVNode(value.toString))
   }
 }

--- a/src/main/scala/outwatch/StaticVNodeRender.scala
+++ b/src/main/scala/outwatch/StaticVNodeRender.scala
@@ -1,13 +1,21 @@
 package outwatch
 
 import cats.effect.IO
-import outwatch.dom.{StaticVNode, StringVNode}
+import outwatch.dom.{StaticVNode, StringVNode, VNode}
 
 trait StaticVNodeRender[-T] {
   def render(value: T): IO[StaticVNode]
 }
 
 object StaticVNodeRender {
+
+  implicit def vNodeRender: StaticVNodeRender[VNode] = {
+    (value: VNode) => value
+  }
+
+  implicit def optionRender[T](implicit svnr: StaticVNodeRender[T]): StaticVNodeRender[Option[T]] = {
+    (value: Option[T]) => value.fold(IO.pure(StringVNode(""):StaticVNode))(svnr.render _)
+  }
 
   implicit object StringRender extends StaticVNodeRender[String] {
     def render(value: String): IO[StaticVNode] = IO.pure(StringVNode(value))

--- a/src/main/scala/outwatch/dom/Implicits.scala
+++ b/src/main/scala/outwatch/dom/Implicits.scala
@@ -17,6 +17,7 @@ trait Implicits {
   implicit def StyleIsBuilder[T](style: keys.Style[T]): BasicStyleBuilder[T] = new BasicStyleBuilder[T](style.cssName)
 
   private[outwatch] implicit class SeqIOSequence[T](args: Seq[IO[T]]) {
+    //TODO: is it possible to use a cats instance instead?
     def sequence: IO[Seq[T]] = args.foldRight(IO.pure(List.empty[T]))((a, l) => a.map2(l)(_ :: _))
   }
 }

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -41,7 +41,6 @@ VDomModifier_
   Emitter
   AttributeStreamReceiver
   CompositeModifier
-  StringModifier
   EmptyModifier
  */
 
@@ -60,7 +59,6 @@ private[outwatch] final case class CompositeModifier(modifiers: Seq[VDomModifier
 
 case object EmptyModifier extends VDomModifier_
 
-private[outwatch] final case class StringModifier(string: String) extends VDomModifier_
 
 sealed trait ChildVNode extends Any with VDomModifier_
 

--- a/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
+++ b/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
@@ -206,8 +206,6 @@ private[outwatch] trait SnabbdomModifiers { self: SeparatedModifiers =>
         implicit val scheduler = s
         val childProxies: js.Array[VNodeProxy] = vnodes.collect { case s: StaticVNode => s.asProxy }(breakOut)
         hFunction(nodeType, dataObject, childProxies)
-      case Children.StringModifiers(textChildren) =>
-        hFunction(nodeType, dataObject, textChildren.map(_.string).mkString)
       case Children.Empty =>
         hFunction(nodeType, dataObject)
     }

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -8,8 +8,6 @@ package object dom extends Implicits with ManagedSubscriptions with SideEffects 
   type VDomModifier = IO[VDomModifier_]
   object VDomModifier {
     val empty: VDomModifier = IO.pure(EmptyModifier)
-
-    def apply(modifiers: VDomModifier*): VDomModifier = modifiers.sequence.map(CompositeModifier)
   }
 
   type Observable[+A] = monix.reactive.Observable[A]

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -831,6 +831,13 @@ class OutWatchDomSpec extends JSDomSpec {
     OutWatch.renderReplace(node, div("one")).unsafeRunSync()
     node.innerHTML shouldBe "one"
 
+    OutWatch.renderReplace(node, div(Some("one"))).unsafeRunSync()
+    node.innerHTML shouldBe "one"
+
+    val node2 = document.createElement("div")
+    OutWatch.renderReplace(node2, div(None:Option[Int])).unsafeRunSync()
+    node2.innerHTML shouldBe ""
+
     OutWatch.renderReplace(node, div(1)).unsafeRunSync()
     node.innerHTML shouldBe "1"
 
@@ -857,6 +864,36 @@ class OutWatchDomSpec extends JSDomSpec {
 
     val element = document.getElementById("strings")
     element.innerHTML shouldBe "ab"
+  }
+
+  "Child stream" should "work for string options" in {
+    val myOption: Handler[Option[String]] = Handler.create(Option("a")).unsafeRunSync()
+    val node = div(id := "strings",
+      child <-- myOption
+    )
+
+    OutWatch.renderInto("#app", node).unsafeRunSync()
+
+    val element = document.getElementById("strings")
+    element.innerHTML shouldBe "a"
+
+    myOption.unsafeOnNext(None)
+    element.innerHTML shouldBe ""
+  }
+
+  "Child stream" should "work for vnode options" in {
+    val myOption: Handler[Option[VNode]] = Handler.create(Option(div("a"))).unsafeRunSync()
+    val node = div(id := "strings",
+      child <-- myOption
+    )
+
+    OutWatch.renderInto("#app", node).unsafeRunSync()
+
+    val element = document.getElementById("strings")
+    element.innerHTML shouldBe "<div>a</div>"
+
+    myOption.unsafeOnNext(None)
+    element.innerHTML shouldBe ""
   }
 
   "LocalStorage" should "provide a handler" in {


### PR DESCRIPTION
I found that we could probably remove `StringModifier`, since it is converted to `StringVNode` anyways. I'm not sure If I'm missing something.

based on #161