### PR TITLE
AsVDomModifier typeclass support for Observable and Observable[Seq]

### DIFF
--- a/src/main/scala/outwatch/StaticVNodeRender.scala
+++ b/src/main/scala/outwatch/StaticVNodeRender.scala
@@ -28,5 +28,4 @@ object StaticVNodeRender {
   implicit object DoubleRender extends StaticVNodeRender[Double] {
     def render(value: Double): IO[StaticVNode] = IO.pure(StringVNode(value.toString))
   }
-
 }

--- a/src/main/scala/outwatch/dom/Compat.scala
+++ b/src/main/scala/outwatch/dom/Compat.scala
@@ -3,6 +3,7 @@ package outwatch.dom
 import cats.effect.IO
 import monix.execution.Scheduler
 import org.scalajs.dom.{ClipboardEvent, DragEvent, KeyboardEvent, MouseEvent}
+import outwatch.dom.helpers.{ChildStreamReceiverBuilder, ChildrenStreamReceiverBuilder}
 
 trait Handlers {
   @deprecated("Use Handler.create[MouseEvent] instead", "0.11.0")
@@ -26,7 +27,20 @@ trait Handlers {
 }
 object Handlers extends Handlers
 
-trait AttributesCompat { self: Attributes =>
+
+/** OutWatch specific attributes used to asign child nodes to a VNode. */
+trait OutWatchChildAttributesCompat {
+  /** A special attribute that takes a stream of single child nodes. */
+  @deprecated("Use the observable directly", "1.0.0")
+  lazy val child    = ChildStreamReceiverBuilder
+
+  /** A special attribute that takes a stream of lists of child nodes. */
+  @deprecated("Use the observable directly", "1.0.0")
+  lazy val children = ChildrenStreamReceiverBuilder
+}
+
+
+trait AttributesCompat extends OutWatchChildAttributesCompat { self: Attributes =>
 
   @deprecated("Use `type`, tpe or typ instead", "0.11.0")
   lazy val inputType = tpe
@@ -58,13 +72,13 @@ trait AttributesCompat { self: Attributes =>
   @deprecated("Use onInsert instead", "0.11.0")
   lazy val insert = onInsert
 
-  @deprecated("Use onPrepatch instead", "0.11.0")
+  @deprecated("Use onPrePatch instead", "0.11.0")
   lazy val prepatch = onPrePatch
 
   @deprecated("Use onUpdate instead", "0.11.0")
   lazy val update = onUpdate
 
-  @deprecated("Use onPostpatch instead", "0.11.0")
+  @deprecated("Use onPostPatch instead", "0.11.0")
   lazy val postpatch = onPostPatch
 
   @deprecated("Use onDestroy instead", "0.11.0")

--- a/src/main/scala/outwatch/dom/DomTypes.scala
+++ b/src/main/scala/outwatch/dom/DomTypes.scala
@@ -77,7 +77,6 @@ trait Attributes
 object Attributes extends Attributes
 
 // Attrs
-
 trait Attrs
   extends attrs.Attrs[BasicAttrBuilder]
   with builders.AttrBuilder[BasicAttrBuilder] {
@@ -87,7 +86,6 @@ trait Attrs
 }
 
 // Reflected attrs
-
 trait ReflectedAttrs
   extends reflectedAttrs.ReflectedAttrs[BuilderTypes.Attribute]
   with builders.ReflectedAttrBuilder[BuilderTypes.Attribute] {

--- a/src/main/scala/outwatch/dom/OutwatchAttributes.scala
+++ b/src/main/scala/outwatch/dom/OutwatchAttributes.scala
@@ -8,20 +8,8 @@ import cats.effect.IO
   * and mix in other traits (defined above) as needed to get full coverage.
   */
 trait OutwatchAttributes
-  extends OutWatchChildAttributes
-  with SnabbdomKeyAttributes
+  extends SnabbdomKeyAttributes
   with OutWatchLifeCycleAttributes
-
-object OutwatchAttributes extends OutwatchAttributes
-
-/** OutWatch specific attributes used to asign child nodes to a VNode. */
-trait OutWatchChildAttributes {
-  /** A special attribute that takes a stream of single child nodes. */
-  lazy val child    = ChildStreamReceiverBuilder
-
-  /** A special attribute that takes a stream of lists of child nodes. */
-  lazy val children = ChildrenStreamReceiverBuilder
-}
 
 /** Outwatch component life cycle hooks. */
 trait OutWatchLifeCycleAttributes {

--- a/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
+++ b/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
@@ -123,7 +123,7 @@ private[outwatch] trait SnabbdomHooks { self: SeparatedHooks =>
       .bufferSliding(2, 1)
       .subscribe(
         { case Seq(old, crt) => patch(old, crt); Continue },
-        error => dom.console.error(error.getMessage)
+        error => dom.console.error(error.getMessage + "\n" + error.getStackTrace.mkString("\n"))
       )
 
     proxy.elm.foreach((e: dom.Element) => hooks.foreach(_.observer.onNext(e)))

--- a/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -69,7 +69,7 @@ class LifecycleHookSpec extends JSDomSpec {
     }
 
     val node = sink.flatMap { sink =>
-      div(child <-- Observable(span(onDestroy --> sink), div("Hasdasd")))
+      div(Observable(span(onDestroy --> sink), div("Hasdasd")))
     }
 
     switch shouldBe false
@@ -96,7 +96,7 @@ class LifecycleHookSpec extends JSDomSpec {
     val node = for {
       sink <- sink
       sink2 <- sink2
-      node <- div(child <-- Observable(span(onDestroy --> sink)(onDestroy --> sink2), div("Hasdasd")))
+      node <- div(Observable(span(onDestroy --> sink)(onDestroy --> sink2), div("Hasdasd")))
     } yield node
 
     switch shouldBe false
@@ -124,7 +124,7 @@ class LifecycleHookSpec extends JSDomSpec {
     val node = for {
       sink1 <- sink1
       sink2 <- sink2
-      node <- div(child <-- message, onUpdate --> sink1)(onUpdate --> sink2)
+      node <- div(message, onUpdate --> sink1)(onUpdate --> sink2)
     } yield node
 
     OutWatch.renderInto("#app", node).unsafeRunSync()
@@ -146,7 +146,7 @@ class LifecycleHookSpec extends JSDomSpec {
     }
 
     val node = sink.flatMap { sink =>
-      div(child <-- Observable(span(onUpdate --> sink, "Hello"), span(onUpdate --> sink, "Hey")))
+      div(Observable(span(onUpdate --> sink, "Hello"), span(onUpdate --> sink, "Hey")))
     }
 
     switch shouldBe false
@@ -166,7 +166,7 @@ class LifecycleHookSpec extends JSDomSpec {
     }
 
     val node = sink.flatMap { sink =>
-      div(child <-- Observable(span("Hello")), span(attributes.key := "1", onPrePatch --> sink, "Hey"))
+      div(Observable(span("Hello")), span(attributes.key := "1", onPrePatch --> sink, "Hey"))
     }
 
     switch shouldBe false
@@ -191,7 +191,7 @@ class LifecycleHookSpec extends JSDomSpec {
     val node =  for {
       sink1 <- sink1
       sink2 <- sink2
-      node <- div(child <-- message, onPrePatch --> sink1)(onPrePatch --> sink2)
+      node <- div(message, onPrePatch --> sink1)(onPrePatch --> sink2)
     } yield node
 
     OutWatch.renderInto("#app", node).unsafeRunSync()
@@ -213,7 +213,7 @@ class LifecycleHookSpec extends JSDomSpec {
     }
 
     val node = sink.flatMap { sink =>
-      div(child <-- Observable("message"), onPostPatch --> sink, "Hey")
+      div(Observable.pure("message"), onPostPatch --> sink, "Hey")
     }
 
     switch shouldBe false
@@ -239,7 +239,7 @@ class LifecycleHookSpec extends JSDomSpec {
     val node = for {
       sink1 <- sink1
       sink2 <- sink2
-      node <- div(child <-- message, onPostPatch --> sink1)(onPostPatch --> sink2)
+      node <- div(message, onPostPatch --> sink1)(onPostPatch --> sink2)
     } yield node
 
     OutWatch.renderInto("#app", node).unsafeRunSync()
@@ -284,7 +284,7 @@ class LifecycleHookSpec extends JSDomSpec {
       destroySink <- destroySink
       prepatchSink <- prepatchSink
       postpatchSink <- postpatchSink
-      node <- div(child <-- message,
+      node <- div(message,
         onInsert --> insertSink,
         onPrePatch --> prepatchSink,
         onUpdate --> updateSink,
@@ -319,7 +319,7 @@ class LifecycleHookSpec extends JSDomSpec {
     val node = for {
       insertSink <- insertSink
       updateSink <- updateSink
-      node <- div("Hello", children <-- messageList.map(_.map(span(_))),
+      node <- div("Hello", messageList.map(_.map(span(_))),
         onInsert --> insertSink,
         onUpdate --> updateSink
       )
@@ -353,7 +353,7 @@ class LifecycleHookSpec extends JSDomSpec {
       updateSink <- updateSink
       destroySink <- destroySink
       node <- div(span("Hello", onInsert --> insertSink, onUpdate --> updateSink, onDestroy --> destroySink),
-        child <-- message.map(span(_))
+        message.map(span(_))
       )
     } yield node
 
@@ -386,7 +386,7 @@ class LifecycleHookSpec extends JSDomSpec {
       insertSink <- insertSink
       updateSink <- updateSink
       destroySink <- destroySink
-      node <- div(children <-- messageList.map(_.map(span(_))),
+      node <- div(messageList.map(_.map(span(_))),
         span("Hello", onInsert --> insertSink, onUpdate --> updateSink, onDestroy --> destroySink)
       )
     } yield node
@@ -416,7 +416,7 @@ class LifecycleHookSpec extends JSDomSpec {
     val sub = PublishSubject[String]
 
     val node = sink.flatMap { sink =>
-      div(child <-- nodes.startWith(Seq(
+      div(nodes.startWith(Seq(
         span(managed(sink <-- sub))
       )))
     }

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -285,7 +285,7 @@ class OutWatchDomSpec extends JSDomSpec {
           Attribute("hans", "")
         }
       ),
-      child <-- stringHandler
+      stringHandler
     )
 
     val node = document.createElement("div")
@@ -316,7 +316,7 @@ class OutWatchDomSpec extends JSDomSpec {
           Attribute("hans", "")
         }
       )),
-      child <-- stringHandler
+      stringHandler
     )
 
     val node = document.createElement("div")
@@ -362,9 +362,9 @@ class OutWatchDomSpec extends JSDomSpec {
       div( id := "page",
         num match {
           case 1 =>
-            div(child <-- pageNum)
+            div(pageNum)
           case 2 =>
-            div(child <-- pageNum)
+            div(pageNum)
         }
       )
     }
@@ -372,7 +372,7 @@ class OutWatchDomSpec extends JSDomSpec {
     val pageHandler = PublishSubject[Int]
 
     val vtree = div(
-      div(child <-- pageHandler.map(page))
+      div(pageHandler.map(page))
     )
 
     val node = document.createElement("div")
@@ -494,9 +494,9 @@ class OutWatchDomSpec extends JSDomSpec {
     val messagesB = PublishSubject[String]
     val vNode = div(
       span("A"),
-      child <-- messagesA.map(span(_)),
+      messagesA.map(span(_)),
       span("B"),
-      child <-- messagesB.map(span(_))
+      messagesB.map(span(_))
     )
 
     val node = document.createElement("div")
@@ -514,9 +514,9 @@ class OutWatchDomSpec extends JSDomSpec {
     val messagesB = PublishSubject[String]
     val vNode = div(
       "A",
-      child <-- messagesA,
+      messagesA,
       "B",
-      child <-- messagesB
+      messagesB
     )
 
     val node = document.createElement("div")
@@ -538,10 +538,10 @@ class OutWatchDomSpec extends JSDomSpec {
     val messagesC = PublishSubject[Seq[VNode]]
     val vNode = div(
       "A",
-      child <-- messagesA,
-      children <-- messagesC,
+      messagesA,
+      messagesC,
       "B",
-      child <-- messagesB
+      messagesB
     )
 
     val node = document.createElement("div")
@@ -563,7 +563,7 @@ class OutWatchDomSpec extends JSDomSpec {
   it should "update merged nodes children correctly" in {
     val messages = PublishSubject[Seq[VNode]]
     val otherMessages = PublishSubject[Seq[VNode]]
-    val vNode = div(children <-- messages)(children <-- otherMessages)
+    val vNode = div(messages)(otherMessages)
 
     val node = document.createElement("div")
     document.body.appendChild(node)
@@ -582,7 +582,7 @@ class OutWatchDomSpec extends JSDomSpec {
   it should "update merged nodes separate children correctly" in {
     val messages = PublishSubject[String]
     val otherMessages = PublishSubject[String]
-    val vNode = div(child <-- messages)(child <-- otherMessages)
+    val vNode = div(messages)(otherMessages)
 
     val node = document.createElement("div")
     document.body.appendChild(node)
@@ -608,7 +608,7 @@ class OutWatchDomSpec extends JSDomSpec {
     val vNode = div( id := "inner",
       color <-- messagesColor,
       backgroundColor <-- messagesBgColor,
-      child <-- childString
+      childString
     )
 
     val node = document.createElement("div")
@@ -642,7 +642,7 @@ class OutWatchDomSpec extends JSDomSpec {
 
     val vNode = div( id := "inner",
       color <-- messagesColor,
-      child <-- childString
+      childString
     )
 
     val node = document.createElement("div")
@@ -664,7 +664,7 @@ class OutWatchDomSpec extends JSDomSpec {
 
   it should "update reused vnodes correctly" in {
     val messages = PublishSubject[String]
-    val vNode = div(data.ralf := true, child <-- messages)
+    val vNode = div(data.ralf := true, messages)
     val container = div(vNode, vNode)
 
     val node = document.createElement("div")
@@ -683,8 +683,8 @@ class OutWatchDomSpec extends JSDomSpec {
   it should "update merged nodes correctly (render reuse)" in {
     val messages = PublishSubject[String]
     val otherMessages = PublishSubject[String]
-    val vNodeTemplate = div(child <-- messages)
-    val vNode = vNodeTemplate(child <-- otherMessages)
+    val vNodeTemplate = div(messages)
+    val vNode = vNodeTemplate(otherMessages)
 
     val node1 = document.createElement("div")
     document.body.appendChild(node1)
@@ -852,7 +852,7 @@ class OutWatchDomSpec extends JSDomSpec {
   "Children stream" should "work for string sequences" in {
     val myStrings: Observable[Seq[String]] = Observable(Seq("a", "b"))
     val node = div(id := "strings",
-      children <-- myStrings
+      myStrings
     )
 
     OutWatch.renderInto("#app", node).unsafeRunSync()
@@ -864,7 +864,7 @@ class OutWatchDomSpec extends JSDomSpec {
   "Child stream" should "work for string options" in {
     val myOption: Handler[Option[String]] = Handler.create(Option("a")).unsafeRunSync()
     val node = div(id := "strings",
-      child <-- myOption
+      myOption
     )
 
     OutWatch.renderInto("#app", node).unsafeRunSync()
@@ -879,7 +879,7 @@ class OutWatchDomSpec extends JSDomSpec {
   "Child stream" should "work for vnode options" in {
     val myOption: Handler[Option[VNode]] = Handler.create(Option(div("a"))).unsafeRunSync()
     val node = div(id := "strings",
-      child <-- myOption
+      myOption
     )
 
     OutWatch.renderInto("#app", node).unsafeRunSync()

--- a/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -22,7 +22,7 @@ class ScenarioTestSpec extends JSDomSpec {
         div(
           button(id := "plus", "+", onClick --> handlePlus),
           button(id := "minus", "-", onClick --> handleMinus),
-          span(id:="counter",child <-- count)
+          span(id:="counter", count)
         )
       )
     } yield div
@@ -55,7 +55,7 @@ class ScenarioTestSpec extends JSDomSpec {
         label("Name:"),
         input(id := "input", tpe := "text", onInput.value --> nameHandler),
         hr(),
-        h1(id := "greeting", greetStart, child <-- nameHandler)
+        h1(id := "greeting", greetStart, nameHandler)
       )
     }
 
@@ -88,7 +88,7 @@ class ScenarioTestSpec extends JSDomSpec {
       Handler.create[String].flatMap { handler =>
         div(
           button(onClick("clicked") --> handler),
-          div(cls := "label", child <-- handler)
+          div(cls := "label", handler)
         )
       }
     }
@@ -174,7 +174,7 @@ class ScenarioTestSpec extends JSDomSpec {
 
       div <- div(
         textFieldComponent,
-        ul(id:= "list", children <-- state)
+        ul(id:= "list", state)
       )
     } yield div
 

--- a/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -43,7 +43,7 @@ class SnabbdomSpec extends JSDomSpec {
     node.id = "app"
     document.body.appendChild(node)
 
-    OutWatch.renderInto("#app", div(child <-- nodes)).unsafeRunSync()
+    OutWatch.renderInto("#app", div(nodes)).unsafeRunSync()
 
     val inputEvt = document.createEvent("HTMLEvents")
     initEvent(inputEvt)("input", false, true)


### PR DESCRIPTION
Keeps, but deprecates `child <--` and `children <--`.

Closes #169.