### PR TITLE
Snabbdom thunk method

### DIFF
--- a/src/main/scala/outwatch/dom/Implicits.scala
+++ b/src/main/scala/outwatch/dom/Implicits.scala
@@ -5,6 +5,8 @@ import cats.syntax.apply._
 import com.raquo.domtypes.generic.keys
 import outwatch.AsVDomModifier
 import outwatch.dom.helpers.BasicStyleBuilder
+import monix.reactive.Observable
+import monix.execution.Scheduler
 
 trait Implicits {
 
@@ -12,6 +14,7 @@ trait Implicits {
 
   implicit class ioVTreeMerge(vnode: VNode) {
     def apply(args: VDomModifier*): VNode = vnode.flatMap(_.apply(args: _*))
+    def thunk[T](renderFn: T => VDomModifier, argumentStream: Observable[T])(implicit scheduler: Scheduler): VDomModifier = vnode.flatMap(_.thunk(renderFn, argumentStream))
   }
 
   implicit def StyleIsBuilder[T](style: keys.Style[T]): BasicStyleBuilder[T] = new BasicStyleBuilder[T](style.cssName)

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -164,7 +164,7 @@ private[outwatch] final case class ChildrenStreamReceiver(childrenStream: Observ
 // Static Nodes
 
 private[outwatch] final case class ThunkVNode[T](selector: String, key: String, renderFn: js.Function1[T, VNodeProxy], argument: T) extends StaticVNode {
-  override def toSnabbdom(implicit s: Scheduler): VNodeProxy = thunk(selector, key, renderFn, argument)
+  override def toSnabbdom(implicit s: Scheduler): VNodeProxy = thunk(selector, key, renderFn, js.Array(argument))
 }
 
 private[outwatch] final case class StringVNode(string: String) extends AnyVal with StaticVNode {

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -5,7 +5,8 @@ import monix.execution.{Ack, Scheduler}
 import monix.reactive.Observer
 import org.scalajs.dom._
 import outwatch.dom.helpers.SeparatedModifiers
-import snabbdom.{DataObject, VNodeProxy}
+import snabbdom.{DataObject, VNodeProxy, thunk}
+import scala.scalajs.js
 
 import scala.concurrent.Future
 
@@ -146,11 +147,26 @@ object StaticVNode {
   val empty: StaticVNode = StringVNode("")
 }
 
+// we use js.Function here, because we need equality on the function as well as on the args to make thunk work.
+private[outwatch] final case class ThunkStreamReceiver[T] private(selector: String, renderFn: js.Function1[T, VNodeProxy], argumentStream: Observable[T]) extends StreamVNode
+private[outwatch] object ThunkStreamReceiver {
+  def apply[T](initial: VTree, renderFn: T => VDomModifier, argumentStream: Observable[T])(implicit scheduler: Scheduler) = IO {
+    val proxy = initial.toSnabbdom
+    val render = renderFn.andThen(mod => initial(mod).unsafeRunSync.toSnabbdom)
+    new ThunkStreamReceiver[T](proxy.sel, render, argumentStream)
+  }
+}
+
 private[outwatch] final case class ChildStreamReceiver(childStream: Observable[IO[StaticVNode]]) extends AnyVal with StreamVNode
 
 private[outwatch] final case class ChildrenStreamReceiver(childrenStream: Observable[Seq[IO[StaticVNode]]]) extends AnyVal with StreamVNode
 
 // Static Nodes
+
+private[outwatch] final case class ThunkVNode[T](selector: String, key: String, renderFn: js.Function1[T, VNodeProxy], argument: T) extends StaticVNode {
+  override def toSnabbdom(implicit s: Scheduler): VNodeProxy = thunk(selector, key, renderFn, argument)
+}
+
 private[outwatch] final case class StringVNode(string: String) extends AnyVal with StaticVNode {
   override def toSnabbdom(implicit s: Scheduler): VNodeProxy = VNodeProxy.fromString(string)
 }
@@ -161,6 +177,9 @@ private[outwatch] final case class StringVNode(string: String) extends AnyVal wi
 private[outwatch] final case class VTree(nodeType: String, modifiers: Seq[Modifier]) extends StaticVNode {
 
   def apply(args: VDomModifier*): VNode = args.sequence.map(args => copy(modifiers = modifiers ++ args))
+
+  def thunk[T](renderFn: T => VDomModifier, argumentStream: Observable[T])(implicit scheduler: Scheduler): VDomModifier =
+    ThunkStreamReceiver(this, renderFn, argumentStream)
 
   override def toSnabbdom(implicit s: Scheduler): VNodeProxy = {
     SeparatedModifiers.from(modifiers).toSnabbdom(nodeType)

--- a/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -169,6 +169,9 @@ private[outwatch] final case class Receivers(
       csr.childStream.map[VNodeState.Updater](n => s => s.copy(nodes = s.nodes.updated(index, n :: Nil)))
     case (csr: ChildrenStreamReceiver, index) =>
       csr.childrenStream.map[VNodeState.Updater](n => s => s.copy(nodes = s.nodes.updated(index, n)))
+    case (tsr: ThunkStreamReceiver[_], index) =>
+      tsr.argumentStream.map[VNodeState.Updater](arg => s => s.copy(nodes = s.nodes.updated(index, IO.pure(ThunkVNode(tsr.selector, tsr.hashCode.toString, tsr.renderFn, arg)) :: Nil)))
+
   } ++ attributeStreamReceivers.groupBy(_.attribute).values.map(_.last).map {
     case AttributeStreamReceiver(name, attributeStream) =>
       attributeStream.map[VNodeState.Updater](a => s => s.copy(attributes = s.attributes.updated(name, a)))

--- a/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
+++ b/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
@@ -71,7 +71,7 @@ private[outwatch] trait SnabbdomAttributes { self: SeparatedAttributes =>
       attrs = merge(obj.attrs, attrs),
       props = merge(obj.props, props),
       style = merge(obj.style, style),
-      on = obj.on, hook = obj.hook, key = obj.key
+      on = obj.on, hook = obj.hook, key = obj.key, args = obj.args, fn = obj.fn
     )
   }
 }
@@ -152,8 +152,9 @@ private[outwatch] trait SnabbdomHooks { self: SeparatedHooks =>
     val prePatchHook = createHookPairOption(prePatchHooks)
     val updateHook = createHookPair(updateHooks)
     val postPatchHook = createHookPair(postPatchHooks)
+    val initHook = js.undefined
 
-    Hooks(insertHook, prePatchHook, updateHook, postPatchHook, destroyHook)
+    Hooks(initHook, insertHook, prePatchHook, updateHook, postPatchHook, destroyHook)
   }
 }
 
@@ -186,7 +187,7 @@ private[outwatch] trait SnabbdomModifiers { self: SeparatedModifiers =>
     DataObject(
       attrs, props, style, emitters.toSnabbdom,
       properties.hooks.toSnabbdom(receivers),
-      key
+      key, js.undefined, js.undefined
     )
   }
 

--- a/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
+++ b/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
@@ -119,10 +119,9 @@ private[outwatch] trait SnabbdomHooks { self: SeparatedHooks =>
 
     subscription := receivers.observable
       .map(toProxy)
-      .startWith(Seq(proxy))
-      .bufferSliding(2, 1)
+      .scan(proxy) { case (old, crt) => patch(old, crt) }
       .subscribe(
-        { case Seq(old, crt) => patch(old, crt); Continue },
+        _ => Continue,
         error => dom.console.error(error.getMessage + "\n" + error.getStackTrace.mkString("\n"))
       )
 

--- a/src/main/scala/snabbdom/hFunction.scala
+++ b/src/main/scala/snabbdom/hFunction.scala
@@ -126,9 +126,9 @@ object patch {
     SnabbdomStyle.default
   ))
 
-  def apply(firstNode: VNodeProxy, vNode: VNodeProxy): Unit = p(firstNode,vNode)
+  def apply(firstNode: VNodeProxy, vNode: VNodeProxy): VNodeProxy = p(firstNode,vNode)
 
-  def apply(firstNode: org.scalajs.dom.Element, vNode: VNodeProxy): Unit = p(firstNode,vNode)
+  def apply(firstNode: org.scalajs.dom.Element, vNode: VNodeProxy): VNodeProxy = p(firstNode,vNode)
 }
 
 @js.native
@@ -149,7 +149,7 @@ object VNodeProxy {
 @js.native
 @JSImport("snabbdom", JSImport.Namespace, globalFallback = "snabbdom")
 object Snabbdom extends js.Object {
-  def init(args: js.Array[Any]): js.Function2[Node | VNodeProxy, VNodeProxy, Unit] = js.native
+  def init(args: js.Array[Any]): js.Function2[Node | VNodeProxy, VNodeProxy, VNodeProxy] = js.native
 
 }
 

--- a/src/main/scala/snabbdom/hFunction.scala
+++ b/src/main/scala/snabbdom/hFunction.scala
@@ -116,6 +116,26 @@ object DataObject {
   }
 }
 
+@js.native
+@JSImport("snabbdom/thunk", JSImport.Namespace, globalFallback = "thunk")
+object thunkProvider extends js.Object {
+  val default: thunkFunction = js.native
+}
+
+@js.native
+trait thunkFunction extends js.Any {
+  def apply(selector: String, renderFn: js.Function, argument: js.Array[Any]): VNodeProxy = js.native
+  def apply(selector: String, key: String, renderFn: js.Function, argument: js.Array[Any]): VNodeProxy = js.native
+}
+
+object thunk {
+  def apply[T](selector: String, renderFn: js.Function1[T, VNodeProxy], argument: T): VNodeProxy =
+    thunkProvider.default(selector, renderFn, js.Array(argument))
+
+  def apply[T](selector: String, key: String, renderFn: js.Function1[T, VNodeProxy], argument: T): VNodeProxy =
+    thunkProvider.default(selector, key, renderFn, js.Array(argument))
+}
+
 object patch {
 
   private lazy val p = Snabbdom.init(js.Array(

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -1001,4 +1001,39 @@ class OutWatchDomSpec extends JSDomSpec {
     renderFnCounter shouldBe 2
     document.getElementById("strings").innerHTML shouldBe """<b id="bla" class="b">hai!</b><b>something else</b>"""
   }
+
+  //TODO: does not work: https://github.com/snabbdom/snabbdom/issues/143
+  it should "work for vnode with case class equality" in {
+    pending
+
+    case class Wrap(s: String)
+    val myString: Handler[String] = Handler.create().unsafeRunSync()
+
+    var renderFnCounter = 0
+    val renderFn: Wrap => VDomModifier = { str =>
+      renderFnCounter += 1
+      Seq[VDomModifier](cls := "b", str.s)
+    }
+    val node = div(
+      id := "strings",
+      b(id := "bla").thunk(renderFn, myString.map(Wrap(_))),
+      b("something else")
+    )
+
+    OutWatch.renderInto("#app", node).unsafeRunSync()
+    document.getElementById("strings").innerHTML shouldBe "<b>something else</b>"
+    renderFnCounter shouldBe 0
+
+    myString.unsafeOnNext("wal?")
+    renderFnCounter shouldBe 1
+    document.getElementById("strings").innerHTML shouldBe """<b id="bla" class="b">wal?</b><b>something else</b>"""
+
+    myString.unsafeOnNext("wal?")
+    renderFnCounter shouldBe 1
+    document.getElementById("strings").innerHTML shouldBe """<b id="bla" class="b">wal?</b><b>something else</b>"""
+
+    myString.unsafeOnNext("hai!")
+    renderFnCounter shouldBe 2
+    document.getElementById("strings").innerHTML shouldBe """<b id="bla" class="b">hai!</b><b>something else</b>"""
+  }
 }

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -939,4 +939,66 @@ class OutWatchDomSpec extends JSDomSpec {
     assert(localStorage.getItem(key) == null)
     assert(triggeredHandlerEvents.toList == List(None, Some("joe"), None, Some("split"), None, Some("rhabarbar"), None))
   }
+
+  "ChildStreamReceiver" should "work for vnode" in {
+    val myString: Handler[String] = Handler.create().unsafeRunSync()
+
+    var renderFnCounter = 0
+    val renderFn: String => VNode = { str =>
+      renderFnCounter += 1
+      b(str)
+    }
+    val node = div(
+      id := "strings",
+      IO(ChildStreamReceiver(myString.map(renderFn))),
+      b("something else")
+    )
+
+    OutWatch.renderInto("#app", node).unsafeRunSync()
+    document.getElementById("strings").innerHTML shouldBe "<b>something else</b>"
+    renderFnCounter shouldBe 0
+
+    myString.unsafeOnNext("wal?")
+    renderFnCounter shouldBe 1
+    document.getElementById("strings").innerHTML shouldBe "<b>wal?</b><b>something else</b>"
+
+    myString.unsafeOnNext("wal?")
+    renderFnCounter shouldBe 2
+    document.getElementById("strings").innerHTML shouldBe "<b>wal?</b><b>something else</b>"
+
+    myString.unsafeOnNext("hai!")
+    renderFnCounter shouldBe 3
+    document.getElementById("strings").innerHTML shouldBe "<b>hai!</b><b>something else</b>"
+  }
+
+  "ThunkStreamReceiver" should "work for vnode" in {
+    val myString: Handler[String] = Handler.create().unsafeRunSync()
+
+    var renderFnCounter = 0
+    val renderFn: String => VDomModifier = { str =>
+      renderFnCounter += 1
+      Seq[VDomModifier](cls := "b", str)
+    }
+    val node = div(
+      id := "strings",
+      b(id := "bla").thunk(renderFn, myString),
+      b("something else")
+    )
+
+    OutWatch.renderInto("#app", node).unsafeRunSync()
+    document.getElementById("strings").innerHTML shouldBe "<b>something else</b>"
+    renderFnCounter shouldBe 0
+
+    myString.unsafeOnNext("wal?")
+    renderFnCounter shouldBe 1
+    document.getElementById("strings").innerHTML shouldBe """<b id="bla" class="b">wal?</b><b>something else</b>"""
+
+    myString.unsafeOnNext("wal?")
+    renderFnCounter shouldBe 1
+    document.getElementById("strings").innerHTML shouldBe """<b id="bla" class="b">wal?</b><b>something else</b>"""
+
+    myString.unsafeOnNext("hai!")
+    renderFnCounter shouldBe 2
+    document.getElementById("strings").innerHTML shouldBe """<b id="bla" class="b">hai!</b><b>something else</b>"""
+  }
 }

--- a/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -1,8 +1,8 @@
 package outwatch
 
-import org.scalajs.dom.{document, html}
+import org.scalajs.dom.{document, html, console}
 import outwatch.Deprecated.IgnoreWarnings.initEvent
-import snabbdom.{DataObject, hFunction, patch}
+import snabbdom.{DataObject, hFunction, patch, thunk, VNodeProxy}
 
 import scala.scalajs.js
 
@@ -73,5 +73,43 @@ class SnabbdomSpec extends JSDomSpec {
 
     val expected = s"""<span id="msg" bool1="" string1="true" string0="false">$message</span>"""
     document.getElementById("msg").outerHTML shouldBe expected
+  }
+
+  it should "correctly use thunks for updating" in {
+    var renderFnCounter = 0
+
+    val renderFn: js.Function1[String, VNodeProxy] = { message =>
+      renderFnCounter += 1
+      hFunction("span#msg", DataObject(js.Dictionary(), js.Dictionary()), message)
+    }
+
+    val message = "Hello World"
+
+    val node = document.createElement("div")
+    document.body.appendChild(node)
+
+    renderFnCounter shouldBe 0
+
+    val vNode1 = thunk("span#msg", renderFn, message)
+    val p1 = patch(node, vNode1)
+
+
+    renderFnCounter shouldBe 1
+    document.getElementById("msg").innerHTML shouldBe message
+
+
+    val vNode2 = thunk("span#msg", renderFn, message)
+    val p2 = patch(p1, vNode2)
+
+    renderFnCounter shouldBe 1
+    document.getElementById("msg").innerHTML shouldBe message
+
+
+    val newMessage = "Hello Snabbdom!"
+    val vNode3 = thunk("span#msg", renderFn, newMessage)
+    val p3 = patch(p2, vNode3)
+
+    renderFnCounter shouldBe 2
+    document.getElementById("msg").innerHTML shouldBe newMessage
   }
 }

--- a/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -90,15 +90,15 @@ class SnabbdomSpec extends JSDomSpec {
 
     renderFnCounter shouldBe 0
 
-    val vNode1 = thunk("span#msg", renderFn, message)
-    val p1 = patch(node, vNode1)
 
+    val vNode1 = thunk("span#msg", renderFn, js.Array(message))
+    val p1 = patch(node, vNode1)
 
     renderFnCounter shouldBe 1
     document.getElementById("msg").innerHTML shouldBe message
 
 
-    val vNode2 = thunk("span#msg", renderFn, message)
+    val vNode2 = thunk("span#msg", renderFn, js.Array(message))
     val p2 = patch(p1, vNode2)
 
     renderFnCounter shouldBe 1
@@ -106,7 +106,7 @@ class SnabbdomSpec extends JSDomSpec {
 
 
     val newMessage = "Hello Snabbdom!"
-    val vNode3 = thunk("span#msg", renderFn, newMessage)
+    val vNode3 = thunk("span#msg", renderFn, js.Array(newMessage))
     val p3 = patch(p2, vNode3)
 
     renderFnCounter shouldBe 2


### PR DESCRIPTION
Introduce `thunk` method for more efficient diffing on the relevant argument instread of comparing the `VNodeProxy`.

This PR introduces a method `.thunk` on a `VNode`, so you can do something like this:
```scala
    val myString: Handler[String] = Handler.create().unsafeRunSync()
    val renderFn: String => VDomModifier = { str =>
      Seq[VDomModifier](cls := "b", str)
    }
    val node = div(
      b(id := "bla").thunk(renderFn, myString),
      b("something else")
    )

```

Here `renderFn` will only be called if the argument from `myString` Handler changes.

fixes #104
based on #196 