### PR TITLE
Renames / Refactorings

### DIFF
--- a/src/main/scala/outwatch/Sink.scala
+++ b/src/main/scala/outwatch/Sink.scala
@@ -24,7 +24,7 @@ sealed trait Sink[-T] extends Any {
 
   private[outwatch] def observer: Subscriber[T]
 
-  def unsafeOnNext(value:T):Future[Ack] = observer.onNext(value)
+  def unsafeOnNext(value: T): Future[Ack] = observer.onNext(value)
 
   /**
     * Creates a new sink. That sink will transform the values it receives and then forward them along to this sink.

--- a/src/main/scala/outwatch/dom/DomTypes.scala
+++ b/src/main/scala/outwatch/dom/DomTypes.scala
@@ -1,14 +1,14 @@
 package outwatch.dom
 
-import com.raquo.domtypes.generic.builders._
+import com.raquo.domtypes.generic.builders
 import com.raquo.domtypes.generic.keys
-import com.raquo.domtypes.generic.codecs._
+import com.raquo.domtypes.generic.codecs
 import com.raquo.domtypes.generic.defs.attrs
 import com.raquo.domtypes.generic.defs.reflectedAttrs
 import com.raquo.domtypes.generic.defs.props
 import com.raquo.domtypes.generic.defs.styles
 import com.raquo.domtypes.generic.defs.sameRefTags._
-import com.raquo.domtypes.jsdom.defs.eventProps._
+import com.raquo.domtypes.jsdom.defs.eventProps
 import cats.effect.IO
 import org.scalajs.dom
 import helpers._
@@ -17,49 +17,40 @@ import monix.reactive.OverflowStrategy.Unbounded
 
 import scala.scalajs.js
 
-private[outwatch] object Builders {
-  type Attribute[T, _] = helpers.ValueBuilder[T, Attr]
-  type Property[T, _] = helpers.PropertyBuilder[T]
+private[outwatch] object BuilderTypes {
+  type Attribute[T, _] = helpers.AttributeBuilder[T, Attr]
+  type Property[T, _] = helpers.PropBuilder[T]
   type EventEmitter[E <: dom.Event] = SimpleEmitterBuilder[E, Emitter]
 }
 
-private[outwatch] object DomTypesBuilder {
-  type VNode = IO[VTree]
-  type GenericVNode[T] = VNode
-
-  trait VNodeBuilder extends TagBuilder[GenericVNode, VNode] {
-    // we can ignore information about void tags here, because snabbdom handles this automatically for us based on the tagname.
-    protected override def tag[Ref <: VNode](tagName: String, void: Boolean): VNode = IO.pure(VTree(tagName, Seq.empty))
-  }
-
-  object CodecBuilder {
-    def encodeAttribute[V](codec: Codec[V, String]): V => Attr.Value = codec match {
-      //The BooleanAsAttrPresenceCodec does not play well with snabbdom. it
-      //encodes true as "" and false as null, whereas snabbdom needs true/false
-      //of type boolean (not string) for toggling the presence of the attribute.
-      case _: BooleanAsAttrPresenceCodec.type => identity
-      case _ => codec.encode
-    }
-  }
-
-  abstract class ObservableEventPropBuilder(target: dom.EventTarget) extends EventPropBuilder[Observable, dom.Event] {
-    override def eventProp[V <: dom.Event](key: String): Observable[V] = Observable.create(Unbounded) { obs =>
-      val eventHandler: js.Function1[V, Ack] = obs.onNext _
-      target.addEventListener(key, eventHandler)
-      Cancelable(() => target.removeEventListener(key, eventHandler))
-    }
+private[outwatch] object CodecBuilder {
+  def encodeAttribute[V](codec: codecs.Codec[V, String]): V => Attr.Value = codec match {
+    //The BooleanAsAttrPresenceCodec does not play well with snabbdom. it
+    //encodes true as "" and false as null, whereas snabbdom needs true/false
+    //of type boolean (not string) for toggling the presence of the attribute.
+    case _: codecs.BooleanAsAttrPresenceCodec.type => identity
+    case _ => codec.encode
   }
 }
-import DomTypesBuilder._
+
+// Tags
+
+private[outwatch] trait TagBuilder extends builders.TagBuilder[TagBuilder.Tag, VNode] {
+  // we can ignore information about void tags here, because snabbdom handles this automatically for us based on the tagname.
+  protected override def tag[Ref <: VNode](tagName: String, void: Boolean): VNode = IO.pure(VTree(tagName, Seq.empty))
+}
+private[outwatch] object TagBuilder {
+  type Tag[T] = VNode
+}
 
 trait Tags
-  extends EmbedTags[GenericVNode, VNode]
-  with GroupingTags[GenericVNode, VNode]
-  with TextTags[GenericVNode, VNode]
-  with FormTags[GenericVNode, VNode]
-  with SectionTags[GenericVNode, VNode]
-  with TableTags[GenericVNode, VNode]
-  with VNodeBuilder
+  extends EmbedTags[TagBuilder.Tag, VNode]
+  with GroupingTags[TagBuilder.Tag, VNode]
+  with TextTags[TagBuilder.Tag, VNode]
+  with FormTags[TagBuilder.Tag, VNode]
+  with SectionTags[TagBuilder.Tag, VNode]
+  with TableTags[TagBuilder.Tag, VNode]
+  with TagBuilder
   with TagHelpers
   with TagsCompat
 
@@ -67,9 +58,11 @@ trait Tags
 object Tags extends Tags
 
 trait TagsExtra
-  extends DocumentTags[GenericVNode, VNode]
-  with MiscTags[GenericVNode, VNode]
-  with VNodeBuilder
+  extends DocumentTags[TagBuilder.Tag, VNode]
+  with MiscTags[TagBuilder.Tag, VNode]
+  with TagBuilder
+
+// all Attributes
 
 trait Attributes
   extends Attrs
@@ -84,22 +77,23 @@ trait Attributes
 object Attributes extends Attributes
 
 // Attrs
-trait Attrs
-  extends attrs.Attrs[AttributeBuilder]
-  with AttrBuilder[AttributeBuilder] {
 
-  override protected def attr[V](key: String, codec: Codec[V, String]): AttributeBuilder[V] =
-    new AttributeBuilder(key, CodecBuilder.encodeAttribute(codec))
+trait Attrs
+  extends attrs.Attrs[BasicAttrBuilder]
+  with builders.AttrBuilder[BasicAttrBuilder] {
+
+  override protected def attr[V](key: String, codec: codecs.Codec[V, String]): BasicAttrBuilder[V] =
+    new BasicAttrBuilder(key, CodecBuilder.encodeAttribute(codec))
 }
 
 // Reflected attrs
 
 trait ReflectedAttrs
-  extends reflectedAttrs.ReflectedAttrs[Builders.Attribute]
-  with ReflectedAttrBuilder[Builders.Attribute] {
+  extends reflectedAttrs.ReflectedAttrs[BuilderTypes.Attribute]
+  with builders.ReflectedAttrBuilder[BuilderTypes.Attribute] {
 
   // super.className.accum(" ") would have been nicer, but we can't do super.className on a lazy val
-  override lazy val className = new AccumAttributeBuilder[String]("class",
+  override lazy val className = new AccumAttrBuilder[String]("class",
     stringReflectedAttr(attrKey = "class", propKey = "className"),
     _ + " " + _
   )
@@ -107,43 +101,57 @@ trait ReflectedAttrs
   override protected def reflectedAttr[V, DomPropV](
     attrKey: String,
     propKey: String,
-    attrCodec: Codec[V, String],
-    propCodec: Codec[V, DomPropV]
-  ) = new AttributeBuilder(attrKey, CodecBuilder.encodeAttribute(attrCodec))
+    attrCodec: codecs.Codec[V, String],
+    propCodec: codecs.Codec[V, DomPropV]
+  ) = new BasicAttrBuilder(attrKey, CodecBuilder.encodeAttribute(attrCodec))
     //or: new PropertyBuilder(propKey, propCodec.encode)
 }
 
 // Props
 trait Props
-  extends props.Props[Builders.Property]
-  with PropBuilder[Builders.Property] {
+  extends props.Props[BuilderTypes.Property]
+  with builders.PropBuilder[BuilderTypes.Property] {
 
-  override protected def prop[V, DomV](key: String, codec: Codec[V, DomV]): PropertyBuilder[V] =
-    new PropertyBuilder(key, codec.encode)
+  override protected def prop[V, DomV](key: String, codec: codecs.Codec[V, DomV]): PropBuilder[V] =
+    new PropBuilder(key, codec.encode)
 }
 
-trait Events
-  extends HTMLElementEventProps[Builders.EventEmitter]
-  with EventPropBuilder[Builders.EventEmitter, dom.Event] {
 
-  override def eventProp[V <: dom.Event](key: String): Builders.EventEmitter[V] =  EmitterBuilder[V](key)
+// Events
+trait Events
+  extends eventProps.HTMLElementEventProps[BuilderTypes.EventEmitter]
+  with builders.EventPropBuilder[BuilderTypes.EventEmitter, dom.Event] {
+
+  override def eventProp[V <: dom.Event](key: String): BuilderTypes.EventEmitter[V] =  EmitterBuilder[V](key)
+}
+
+
+// Window / Document events
+
+private[outwatch] abstract class ObservableEventPropBuilder(target: dom.EventTarget)
+  extends builders.EventPropBuilder[Observable, dom.Event] {
+  override def eventProp[V <: dom.Event](key: String): Observable[V] = Observable.create(Unbounded) { obs =>
+    val eventHandler: js.Function1[V, Ack] = obs.onNext _
+    target.addEventListener(key, eventHandler)
+    Cancelable(() => target.removeEventListener(key, eventHandler))
+  }
 }
 
 abstract class WindowEvents
   extends ObservableEventPropBuilder(dom.window)
-  with WindowEventProps[Observable]
+  with eventProps.WindowEventProps[Observable]
 
 abstract class DocumentEvents
   extends ObservableEventPropBuilder(dom.document)
-  with DocumentEventProps[Observable]
+  with eventProps.DocumentEventProps[Observable]
 
+// Styles
 
-private[outwatch] trait SimpleStyleBuilder extends StyleBuilders[IO[Style]] {
+private[outwatch] trait SimpleStyleBuilder extends builders.StyleBuilders[IO[Style]] {
   override protected def buildDoubleStyleSetter(style: keys.Style[Double], value: Double): IO[Style] = style := value
-  override protected def buildIntStyleSetter(style: keys.Style[Int],value: Int): IO[Style] = style := value
-  override protected def buildStringStyleSetter(style: keys.Style[_],value: String): IO[Style] = new BasicStyleBuilder[Any](style.cssName) := value
+  override protected def buildIntStyleSetter(style: keys.Style[Int], value: Int): IO[Style] = style := value
+  override protected def buildStringStyleSetter(style: keys.Style[_], value: String): IO[Style] = new BasicStyleBuilder[Any](style.cssName) := value
 }
-
 
 trait Styles
   extends styles.Styles[IO[Style]]

--- a/src/main/scala/outwatch/dom/OutWatch.scala
+++ b/src/main/scala/outwatch/dom/OutWatch.scala
@@ -14,13 +14,13 @@ object OutWatch {
     _ <- IO {
       val elem = dom.document.createElement("app")
       element.appendChild(elem)
-      patch(elem, node.asProxy)
+      patch(elem, node.toSnabbdom)
     }
   } yield ()
 
   def renderReplace(element: dom.Element, vNode: VNode)(implicit s: Scheduler): IO[Unit] = for {
     node <- vNode
-    _ <- IO(patch(element, node.asProxy))
+    _ <- IO(patch(element, node.toSnabbdom))
   } yield ()
 
   def renderInto(querySelector: String, vNode: VNode)(implicit s: Scheduler): IO[Unit] =

--- a/src/main/scala/outwatch/dom/OutwatchAttributes.scala
+++ b/src/main/scala/outwatch/dom/OutwatchAttributes.scala
@@ -65,10 +65,10 @@ trait AttributeHelpers { self: Attributes =>
 
   lazy val `for` = forId
 
-  lazy val data = new DynamicAttributeBuilder[Any]("data" :: Nil)
+  lazy val data = new DynamicAttrBuilder[Any]("data" :: Nil)
 
-  def attr[T](key: String, convert: T => Attr.Value = (t: T) => t.toString : Attr.Value) = new AttributeBuilder[T](key, convert)
-  def prop[T](key: String, convert: T => Prop.Value = (t: T) => t) = new PropertyBuilder[T](key, convert)
+  def attr[T](key: String, convert: T => Attr.Value = (t: T) => t.toString : Attr.Value) = new BasicAttrBuilder[T](key, convert)
+  def prop[T](key: String, convert: T => Prop.Value = (t: T) => t) = new PropBuilder[T](key, convert)
   def style[T](key: String) = new BasicStyleBuilder[T](key)
 }
 

--- a/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -6,88 +6,92 @@ import outwatch.StaticVNodeRender
 import scala.language.dynamics
 import outwatch.dom._
 
-trait ValueBuilder[-T, +SELF <: Attribute] extends Any {
-  protected def attributeName: String
-  private[outwatch] def assign(value: T): SELF
+trait AttributeBuilder[-T, +A <: Attribute] extends Any {
+  protected def name: String
+  private[outwatch] def assign(value: T): A
 
-  def :=(value: T): IO[SELF] = IO.pure(assign(value))
+  def :=(value: T): IO[A] = IO.pure(assign(value))
   def :=?(value: Option[T]): Option[VDomModifier] = value.map(:=)
   def <--(valueStream: Observable[T]): IO[AttributeStreamReceiver] = {
-    IO.pure(AttributeStreamReceiver(attributeName, valueStream.map(assign)))
+    IO.pure(AttributeStreamReceiver(name, valueStream.map(assign)))
   }
 }
 
-object ValueBuilder {
-  implicit def toAttribute(builder: ValueBuilder[Boolean, Attr]): IO[Attribute] = builder := true
-  implicit def toProperty(builder: ValueBuilder[Boolean, Prop]): IO[Property] = builder := true
+object AttributeBuilder {
+  implicit def toAttribute(builder: AttributeBuilder[Boolean, Attr]): IO[Attribute] = builder := true
+  implicit def toProperty(builder: AttributeBuilder[Boolean, Prop]): IO[Property] = builder := true
 }
 
-trait AccumulateOps[T] { self: ValueBuilder[T, BasicAttr] =>
-  def accum(s: String): AccumAttributeBuilder[T] = accum(_ + s + _)
-  def accum(reducer: (Attr.Value, Attr.Value) => Attr.Value) = new AccumAttributeBuilder[T](attributeName, this, reducer)
+// Attr
+
+trait AccumulateAttrOps[T] { self: AttributeBuilder[T, BasicAttr] =>
+  def accum(s: String): AccumAttrBuilder[T] = accum(_ + s + _)
+  def accum(reducer: (Attr.Value, Attr.Value) => Attr.Value) = new AccumAttrBuilder[T](name, this, reducer)
 }
 
-final class AttributeBuilder[T](val attributeName: String, encode: T => Attr.Value) extends ValueBuilder[T, BasicAttr]
-                                                                                            with AccumulateOps[T] {
-  @inline private[outwatch] def assign(value: T) = BasicAttr(attributeName, encode(value))
+final class BasicAttrBuilder[T](val name: String, encode: T => Attr.Value) extends AttributeBuilder[T, BasicAttr]
+                                                                                   with AccumulateAttrOps[T] {
+  @inline private[outwatch] def assign(value: T) = BasicAttr(name, encode(value))
 }
 
-final class DynamicAttributeBuilder[T](parts: List[String]) extends Dynamic
-                                                                    with ValueBuilder[T, BasicAttr]
-                                                                    with AccumulateOps[T] {
-  lazy val attributeName: String = parts.reverse.mkString("-")
+final class DynamicAttrBuilder[T](parts: List[String]) extends Dynamic
+                                                               with AttributeBuilder[T, BasicAttr]
+                                                               with AccumulateAttrOps[T] {
+  lazy val name: String = parts.reverse.mkString("-")
 
-  def selectDynamic(s: String) = new DynamicAttributeBuilder[T](s :: parts)
+  def selectDynamic(s: String) = new DynamicAttrBuilder[T](s :: parts)
 
-  @inline private[outwatch] def assign(value: T) = BasicAttr(attributeName, value.toString)
+  @inline private[outwatch] def assign(value: T) = BasicAttr(name, value.toString)
 }
 
-final class AccumAttributeBuilder[T](
-  val attributeName: String,
-  builder: ValueBuilder[T, Attr],
+final class AccumAttrBuilder[T](
+  val name: String,
+  builder: AttributeBuilder[T, Attr],
   reduce: (Attr.Value, Attr.Value) => Attr.Value
-) extends ValueBuilder[T, AccumAttr] {
-  @inline private[outwatch] def assign(value: T) = AccumAttr(attributeName, builder.assign(value).value, reduce)
+) extends AttributeBuilder[T, AccumAttr] {
+  @inline private[outwatch] def assign(value: T) = AccumAttr(name, builder.assign(value).value, reduce)
 }
 
+// Props
 
-final class PropertyBuilder[T](val attributeName: String, encode: T => Prop.Value) extends ValueBuilder[T, Prop] {
-  @inline private[outwatch] def assign(value: T) = Prop(attributeName, encode(value))
-}
-
-trait AccumulateStyleOps[T] extends Any { self: ValueBuilder[T, BasicStyle] =>
-
-  def accum: AccumStyleBuilder[T] = accum(",")
-  def accum(s: String): AccumStyleBuilder[T] = accum(_ + s + _)
-  def accum(reducer: (String, String) => String) = new AccumStyleBuilder[T](attributeName, reducer)
+final class PropBuilder[T](val name: String, encode: T => Prop.Value) extends AttributeBuilder[T, Prop] {
+  @inline private[outwatch] def assign(value: T) = Prop(name, encode(value))
 }
 
 // Styles
-final class BasicStyleBuilder[T](val attributeName: String) extends AnyVal
-                                                                    with ValueBuilder[T, BasicStyle]
-                                                                    with AccumulateStyleOps[T] {
-  @inline private[outwatch] def assign(value: T) = BasicStyle(attributeName, value.toString)
 
-  def delayed: DelayedStyleBuilder[T] = new DelayedStyleBuilder[T](attributeName)
-  def remove: RemoveStyleBuilder[T] = new RemoveStyleBuilder[T](attributeName)
-  def destroy: DestroyStyleBuilder[T] = new DestroyStyleBuilder[T](attributeName)
+trait AccumulateStyleOps[T] extends Any { self: AttributeBuilder[T, BasicStyle] =>
+
+  def accum: AccumStyleBuilder[T] = accum(",")
+  def accum(s: String): AccumStyleBuilder[T] = accum(_ + s + _)
+  def accum(reducer: (String, String) => String) = new AccumStyleBuilder[T](name, reducer)
 }
 
-final class DelayedStyleBuilder[T](val attributeName: String) extends AnyVal with ValueBuilder[T, DelayedStyle] {
-  @inline private[outwatch] def assign(value: T) = DelayedStyle(attributeName, value.toString)
+final class BasicStyleBuilder[T](val name: String) extends AnyVal
+                                                           with AttributeBuilder[T, BasicStyle]
+                                                           with AccumulateStyleOps[T] {
+  @inline private[outwatch] def assign(value: T) = BasicStyle(name, value.toString)
+
+  def delayed: DelayedStyleBuilder[T] = new DelayedStyleBuilder[T](name)
+  def remove: RemoveStyleBuilder[T] = new RemoveStyleBuilder[T](name)
+  def destroy: DestroyStyleBuilder[T] = new DestroyStyleBuilder[T](name)
 }
 
-final class RemoveStyleBuilder[T](val attributeName: String) extends AnyVal with ValueBuilder[T, RemoveStyle] {
-  @inline private[outwatch] def assign(value: T) = RemoveStyle(attributeName, value.toString)
+final class DelayedStyleBuilder[T](val name: String) extends AnyVal with AttributeBuilder[T, DelayedStyle] {
+  @inline private[outwatch] def assign(value: T) = DelayedStyle(name, value.toString)
 }
 
-final class DestroyStyleBuilder[T](val attributeName: String) extends AnyVal with ValueBuilder[T, DestroyStyle] {
-  @inline private[outwatch] def assign(value: T) = DestroyStyle(attributeName, value.toString)
+final class RemoveStyleBuilder[T](val name: String) extends AnyVal with AttributeBuilder[T, RemoveStyle] {
+  @inline private[outwatch] def assign(value: T) = RemoveStyle(name, value.toString)
 }
 
-final class AccumStyleBuilder[T](val attributeName: String, reducer: (String, String) => String)
-  extends ValueBuilder[T, AccumStyle] {
-  @inline private[outwatch] def assign(value: T) = AccumStyle(attributeName, value.toString, reducer)
+final class DestroyStyleBuilder[T](val name: String) extends AnyVal with AttributeBuilder[T, DestroyStyle] {
+  @inline private[outwatch] def assign(value: T) = DestroyStyle(name, value.toString)
+}
+
+final class AccumStyleBuilder[T](val name: String, reducer: (String, String) => String)
+  extends AttributeBuilder[T, AccumStyle] {
+  @inline private[outwatch] def assign(value: T) = AccumStyle(name, value.toString, reducer)
 }
 
 
@@ -98,18 +102,20 @@ object KeyBuilder {
 // Child / Children
 
 object ChildStreamReceiverBuilder {
-  def <--[T](valueStream: Observable[VNode]): IO[ChildStreamReceiver] = IO.pure (
+  def <--[T](valueStream: Observable[VNode]): IO[ChildStreamReceiver] = IO.pure(
     ChildStreamReceiver(valueStream)
   )
-  def <--[T](valueStream: Observable[T])(implicit r: StaticVNodeRender[T]): IO[ChildStreamReceiver] = IO.pure (
+
+  def <--[T](valueStream: Observable[T])(implicit r: StaticVNodeRender[T]): IO[ChildStreamReceiver] = IO.pure(
     ChildStreamReceiver(valueStream.map(r.render))
   )
 }
 
 object ChildrenStreamReceiverBuilder {
-  def <--(childrenStream: Observable[Seq[VNode]]): IO[ChildrenStreamReceiver] = IO.pure (
+  def <--(childrenStream: Observable[Seq[VNode]]): IO[ChildrenStreamReceiver] = IO.pure(
     ChildrenStreamReceiver(childrenStream)
   )
+
   def <--[T](childrenStream: Observable[Seq[T]])(implicit r: StaticVNodeRender[T]): IO[ChildrenStreamReceiver] = IO.pure(
     ChildrenStreamReceiver(childrenStream.map(_.map(r.render)))
   )

--- a/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -7,7 +7,7 @@ import outwatch.dom._
 import scala.collection.breakOut
 
 object SeparatedModifiers {
-  private[outwatch] def separate(modifiers: Seq[VDomModifier_]): SeparatedModifiers = {
+  private[outwatch] def from(modifiers: Seq[Modifier]): SeparatedModifiers = {
     modifiers.foldRight(SeparatedModifiers())((m, sm) => m :: sm)
   }
 }
@@ -19,7 +19,7 @@ private[outwatch] final case class SeparatedModifiers(
   children: Children = Children.Empty
 ) extends SnabbdomModifiers { self =>
 
-  def ::(m: VDomModifier_): SeparatedModifiers = m match {
+  def ::(m: Modifier): SeparatedModifiers = m match {
     case pr: Property => copy(properties = pr :: properties)
     case vn: ChildVNode => copy(children = vn :: children)
     case em: Emitter => copy(emitters = em :: emitters)

--- a/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
+++ b/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
@@ -11,6 +11,8 @@ trait EmitterBuilder[E, O, R] extends Any {
 
   def transform[T](tr: Observable[O] => Observable[T]): EmitterBuilder[E, T, R]
 
+  def -->(sink: Sink[_ >: O]): IO[R]
+
   def apply[T](value: T): EmitterBuilder[E, T, R] = map(_ => value)
 
   def apply[T](latest: Observable[T]): EmitterBuilder[E, T, R] = transform(_.withLatestFrom(latest)((_, u) => u))
@@ -23,8 +25,6 @@ trait EmitterBuilder[E, O, R] extends Any {
   def filter(predicate: O => Boolean): EmitterBuilder[E, O, R] = transform(_.filter(predicate))
 
   def collect[T](f: PartialFunction[O, T]): EmitterBuilder[E, T, R] = transform(_.collect(f))
-
-  def -->(sink: Sink[_ >: O]): IO[R]
 }
 
 object EmitterBuilder extends EmitterOps {

--- a/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
+++ b/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
@@ -114,7 +114,7 @@ private[outwatch] trait SnabbdomHooks { self: SeparatedHooks =>
           hFunction(proxy.sel, newData, proxy.text)
         }
       } else {
-        hFunction(proxy.sel,newData, nodes.map(_.unsafeRunSync().asProxy)(breakOut): js.Array[VNodeProxy])
+        hFunction(proxy.sel,newData, nodes.map(_.unsafeRunSync().toSnabbdom)(breakOut): js.Array[VNodeProxy])
       }
     }
 
@@ -204,7 +204,7 @@ private[outwatch] trait SnabbdomModifiers { self: SeparatedModifiers =>
     childrenWithKey match {
       case Children.VNodes(vnodes, _) =>
         implicit val scheduler = s
-        val childProxies: js.Array[VNodeProxy] = vnodes.collect { case s: StaticVNode => s.asProxy }(breakOut)
+        val childProxies: js.Array[VNodeProxy] = vnodes.collect { case s: StaticVNode => s.toSnabbdom }(breakOut)
         hFunction(nodeType, dataObject, childProxies)
       case Children.StringModifiers(textChildren) =>
         hFunction(nodeType, dataObject, textChildren.map(_.string).mkString)

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -5,7 +5,7 @@ import cats.effect.IO
 package object dom extends Implicits with ManagedSubscriptions with SideEffects {
 
   type VNode = IO[VTree]
-  type VDomModifier = IO[VDomModifier_]
+  type VDomModifier = IO[Modifier]
   object VDomModifier {
     val empty: VDomModifier = IO.pure(EmptyModifier)
 

--- a/src/main/scala/outwatch/http/Http.scala
+++ b/src/main/scala/outwatch/http/Http.scala
@@ -2,10 +2,10 @@ package outwatch.http
 
 import cats.effect.IO
 import monix.execution.Scheduler
-import monix.reactive.Observable
 import org.scalajs.dom.ext.Ajax.InputData
 import org.scalajs.dom.ext.{Ajax, AjaxException}
 import org.scalajs.dom.{Blob, XMLHttpRequest}
+import outwatch.dom.Observable
 
 import scala.concurrent.Future
 import scala.scalajs.js

--- a/src/main/scala/outwatch/util/WebSocket.scala
+++ b/src/main/scala/outwatch/util/WebSocket.scala
@@ -3,10 +3,10 @@ package outwatch.util
 import cats.effect.IO
 import monix.execution.Ack.Continue
 import monix.execution.{Cancelable, Scheduler}
-import monix.reactive.Observable
 import monix.reactive.OverflowStrategy.Unbounded
 import org.scalajs.dom.{CloseEvent, ErrorEvent, MessageEvent}
 import outwatch.Sink
+import outwatch.dom.Observable
 
 object WebSocket {
   implicit def toSink(socket: WebSocket): Sink[String] = socket.sink

--- a/src/test/scala/outwatch/AttributeSpec.scala
+++ b/src/test/scala/outwatch/AttributeSpec.scala
@@ -12,7 +12,7 @@ class AttributeSpec extends JSDomSpec {
     val node = input(
       className := "class1",
       cls := "class2"
-    ).map(_.asProxy).unsafeRunSync()
+    ).map(_.toSnabbdom).unsafeRunSync()
 
     node.data.attrs.toList shouldBe List("class" -> "class1 class2")
   }
@@ -22,7 +22,7 @@ class AttributeSpec extends JSDomSpec {
     val node = input(
       attr("id").accum(",") := "foo1",
       attr("id").accum(",") := "foo2"
-    ).map(_.asProxy).unsafeRunSync()
+    ).map(_.toSnabbdom).unsafeRunSync()
 
     node.data.attrs.toList shouldBe List("id" -> "foo1,foo2")
   }
@@ -32,7 +32,7 @@ class AttributeSpec extends JSDomSpec {
     val node = input(
       data.foo.accum(",") := "foo1",
       data.foo.accum(",") := "foo2"
-    ).map(_.asProxy).unsafeRunSync()
+    ).map(_.toSnabbdom).unsafeRunSync()
 
     node.data.attrs.toList shouldBe List("data-foo" -> "foo1,foo2")
   }
@@ -41,7 +41,7 @@ class AttributeSpec extends JSDomSpec {
     val node = input(
       data.geul := "bar",
       data.geuli.gurk := "barz"
-    ).map(_.asProxy).unsafeRunSync()
+    ).map(_.toSnabbdom).unsafeRunSync()
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data-geul" -> "bar",
@@ -53,7 +53,7 @@ class AttributeSpec extends JSDomSpec {
     val node = input(
       dataAttr("geul") := "bar",
       dataAttr("geuli-gurk") := "barz"
-    ).map(_.asProxy).unsafeRunSync()
+    ).map(_.toSnabbdom).unsafeRunSync()
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data-geul" -> "bar",
@@ -81,7 +81,7 @@ class AttributeSpec extends JSDomSpec {
       contentEditable := false,
       autoComplete := false,
       disabled := false
-    ).map(_.asProxy).unsafeRunSync()
+    ).map(_.toSnabbdom).unsafeRunSync()
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "foo" -> "foo",
@@ -104,7 +104,7 @@ class AttributeSpec extends JSDomSpec {
     val node = input(
       data.foo :=? Option("bar"),
       data.bar :=? Option.empty[String]
-    ).map(_.asProxy).unsafeRunSync()
+    ).map(_.toSnabbdom).unsafeRunSync()
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data-foo" -> "bar"
@@ -118,7 +118,7 @@ class AttributeSpec extends JSDomSpec {
     )(
       data.a := "buh",
       data.a.tomate := "gisela"
-    ).map(_.asProxy).unsafeRunSync()
+    ).map(_.toSnabbdom).unsafeRunSync()
 
     node.data.attrs.toList should contain theSameElementsAs List(
       "data-a" -> "buh",
@@ -134,7 +134,7 @@ class AttributeSpec extends JSDomSpec {
     )(
       style("color") := "blue",
       border := "1px solid black"
-    ).map(_.asProxy).unsafeRunSync()
+    ).map(_.toSnabbdom).unsafeRunSync()
 
     node.data.style.toList should contain theSameElementsAs List(
       ("color", "blue"),
@@ -150,7 +150,7 @@ class AttributeSpec extends JSDomSpec {
     )(
       color.blue,
       border := "1px solid black"
-    ).map(_.asProxy).unsafeRunSync()
+    ).map(_.toSnabbdom).unsafeRunSync()
 
     node.data.style.toList should contain theSameElementsAs List(
       ("color", "blue"),
@@ -161,18 +161,18 @@ class AttributeSpec extends JSDomSpec {
 
   it should "correctly merge keys" in {
 
-    val node = input( attributes.key := "bumm")( attributes.key := "klapp").map(_.asProxy).unsafeRunSync()
+    val node = input( attributes.key := "bumm")( attributes.key := "klapp").map(_.toSnabbdom).unsafeRunSync()
     node.data.key.toList should contain theSameElementsAs List("klapp")
 
-    val node2 = input()( attributes.key := "klapp").map(_.asProxy).unsafeRunSync()
+    val node2 = input()( attributes.key := "klapp").map(_.toSnabbdom).unsafeRunSync()
     node2.data.key.toList should contain theSameElementsAs List("klapp")
 
-    val node3 = input( attributes.key := "bumm")().map(_.asProxy).unsafeRunSync()
+    val node3 = input( attributes.key := "bumm")().map(_.toSnabbdom).unsafeRunSync()
     node3.data.key.toList should contain theSameElementsAs List("bumm")
   }
 
   "style attribute" should "render correctly" in {
-    val node = input(color.red).map(_.asProxy).unsafeRunSync()
+    val node = input(color.red).map(_.toSnabbdom).unsafeRunSync()
 
     node.data.style.toList should contain theSameElementsAs List(
       "color" -> "red"
@@ -186,7 +186,7 @@ class AttributeSpec extends JSDomSpec {
       opacity.delayed := 1,
       opacity.remove := 0,
       opacity.destroy := 0
-    ).map(_.asProxy).unsafeRunSync()
+    ).map(_.toSnabbdom).unsafeRunSync()
 
     node.data.style("opacity") shouldBe "0"
     node.data.style("delayed").asInstanceOf[js.Dictionary[String]].toMap shouldBe Map("opacity" -> "1")
@@ -198,7 +198,7 @@ class AttributeSpec extends JSDomSpec {
     val node = div(
       transition := "transform .2s ease-in-out",
       transition.accum(",") := "opacity .2s ease-in-out"
-    ).map(_.asProxy).unsafeRunSync()
+    ).map(_.toSnabbdom).unsafeRunSync()
 
     node.data.style.toMap shouldBe Map("transition" -> "transform .2s ease-in-out,opacity .2s ease-in-out")
   }

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -59,7 +59,7 @@ class OutWatchDomSpec extends JSDomSpec {
     )
 
     val SeparatedModifiers(properties, emitters, receivers, Children.VNodes(childNodes, streamStatus)) =
-      SeparatedModifiers.separate(modifiers)
+      SeparatedModifiers.from(modifiers)
 
     emitters.emitters.length shouldBe 2
     receivers.length shouldBe 2
@@ -70,7 +70,7 @@ class OutWatchDomSpec extends JSDomSpec {
   }
 
   it should "be separated correctly with children" in {
-    val modifiers: Seq[VDomModifier_] = Seq(
+    val modifiers: Seq[Modifier] = Seq(
       Attribute("class","red"),
       EmptyModifier,
       Emitter("click", _ => Continue),
@@ -83,7 +83,7 @@ class OutWatchDomSpec extends JSDomSpec {
     )
 
     val SeparatedModifiers(properties, emitters, receivers, Children.VNodes(childNodes, streamStatus)) =
-      SeparatedModifiers.separate(modifiers)
+      SeparatedModifiers.from(modifiers)
 
     emitters.emitters.length shouldBe 3
     receivers.length shouldBe 2
@@ -94,7 +94,7 @@ class OutWatchDomSpec extends JSDomSpec {
   }
 
   it should "be separated correctly with string children" in {
-    val modifiers: Seq[VDomModifier_] = Seq(
+    val modifiers: Seq[Modifier] = Seq(
       Attribute("class","red"),
       EmptyModifier,
       Emitter("click", _ => Continue),
@@ -107,7 +107,7 @@ class OutWatchDomSpec extends JSDomSpec {
     )
 
     val SeparatedModifiers(properties, emitters, receivers, Children.StringModifiers(stringMods)) =
-      SeparatedModifiers.separate(modifiers)
+      SeparatedModifiers.from(modifiers)
 
     emitters.emitters.length shouldBe 3
     receivers.length shouldBe 2
@@ -135,7 +135,7 @@ class OutWatchDomSpec extends JSDomSpec {
     )
 
     val SeparatedModifiers(properties, emitters, receivers, Children.VNodes(childNodes, streamStatus)) =
-      SeparatedModifiers.separate(modifiers)
+      SeparatedModifiers.from(modifiers)
 
     emitters.emitters.map(_.eventType) shouldBe List("click", "input", "keyup")
     emitters.emitters.length shouldBe 3
@@ -212,7 +212,7 @@ class OutWatchDomSpec extends JSDomSpec {
       // div().unsafeRunSync(), div().unsafeRunSync() //TODO: this should also work, but key is derived from hashCode of VTree (which in this case is equal)
     )
 
-    val modifiers =  SeparatedModifiers.separate(mods)
+    val modifiers =  SeparatedModifiers.from(mods)
     val Children.VNodes(childNodes, streamStatus) = modifiers.children
 
     childNodes.size shouldBe 3
@@ -239,7 +239,7 @@ class OutWatchDomSpec extends JSDomSpec {
       div()(IO.pure(Key(5678))).unsafeRunSync()
     )
 
-    val modifiers =  SeparatedModifiers.separate(mods)
+    val modifiers =  SeparatedModifiers.from(mods)
     val Children.VNodes(childNodes, streamStatus) = modifiers.children
 
     childNodes.size shouldBe 2
@@ -261,7 +261,7 @@ class OutWatchDomSpec extends JSDomSpec {
 
     val proxy = fixture.proxy
 
-    JSON.stringify(vtree.map(_.asProxy).unsafeRunSync()) shouldBe JSON.stringify(proxy)
+    JSON.stringify(vtree.map(_.toSnabbdom).unsafeRunSync()) shouldBe JSON.stringify(proxy)
 
   }
 
@@ -271,7 +271,7 @@ class OutWatchDomSpec extends JSDomSpec {
     val child = span(message)
     val vtree = div(IO.pure(attributes.head), IO.pure(attributes(1)), child)
 
-    JSON.stringify(vtree.map(_.asProxy).unsafeRunSync()) shouldBe JSON.stringify(fixture.proxy)
+    JSON.stringify(vtree.map(_.toSnabbdom).unsafeRunSync()) shouldBe JSON.stringify(fixture.proxy)
   }
 
 
@@ -404,7 +404,7 @@ class OutWatchDomSpec extends JSDomSpec {
       span("Hello")
     )
 
-    JSON.stringify(vtree.map(_.asProxy).unsafeRunSync()) shouldBe JSON.stringify(fixture.proxy)
+    JSON.stringify(vtree.map(_.toSnabbdom).unsafeRunSync()) shouldBe JSON.stringify(fixture.proxy)
   }
 
   it should "construct VTrees with optional children properly" in {
@@ -415,15 +415,15 @@ class OutWatchDomSpec extends JSDomSpec {
       Option.empty[VDomModifier]
     )
 
-    JSON.stringify(vtree.map(_.asProxy).unsafeRunSync()) shouldBe JSON.stringify(fixture.proxy)
+    JSON.stringify(vtree.map(_.toSnabbdom).unsafeRunSync()) shouldBe JSON.stringify(fixture.proxy)
 
   }
 
   it should "construct VTrees with boolean attributes" in {
     import outwatch.dom._
 
-    def boolBuilder(name: String) = new AttributeBuilder[Boolean](name, identity)
-    def stringBuilder(name: String) = new AttributeBuilder[Boolean](name, _.toString)
+    def boolBuilder(name: String) = new BasicAttrBuilder[Boolean](name, identity)
+    def stringBuilder(name: String) = new BasicAttrBuilder[Boolean](name, _.toString)
     val vtree = div(
       boolBuilder("a"),
       boolBuilder("b") := true,
@@ -436,7 +436,7 @@ class OutWatchDomSpec extends JSDomSpec {
     val attrs = js.Dictionary[dom.Attr.Value]("a" -> true, "b" -> true, "c" -> false, "d" -> "true", "e" -> "true", "f" -> "false")
     val expected = hFunction("div", DataObject(attrs, js.Dictionary()))
 
-    JSON.stringify(vtree.map(_.asProxy).unsafeRunSync()) shouldBe JSON.stringify(expected)
+    JSON.stringify(vtree.map(_.toSnabbdom).unsafeRunSync()) shouldBe JSON.stringify(expected)
 
   }
 


### PR DESCRIPTION
This PR consists only of proposed renames and small code shuffles.

* it renames builders in  `Builder.scala` to make them more consistent with the names of the attributes they are building
* renames `VDomModifier_` to `Modifier`
* renames `StaticVNode.asProxy` to `StaticVNode.toSnabbdom`
* re-arranges code in `DomTypes`

Because of so many renames, this PR has a high likelihood of generating conflicts, so it should maybe be left until the other PRs get merged first.