### PR TITLE
Store improvements

### DIFF
--- a/src/main/scala/outwatch/dom/OutWatch.scala
+++ b/src/main/scala/outwatch/dom/OutWatch.scala
@@ -32,7 +32,8 @@ object OutWatch {
   @deprecated("Use renderInto instead (or renderReplace)", "0.11.0")
   def render(querySelector: String, vNode: VNode)(implicit s: Scheduler): IO[Unit] = renderInto(querySelector, vNode)
 
-  def renderWithStore[S, A](initialState: S, reducer: (S, A) => (S, Option[IO[A]]), querySelector: String, root: VNode
+  def renderWithStore[S, A](
+    initialState: S, reducer: Store.Reducer[S, A], querySelector: String, root: VNode
   )(implicit s: Scheduler): IO[Unit] =
     Store.renderWithStore(initialState, reducer, querySelector, root)
 }

--- a/src/main/scala/outwatch/util/Store.scala
+++ b/src/main/scala/outwatch/util/Store.scala
@@ -2,56 +2,72 @@ package outwatch.util
 
 import cats.effect.IO
 import monix.execution.Scheduler
-import monix.execution.{Ack, Cancelable}
-import outwatch.dom.{Observable, OutWatch, VNode}
-import outwatch.{Handler, Pipe, Sink}
+import org.scalajs.dom
 import outwatch.dom.helpers.STRef
+import outwatch.dom.{Observable, OutWatch, VNode}
+import outwatch.{Handler, Pipe}
 
-import scala.concurrent.Future
+import scala.util.Try
+import scala.util.control.NonFatal
 
-
-
-final case class Store[State, Action](initialState: State,
-                                           reducer: (State, Action) => (State, Option[IO[Action]]),
-                                           handler: Pipe[Action, Action])(implicit s: Scheduler) {
-  val sink: Sink[Action] = handler
-  val source: Observable[State] = handler
-    .scan(initialState)(fold)
-    .share
-    .startWith(Seq(initialState))
-
-  private def fold(state: State, action: Action): State = {
-    val (newState, next) = reducer(state, action)
-
-    next.foreach(_.unsafeRunAsync {
-      case Left(e) => sink.observer.onError(e)
-      case Right(r) => sink.observer.onNext(r).asInstanceOf[Unit]
-    })
-
-    newState
-  }
-
-  def subscribe(f: State => IO[Future[Ack]]): IO[Cancelable] =
-    IO(source.subscribe(f andThen(_.unsafeRunSync())))
-}
 
 object Store {
-  implicit def toPipe[State, Action](store: Store[State, Action]): Pipe[Action, State] =
-    Pipe(store.sink, store.source)
+
+  case class Reducer[S, A](reducer: (S, A) => (S, Observable[A]))
+
+  object Reducer {
+
+    implicit def stateAndEffects[S, A](f: (S, A) => (S, Observable[A])): Reducer[S, A] = Reducer(f)
+
+    implicit def justState[S, A](f: (S, A) => S): Reducer[S, A] = Reducer { (s: S, a: A) => (f(s, a), Observable.empty) }
+
+    implicit def stateAndOptionIO[S, A](f: (S, A) => (S, Option[IO[A]])): Reducer[S, A] =  Reducer { (s: S, a: A) =>
+      val (mewState, effect) = f(s, a)
+      (mewState, effect.fold[Observable[A]](Observable.empty)(Observable.fromIO))
+    }
+  }
 
   private val storeRef = STRef.empty
 
-  def renderWithStore[S, A](initialState: S, reducer: (S, A) => (S, Option[IO[A]]), selector: String, root: VNode)(implicit s: Scheduler): IO[Unit] = for {
-    handler <- Handler.create[A]
-    store <- IO(Store(initialState, reducer, handler))
-    _ <- storeRef.asInstanceOf[STRef[Store[S, A]]].put(store)
+  def create[State, Action](
+    initialState: State,
+    reducer: Reducer[State, Action]
+  )(implicit s: Scheduler): IO[Pipe[Action, State]] = {
+
+    Handler.create[Action].map { handler =>
+
+      val fold: (State, Action) => State = (state, action) => Try { // guard against reducer throwing an exception
+        val (newState, effects) = reducer.reducer(state, action)
+
+        effects.subscribe(
+          e => handler.observer.feed(e :: Nil),
+          e => dom.console.error(e.getMessage) // just log the error, don't push it into the handler's observable, because it would stop the scan "loop"
+        )
+        newState
+      }.recover { case NonFatal(e) =>
+        dom.console.error(e.getMessage)
+        state
+      }.get
+
+      handler.transformSource(source =>
+        source
+          .scan(initialState)(fold)
+          .share
+          .startWith(Seq(initialState))
+      )
+    }
+  }
+
+  def get[S, A]: IO[Pipe[A, S]] = storeRef.asInstanceOf[STRef[Pipe[A, S]]].getOrThrow(NoStoreException)
+
+  def renderWithStore[S, A](
+    initialState: S, reducer: Reducer[S, A], selector: String, root: VNode
+  )(implicit s: Scheduler): IO[Unit] = for {
+    store <- Store.create(initialState, reducer)
+    _ <- storeRef.asInstanceOf[STRef[Pipe[A, S]]].put(store)
     _ <- OutWatch.renderInto(selector, root)
   } yield ()
 
-  def getStore[S, A]: IO[Store[S, A]] =
-    storeRef.asInstanceOf[STRef[Store[S, A]]].getOrThrow(NoStoreException)
-
-  private object NoStoreException extends
-    Exception("Application was rendered without specifying a Store, please use Outwatch.renderWithStore instead")
-
+  private object NoStoreException
+    extends Exception("Application was rendered without specifying a Store, please use Outwatch.renderWithStore instead")
 }

--- a/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -4,6 +4,7 @@ import org.scalajs.dom.{html, _}
 import outwatch.Deprecated.IgnoreWarnings.initEvent
 import outwatch.dom._
 import outwatch.dom.dsl._
+import outwatch.util.Store
 
 class ScenarioTestSpec extends JSDomSpec {
 
@@ -23,6 +24,52 @@ class ScenarioTestSpec extends JSDomSpec {
           button(id := "plus", "+", onClick --> handlePlus),
           button(id := "minus", "-", onClick --> handleMinus),
           span(id:="counter", count)
+        )
+      )
+    } yield div
+
+    val root = document.createElement("div")
+    document.body.appendChild(root)
+
+    OutWatch.renderInto(root, node).unsafeRunSync()
+
+    val event = document.createEvent("Events")
+    initEvent(event)("click", canBubbleArg = true, cancelableArg = false)
+
+    document.getElementById("counter").innerHTML shouldBe 0.toString
+
+    document.getElementById("minus").dispatchEvent(event)
+
+    document.getElementById("counter").innerHTML shouldBe (-1).toString
+
+    for (i <- 0 to 10) {
+      document.getElementById("plus").dispatchEvent(event)
+      document.getElementById("counter").innerHTML shouldBe i.toString
+    }
+  }
+
+
+  "A simple counter application that uses Store" should "work as intended" in {
+
+    sealed trait Action
+    case object Plus extends Action
+    case object Minus extends Action
+
+    type State = Int
+
+    def reduce(state: State, action: Action): State = action match {
+      case Plus => state + 1
+      case Minus => state - 1
+    }
+
+    val node = for {
+      store <- Store.create[State, Action](0, reduce _)
+
+      div <- div(
+        div(
+          button(id := "plus", "+", onClick(Plus) --> store),
+          button(id := "minus", "-", onClick(Minus) --> store),
+          span(id:="counter", store)
         )
       )
     } yield div


### PR DESCRIPTION
This PR contains several refactorings/improvements to `Store`:
  * removes the `Store` class and makes the Store just a `Pipe[Action, State]`
  * changes default reducer signature to `(State, Action) => (State, Observable[Action])`, instead of `(State, Action) => (State, Option[IO[Action]])`, which I think is more clear, easier to use and more flexible (allows for more than one effect to be potentially emitted).
  * it's possible to use reducers without effects  `(State, Action) => State` and also in the previous form `(State, Action) => (State, Option[IO[Action]])`
  * added `Store.create` which can be used to create local stores, without the need to use `renderWithStore`
  * uses `observer.feed` instead of `observer.onNext`, so that the store behaves correctly in case an effect is emitted synchronously.

The user facing API remains almost unchanged (except for renaming `Store.getStore` to `Store.get` and the reducer argument to `renderWithStore` needs to be a function (if it's a `def`, it needs to be explicitly followed by `_`: `renderWithStore(initialState, reducer _, ...)`)