### PR TITLE
Use .startWith() after .share on Store

### DIFF
--- a/src/main/scala/outwatch/util/Store.scala
+++ b/src/main/scala/outwatch/util/Store.scala
@@ -17,8 +17,8 @@ final case class Store[State, Action](initialState: State,
   val sink: Sink[Action] = handler
   val source: Observable[State] = handler
     .scan(initialState)(fold)
-    .startWith(Seq(initialState))
     .share
+    .startWith(Seq(initialState))
 
   private def fold(state: State, action: Action): State = {
     val (newState, next) = reducer(state, action)


### PR DESCRIPTION
Fixes #174.

When `.startWith()` comes before `.share`, only the first subscription receives the initial element. This cases problems because every a `store.sink.redirect()` (usually called in most EmitterBuilders) creates a subscription.