### PR TITLE
No need for Sink.create arguments functions to return IO

### DIFF
--- a/src/main/scala/outwatch/SideEffects.scala
+++ b/src/main/scala/outwatch/SideEffects.scala
@@ -1,11 +1,10 @@
 package outwatch
 
-import monix.execution.Scheduler
 import monix.execution.Ack.Continue
-import cats.effect.IO
+import monix.execution.Scheduler
 
 trait SideEffects {
-  def sideEffect[T](f: T => Unit)(implicit s: Scheduler): Sink[T] = Sink.create[T] { e => IO { f(e); Continue } }(s)
-  def sideEffect[S,T](f: (S,T) => Unit)(implicit s: Scheduler): Sink[(S,T)] = Sink.create[(S,T)] { e => IO { f(e._1, e._2); Continue } }(s)
-  def sideEffect(f: => Unit)(implicit s: Scheduler): Sink[Any] = Sink.create[Any] { e => IO { f; Continue } }(s)
+  def sideEffect[T](f: T => Unit)(implicit s: Scheduler): Sink[T] = Sink.create[T] { e => f(e); Continue }(s)
+  def sideEffect[S, T](f: (S, T) => Unit)(implicit s: Scheduler): Sink[(S, T)] = Sink.create[(S, T)] { e => f(e._1, e._2); Continue }(s)
+  def sideEffect(f: => Unit)(implicit s: Scheduler): Sink[Any] = Sink.create[Any] { e => f; Continue }(s)
 }

--- a/src/main/scala/outwatch/Sink.scala
+++ b/src/main/scala/outwatch/Sink.scala
@@ -76,15 +76,15 @@ object Sink {
     * @tparam T the type parameter of the consumed elements.
     * @return a Sink that consumes elements of type T.
     */
-  def create[T](next: T => IO[Future[Ack]],
-                error: Throwable => IO[Unit] = _ => IO.pure(()),
-                complete: () => IO[Unit] = () => IO.pure(())
+  def create[T](next: T => Future[Ack],
+                error: Throwable => Unit = _ => (),
+                complete: () => Unit = () => ()
                )(implicit s: Scheduler): Sink[T] = {
     val sink = ObserverSink(
       new Observer[T] {
-        override def onNext(t: T): Future[Ack] = next(t).unsafeRunSync()
-        override def onError(ex: Throwable): Unit = error(ex).unsafeRunSync()
-        override def onComplete(): Unit = complete().unsafeRunSync()
+        override def onNext(t: T): Future[Ack] = next(t)
+        override def onError(ex: Throwable): Unit = error(ex)
+        override def onComplete(): Unit = complete()
       }
     )
     sink

--- a/src/main/scala/outwatch/dom/ManagedSubscriptions.scala
+++ b/src/main/scala/outwatch/dom/ManagedSubscriptions.scala
@@ -10,10 +10,10 @@ trait ManagedSubscriptions {
 
   def managed(subscription: IO[Cancelable])(implicit s: Scheduler): VDomModifier = {
     subscription.flatMap { sub: Cancelable =>
-      lifecycle.onDestroy --> Sink.create(_ => IO {
+      lifecycle.onDestroy --> Sink.create{_ =>
         sub.cancel()
         Continue
-      })
+      }
     }
   }
 
@@ -21,10 +21,10 @@ trait ManagedSubscriptions {
 
     (sub1 :: sub2 :: subscriptions.toList).sequence.flatMap { subs: Seq[Cancelable] =>
       val composite = CompositeCancelable(subs: _*)
-      lifecycle.onDestroy --> Sink.create(_ => IO {
+      lifecycle.onDestroy --> Sink.create{_ =>
         composite.cancel()
         Continue
-      })
+      }
     }
   }
 

--- a/src/main/scala/outwatch/util/WebSocket.scala
+++ b/src/main/scala/outwatch/util/WebSocket.scala
@@ -1,6 +1,5 @@
 package outwatch.util
 
-import cats.effect.IO
 import monix.execution.Ack.Continue
 import monix.execution.{Cancelable, Scheduler}
 import monix.reactive.OverflowStrategy.Unbounded
@@ -24,12 +23,12 @@ final case class WebSocket private(url: String)(implicit s: Scheduler) {
   })
 
   lazy val sink = Sink.create[String](
-    s => IO {
+    s => {
       ws.send(s)
       Continue
     },
-    _ => IO.pure(()),
-    () => IO(ws.close())
+    _ => (),
+    () => ws.close()
   )
 
 }

--- a/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -1,6 +1,5 @@
 package outwatch
 
-import cats.effect.IO
 import monix.execution.Ack.Continue
 import monix.reactive.Observable
 import monix.reactive.subjects.PublishSubject
@@ -15,10 +14,10 @@ class LifecycleHookSpec extends JSDomSpec {
   "Insertion hooks" should "be called correctly" in {
 
     var switch = false
-    val sink = Sink.create((_: Element) => IO {
+    val sink = Sink.create{(_: Element) =>
       switch = true
       Continue
-    })
+    }
 
     val node = div(onInsert --> sink)
 
@@ -32,15 +31,15 @@ class LifecycleHookSpec extends JSDomSpec {
 
   it should "be called correctly on merged nodes" in {
     var switch = false
-    val sink = Sink.create((_: Element) => IO{
+    val sink = Sink.create{(_: Element) =>
       switch = true
       Continue
-    })
+    }
     var switch2 = false
-    val sink2 = Sink.create((_: Element) => IO{
+    val sink2 = Sink.create{(_: Element) =>
       switch2 = true
       Continue
-    })
+    }
 
     val node = div(onInsert --> sink)(onInsert --> sink2)
 
@@ -58,10 +57,10 @@ class LifecycleHookSpec extends JSDomSpec {
   "Destruction hooks"  should "be called correctly" in {
 
     var switch = false
-    val sink = Sink.create((_: Element) => IO {
+    val sink = Sink.create{(_: Element) =>
       switch = true
       Continue
-    })
+    }
 
     val node = div(child <-- Observable(span(onDestroy --> sink), div("Hasdasd")))
 
@@ -76,15 +75,15 @@ class LifecycleHookSpec extends JSDomSpec {
   it should "be called correctly on merged nodes" in {
 
     var switch = false
-    val sink = Sink.create((_: Element) => IO{
+    val sink = Sink.create{(_: Element) =>
       switch = true
       Continue
-    })
+    }
     var switch2 = false
-    val sink2 = Sink.create((_: Element) => IO{
+    val sink2 = Sink.create{(_: Element) =>
       switch2 = true
       Continue
-    })
+    }
 
     val node = div(child <-- Observable(span(onDestroy --> sink)(onDestroy --> sink2), div("Hasdasd")))
 
@@ -99,15 +98,15 @@ class LifecycleHookSpec extends JSDomSpec {
 
   "Update hooks" should "be called correctly on merged nodes" in {
     var switch1 = false
-    val sink1 = Sink.create((_: (Element, Element)) => IO{
+    val sink1 = Sink.create{(_: (Element, Element)) =>
       switch1 = true
       Continue
-    })
+    }
     var switch2 = false
-    val sink2 = Sink.create((_: (Element, Element)) => IO{
+    val sink2 = Sink.create{(_: (Element, Element)) =>
       switch2 = true
       Continue
-    })
+    }
 
     val message = PublishSubject[String]
     val node = div(child <-- message, onUpdate --> sink1)(onUpdate --> sink2)
@@ -125,10 +124,10 @@ class LifecycleHookSpec extends JSDomSpec {
   it should "be called correctly" in {
 
     var switch = false
-    val sink = Sink.create((_: (Element, Element)) => IO {
+    val sink = Sink.create{(_: (Element, Element)) =>
       switch = true
       Continue
-    })
+    }
 
     val node = div(child <-- Observable(span(onUpdate --> sink, "Hello"), span(onUpdate --> sink, "Hey")))
 
@@ -143,10 +142,10 @@ class LifecycleHookSpec extends JSDomSpec {
   "Prepatch hooks" should "be called" in {
 
     var switch = false
-    val sink = Sink.create((_: (Option[Element], Option[Element])) => IO {
+    val sink = Sink.create{(_: (Option[Element], Option[Element])) =>
       switch = true
       Continue
-    })
+    }
 
     val node = div(child <-- Observable(span("Hello")), span(attributes.key := "1", onPrePatch --> sink, "Hey"))
 
@@ -159,15 +158,15 @@ class LifecycleHookSpec extends JSDomSpec {
 
   it should "be called correctly on merged nodes" in {
     var switch1 = false
-    val sink1 = Sink.create((_: (Option[Element], Option[Element])) => IO {
+    val sink1 = Sink.create{(_: (Option[Element], Option[Element])) =>
       switch1 = true
       Continue
-    })
+    }
     var switch2 = false
-    val sink2 = Sink.create((_: (Option[Element], Option[Element])) => IO {
+    val sink2 = Sink.create{(_: (Option[Element], Option[Element])) =>
       switch2 = true
       Continue
-    })
+    }
     val message = PublishSubject[String]()
     val node = div(child <-- message, onPrePatch --> sink1)(onPrePatch --> sink2)
 
@@ -184,10 +183,10 @@ class LifecycleHookSpec extends JSDomSpec {
   "Postpatch hooks" should "be called" in {
 
     var switch = false
-    val sink = Sink.create((_: (Element, Element)) => IO {
+    val sink = Sink.create{(_: (Element, Element)) =>
       switch = true
       Continue
-    })
+    }
 
     val node = div(child <-- Observable("message"), onPostPatch --> sink, "Hey")
 
@@ -201,15 +200,15 @@ class LifecycleHookSpec extends JSDomSpec {
 
   it should "be called correctly on merged nodes" in {
     var switch1 = false
-    val sink1 = Sink.create((_: (Element, Element)) => IO {
+    val sink1 = Sink.create{(_: (Element, Element)) =>
       switch1 = true
       Continue
-    })
+    }
     var switch2 = false
-    val sink2 = Sink.create((_: (Element, Element)) => IO {
+    val sink2 = Sink.create{(_: (Element, Element)) =>
       switch2 = true
       Continue
-    })
+    }
     val message = PublishSubject[String]()
     val node = div(child <-- message, onPostPatch --> sink1)(onPostPatch --> sink2)
 
@@ -226,36 +225,27 @@ class LifecycleHookSpec extends JSDomSpec {
 
   "Hooks" should "be called in the correct order for modified node" in {
     val hooks = mutable.ArrayBuffer.empty[String]
-    val insertSink = Sink.create((_: Element) =>
-      IO {
-        hooks += "insert"
-        Continue
-      }
-    )
-    val prepatchSink = Sink.create((_: (Option[Element], Option[Element])) =>
-      IO {
-        hooks += "prepatch"
-        Continue
-      }
-    )
-    val updateSink = Sink.create((_: (Element, Element)) =>
-      IO {
-        hooks += "update"
-        Continue
-      }
-    )
-    val postpatchSink = Sink.create((_: (Element, Element)) =>
-      IO {
-        hooks += "postpatch"
-        Continue
-      }
-    )
-    val destroySink = Sink.create((_: Element) =>
-      IO {
-        hooks += "destroy"
-        Continue
-      }
-    )
+    val insertSink = Sink.create { (_: Element) =>
+      hooks += "insert"
+      Continue
+    }
+    val prepatchSink = Sink.create { (_: (Option[Element], Option[Element])) =>
+      hooks += "prepatch"
+      Continue
+    }
+    val updateSink = Sink.create { (_: (Element, Element)) =>
+      hooks += "update"
+      Continue
+    }
+    val postpatchSink = Sink.create { (_: (Element, Element)) =>
+      hooks += "postpatch"
+      Continue
+
+    }
+    val destroySink = Sink.create { (_: Element) =>
+      hooks += "destroy"
+      Continue
+    }
 
     val message = PublishSubject[String]()
     val node = div(child <-- message,
@@ -279,18 +269,14 @@ class LifecycleHookSpec extends JSDomSpec {
 
   "Empty single children receiver" should "not trigger node update on render" in {
     val hooks = mutable.ArrayBuffer.empty[String]
-    val insertSink = Sink.create((_: Element) =>
-      IO {
-        hooks += "insert"
-        Continue
-      }
-    )
-    val updateSink = Sink.create((_: (Element, Element)) =>
-      IO {
-        hooks += "update"
-        Continue
-      }
-    )
+    val insertSink = Sink.create { (_: Element) =>
+      hooks += "insert"
+      Continue
+    }
+    val updateSink = Sink.create { (_: (Element, Element)) =>
+      hooks += "update"
+      Continue
+    }
 
     val messageList = PublishSubject[Seq[String]]()
     val node = div("Hello",  children <-- messageList.map(_.map(span(_))),
@@ -307,24 +293,18 @@ class LifecycleHookSpec extends JSDomSpec {
 
   "Static child nodes" should "not be destroyed and inserted when child stream emits" in {
     val hooks = mutable.ArrayBuffer.empty[String]
-    val insertSink = Sink.create((_: Element) =>
-      IO {
-        hooks += "insert"
-        Continue
-      }
-    )
-    val updateSink = Sink.create((_: (Element, Element)) =>
-      IO {
-        hooks += "update"
-        Continue
-      }
-    )
-    val destroySink = Sink.create((_: Element) =>
-      IO {
-        hooks += "destroy"
-        Continue
-      }
-    )
+    val insertSink = Sink.create { (_: Element) =>
+      hooks += "insert"
+      Continue
+    }
+    val updateSink = Sink.create { (_: (Element, Element)) =>
+      hooks += "update"
+      Continue
+    }
+    val destroySink = Sink.create { (_: Element) =>
+      hooks += "destroy"
+      Continue
+    }
 
     val message = PublishSubject[String]()
     val node = div(span("Hello", onInsert --> insertSink, onUpdate --> updateSink, onDestroy --> destroySink),
@@ -342,24 +322,18 @@ class LifecycleHookSpec extends JSDomSpec {
 
   it should "be only inserted once when children stream emits" in {
     val hooks = mutable.ArrayBuffer.empty[String]
-    val insertSink = Sink.create((_: Element) =>
-      IO {
-        hooks += "insert"
-        Continue
-      }
-    )
-    val updateSink = Sink.create((_: (Element, Element)) =>
-      IO {
-        hooks += "update"
-        Continue
-      }
-    )
-    val destroySink = Sink.create((_: Element) =>
-      IO {
-        hooks += "destroy"
-        Continue
-      }
-    )
+    val insertSink = Sink.create { (_: Element) =>
+      hooks += "insert"
+      Continue
+    }
+    val updateSink = Sink.create { (_: (Element, Element)) =>
+      hooks += "update"
+      Continue
+    }
+    val destroySink = Sink.create { (_: Element) =>
+      hooks += "destroy"
+      Continue
+    }
 
     val messageList = PublishSubject[Seq[String]]()
     val node = div(children <-- messageList.map(_.map(span(_))),
@@ -383,10 +357,10 @@ class LifecycleHookSpec extends JSDomSpec {
     val nodes = PublishSubject[VNode]
 
     var latest = ""
-    val sink = Sink.create((elem: String) => IO {
+    val sink = Sink.create { (elem: String) =>
       latest = elem
       Continue
-    })
+    }
 
     val sub = PublishSubject[String]
 
@@ -412,10 +386,10 @@ class LifecycleHookSpec extends JSDomSpec {
 
     val operations = mutable.ArrayBuffer.empty[String]
 
-    val sink = Sink.create((op: String) => IO {
+    val sink = Sink.create { (op: String) =>
       operations += op
       Continue
-    })
+    }
 
     val divTagName = onInsert.map(_.tagName.toLowerCase).filter(_ == "div")
 
@@ -429,6 +403,5 @@ class LifecycleHookSpec extends JSDomSpec {
     operations.toList shouldBe List("div", "insert")
 
   }
-
 
 }

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -51,7 +51,7 @@ class OutWatchDomSpec extends JSDomSpec {
         Seq(
           div(),
           attributes.`class` := "blue",
-          attributes.onClick(1) --> Sink.create[Int](_ => IO.pure{(); Continue}),
+          attributes.onClick(1) --> Sink.create[Int](_ => Continue),
           attributes.hidden <-- Observable(false)
         ).map(_.unsafeRunSync())
       ),


### PR DESCRIPTION
There is no need for `Sink.create` arguments functions to return `IO`s. Any side-effects that these functions might perform are suspended in the closures.