### PR TITLE
support svg

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ crossScalaVersions := Seq("2.11.12", "2.12.5")
 libraryDependencies ++= Seq(
   "io.monix"        %%% "monix"       % "3.0.0-M3",
   "org.scala-js"    %%% "scalajs-dom" % "0.9.5",
-  "com.raquo"       %%% "domtypes" % "0.5",
+  "com.raquo"       %%% "domtypes" % "0.6",
   "org.typelevel" %%% "cats-core" % "1.1.0",
   "org.typelevel" %%% "cats-effect" % "0.10",
   "org.scalatest" %%% "scalatest" % "3.0.5" % Test

--- a/src/main/scala/outwatch/dom/DomTypes.scala
+++ b/src/main/scala/outwatch/dom/DomTypes.scala
@@ -35,10 +35,10 @@ private[outwatch] object CodecBuilder {
 
 // Tags
 
-private[outwatch] trait TagBuilder extends builders.TagBuilder[TagBuilder.Tag, dom.html.Element] {
+private[outwatch] trait TagBuilder extends builders.TagBuilder[TagBuilder.Tag, dom.Element] {
   // we can ignore information about void tags here, because snabbdom handles this automatically for us based on the tagname.
   //TODO: add element type to VTree for typed interface
-  protected override def tag[Ref <: dom.html.Element](tagName: String, void: Boolean): VTree = VTree(tagName, Seq.empty)
+  protected override def tag[Ref <: dom.Element](tagName: String, void: Boolean): VTree = VTree(tagName, Seq.empty)
 }
 private[outwatch] object TagBuilder {
   type Tag[T] = VTree
@@ -63,6 +63,10 @@ trait TagsExtra
   with MiscTags[TagBuilder.Tag]
   with TagBuilder
 
+trait TagsSvg
+  extends SvgTags[TagBuilder.Tag]
+  with TagBuilder
+
 // all Attributes
 
 trait Attributes
@@ -80,6 +84,15 @@ object Attributes extends Attributes
 // Attrs
 trait Attrs
   extends attrs.Attrs[BasicAttrBuilder]
+  with builders.AttrBuilder[BasicAttrBuilder] {
+
+  override protected def attr[V](key: String, codec: codecs.Codec[V, String]): BasicAttrBuilder[V] =
+    new BasicAttrBuilder(key, CodecBuilder.encodeAttribute(codec))
+}
+
+// Svg attributes
+trait AttrsSvg
+  extends attrs.SvgAttrs[BasicAttrBuilder]
   with builders.AttrBuilder[BasicAttrBuilder] {
 
   override protected def attr[V](key: String, codec: codecs.Codec[V, String]): BasicAttrBuilder[V] =

--- a/src/main/scala/outwatch/dom/DomTypes.scala
+++ b/src/main/scala/outwatch/dom/DomTypes.scala
@@ -7,7 +7,7 @@ import com.raquo.domtypes.generic.defs.attrs
 import com.raquo.domtypes.generic.defs.reflectedAttrs
 import com.raquo.domtypes.generic.defs.props
 import com.raquo.domtypes.generic.defs.styles
-import com.raquo.domtypes.generic.defs.sameRefTags._
+import com.raquo.domtypes.jsdom.defs.tags._
 import com.raquo.domtypes.jsdom.defs.eventProps
 import cats.effect.IO
 import org.scalajs.dom
@@ -35,21 +35,22 @@ private[outwatch] object CodecBuilder {
 
 // Tags
 
-private[outwatch] trait TagBuilder extends builders.TagBuilder[TagBuilder.Tag, VTree] {
+private[outwatch] trait TagBuilder extends builders.TagBuilder[TagBuilder.Tag, dom.html.Element] {
   // we can ignore information about void tags here, because snabbdom handles this automatically for us based on the tagname.
-  protected override def tag[Ref <: VTree](tagName: String, void: Boolean): VTree = VTree(tagName, Seq.empty)
+  //TODO: add element type to VTree for typed interface
+  protected override def tag[Ref <: dom.html.Element](tagName: String, void: Boolean): VTree = VTree(tagName, Seq.empty)
 }
 private[outwatch] object TagBuilder {
   type Tag[T] = VTree
 }
 
 trait Tags
-  extends EmbedTags[TagBuilder.Tag, VTree]
-  with GroupingTags[TagBuilder.Tag, VTree]
-  with TextTags[TagBuilder.Tag, VTree]
-  with FormTags[TagBuilder.Tag, VTree]
-  with SectionTags[TagBuilder.Tag, VTree]
-  with TableTags[TagBuilder.Tag, VTree]
+  extends EmbedTags[TagBuilder.Tag]
+  with GroupingTags[TagBuilder.Tag]
+  with TextTags[TagBuilder.Tag]
+  with FormTags[TagBuilder.Tag]
+  with SectionTags[TagBuilder.Tag]
+  with TableTags[TagBuilder.Tag]
   with TagBuilder
   with TagHelpers
   with TagsCompat
@@ -58,8 +59,8 @@ trait Tags
 object Tags extends Tags
 
 trait TagsExtra
-  extends DocumentTags[TagBuilder.Tag, VTree]
-  with MiscTags[TagBuilder.Tag, VTree]
+  extends DocumentTags[TagBuilder.Tag]
+  with MiscTags[TagBuilder.Tag]
   with TagBuilder
 
 // all Attributes

--- a/src/main/scala/outwatch/dom/dsl.scala
+++ b/src/main/scala/outwatch/dom/dsl.scala
@@ -3,6 +3,7 @@ package outwatch.dom
 object dsl extends Attributes with Tags with Styles {
   object tags extends Tags {
     object extra extends TagsExtra
+    object svg extends TagsSvg
   }
   object attributes extends Attributes {
     object attrs extends Attrs
@@ -11,7 +12,9 @@ object dsl extends Attributes with Tags with Styles {
     object events extends Events
     object outwatch extends OutwatchAttributes
     object lifecycle extends OutWatchLifeCycleAttributes
+    object svg extends AttrsSvg
   }
+  object svg extends AttrsSvg with TagsSvg
   object styles extends Styles {
     object extra extends StylesExtra
   }

--- a/src/test/scala/outwatch/AttributeSpec.scala
+++ b/src/test/scala/outwatch/AttributeSpec.scala
@@ -202,4 +202,13 @@ class AttributeSpec extends JSDomSpec {
 
     node.data.style.toMap shouldBe Map("transition" -> "transform .2s ease-in-out,opacity .2s ease-in-out")
   }
+
+  "svg" should "should work with tags and attributes" in {
+    import outwatch.dom.dsl.svg._
+    val node = svg(
+      path(fill := "red", d := "M 100 100 L 300 100 L 200 300 z")
+    ).map(_.toSnabbdom).unsafeRunSync()
+
+    node.children.get.head.data.attrs.toMap shouldBe Map("fill" -> "red", "d" -> "M 100 100 L 300 100 L 200 300 z")
+  }
 }

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -466,7 +466,7 @@ class DomEventSpec extends JSDomSpec {
         doubleStream <- Handler.create[Double]
         boolStream <- Handler.create[Boolean]
         htmlElementStream <- Handler.create[html.Element]
-        svgElementTupleStream <- Handler.create[(svg.Element, svg.Element)]
+        svgElementTupleStream <- Handler.create[(Element, Element)]
         elem <- div(
           input(
             id := "input", tpe := "text",

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -6,6 +6,7 @@ import org.scalajs.dom.{html, _}
 import outwatch.Deprecated.IgnoreWarnings.initEvent
 import outwatch.dom._
 import outwatch.dom.dsl._
+import org.scalajs.dom
 
 class DomEventSpec extends JSDomSpec {
 
@@ -466,7 +467,7 @@ class DomEventSpec extends JSDomSpec {
         doubleStream <- Handler.create[Double]
         boolStream <- Handler.create[Boolean]
         htmlElementStream <- Handler.create[html.Element]
-        svgElementTupleStream <- Handler.create[(Element, Element)]
+        svgElementTupleStream <- Handler.create[(org.scalajs.dom.svg.Element, org.scalajs.dom.svg.Element)]
         elem <- div(
           input(
             id := "input", tpe := "text",


### PR DESCRIPTION
Uses current jitpack snapshot of scala-dom-types to support svg tags and attributes.