### PR TITLE
Wrap Sink.create in IO

### DIFF
--- a/src/main/scala/outwatch/SideEffects.scala
+++ b/src/main/scala/outwatch/SideEffects.scala
@@ -4,7 +4,7 @@ import monix.execution.Ack.Continue
 import monix.execution.Scheduler
 
 trait SideEffects {
-  def sideEffect[T](f: T => Unit)(implicit s: Scheduler): Sink[T] = Sink.create[T] { e => f(e); Continue }(s)
-  def sideEffect[S, T](f: (S, T) => Unit)(implicit s: Scheduler): Sink[(S, T)] = Sink.create[(S, T)] { e => f(e._1, e._2); Continue }(s)
-  def sideEffect(f: => Unit)(implicit s: Scheduler): Sink[Any] = Sink.create[Any] { e => f; Continue }(s)
+  def sideEffect[T](f: T => Unit)(implicit s: Scheduler): Sink[T] = Sink.create[T] { e => f(e); Continue }(s).unsafeRunSync()
+  def sideEffect[S, T](f: (S, T) => Unit)(implicit s: Scheduler): Sink[(S, T)] = Sink.create[(S, T)] { e => f(e._1, e._2); Continue }(s).unsafeRunSync()
+  def sideEffect(f: => Unit)(implicit s: Scheduler): Sink[Any] = Sink.create[Any] { e => f; Continue }(s).unsafeRunSync()
 }

--- a/src/main/scala/outwatch/Sink.scala
+++ b/src/main/scala/outwatch/Sink.scala
@@ -79,15 +79,16 @@ object Sink {
   def create[T](next: T => Future[Ack],
                 error: Throwable => Unit = _ => (),
                 complete: () => Unit = () => ()
-               )(implicit s: Scheduler): Sink[T] = {
-    val sink = ObserverSink(
-      new Observer[T] {
-        override def onNext(t: T): Future[Ack] = next(t)
-        override def onError(ex: Throwable): Unit = error(ex)
-        override def onComplete(): Unit = complete()
-      }
-    )
-    sink
+               )(implicit s: Scheduler): IO[Sink[T]] = {
+    IO{
+      ObserverSink(
+        new Observer[T] {
+          override def onNext(t: T): Future[Ack] = next(t)
+          override def onError(ex: Throwable): Unit = error(ex)
+          override def onComplete(): Unit = complete()
+        }
+      )
+    }
   }
 
 

--- a/src/main/scala/outwatch/dom/ManagedSubscriptions.scala
+++ b/src/main/scala/outwatch/dom/ManagedSubscriptions.scala
@@ -4,16 +4,17 @@ import cats.effect.IO
 import monix.execution.Ack.Continue
 import monix.execution.cancelables.CompositeCancelable
 import monix.execution.{Cancelable, Scheduler}
+import org.scalajs.dom
 import outwatch.dom.dsl.attributes.lifecycle
 
 trait ManagedSubscriptions {
 
   def managed(subscription: IO[Cancelable])(implicit s: Scheduler): VDomModifier = {
     subscription.flatMap { sub: Cancelable =>
-      lifecycle.onDestroy --> Sink.create{_ =>
+      Sink.create[dom.Element] { _ =>
         sub.cancel()
         Continue
-      }
+      }.flatMap( sink => lifecycle.onDestroy --> sink)
     }
   }
 
@@ -21,10 +22,10 @@ trait ManagedSubscriptions {
 
     (sub1 :: sub2 :: subscriptions.toList).sequence.flatMap { subs: Seq[Cancelable] =>
       val composite = CompositeCancelable(subs: _*)
-      lifecycle.onDestroy --> Sink.create{_ =>
+      Sink.create[dom.Element]{ _ =>
         composite.cancel()
         Continue
-      }
+      }.flatMap(sink => lifecycle.onDestroy --> sink)
     }
   }
 

--- a/src/main/scala/outwatch/util/WebSocket.scala
+++ b/src/main/scala/outwatch/util/WebSocket.scala
@@ -1,5 +1,6 @@
 package outwatch.util
 
+import cats.effect.IO
 import monix.execution.Ack.Continue
 import monix.execution.{Cancelable, Scheduler}
 import monix.reactive.OverflowStrategy.Unbounded
@@ -8,7 +9,7 @@ import outwatch.Sink
 import outwatch.dom.Observable
 
 object WebSocket {
-  implicit def toSink(socket: WebSocket): Sink[String] = socket.sink
+  implicit def toSink(socket: WebSocket): IO[Sink[String]] = socket.sink
   implicit def toSource(socket: WebSocket): Observable[MessageEvent] = socket.source
 }
 

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -51,7 +51,7 @@ class OutWatchDomSpec extends JSDomSpec {
         Seq(
           div(),
           attributes.`class` := "blue",
-          attributes.onClick(1) --> Sink.create[Int](_ => Continue),
+          attributes.onClick(1) --> Sink.create[Int](_ => Continue).unsafeRunSync(),
           attributes.hidden <-- Observable(false)
         ).map(_.unsafeRunSync())
       ),


### PR DESCRIPTION
Wrap `Sink.create` in `IO`. Fixes #81.

On top of #164.