### PR TITLE
Add Sink.unsafeRedirect

### DIFF
--- a/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
+++ b/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
@@ -42,7 +42,7 @@ final case class TransformingEmitterBuilder[E, O, R] private[helpers](
   )
 
   def -->(sink: Sink[_ >: O]): IO[R] = {
-    val redirected: Sink[E] = sink.redirect[E](transformer)
+    val redirected: Sink[E] = sink.unsafeRedirect[E](transformer)
     IO.pure(create(redirected.observer))
   }
 }

--- a/src/main/scala/outwatch/util/Store.scala
+++ b/src/main/scala/outwatch/util/Store.scala
@@ -17,8 +17,8 @@ final case class Store[State, Action](initialState: State,
   val sink: Sink[Action] = handler
   val source: Observable[State] = handler
     .scan(initialState)(fold)
-    .startWith(Seq(initialState))
     .share
+    .startWith(Seq(initialState))
 
   private def fold(state: State, action: Action): State = {
     val (newState, next) = reducer(state, action)


### PR DESCRIPTION
Add `Sink.unsafeRedirect` and use it in `EmitterBuilder`. VDom streams are infinite (don't complete), so the extra checks in Sink.redirect are not needed in this case.

The safer `Sink.redirect` is useful for uses of `Sink` that can complete, such as in `Http`, `WebSocket`.

On top of #175.