### PR TITLE
Stop advertising old Outwatch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To configure hot reloading with webpack devserver, check out [build.sbt](https:/
 ### Documentation
 There is a PR with a corresponding changelog which also serves as documentation with examples: https://github.com/OutWatch/outwatch/blob/changelog/CHANGELOG.md
 
-There is also the slightly outdated but conceptually still correct [documentation](https://outwatch.github.io/) -  [https://github.com/OutWatch/outwatch.github.io](contributions welcome).
+There is also the slightly outdated but conceptually still correct [documentation](https://outwatch.github.io/) -  [contributions welcome](https://github.com/OutWatch/outwatch.github.io).
 
 ## Three main goals of OutWatch
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Getting started
 
 ### g8 template
-For a quick start, use the following g8 template:
+For a quick start, install `java`, `sbt`, `nodejs` and `yarn` and use the following g8 template:
 ```bash
 sbt new outwatch/seed.g8 -b update
 ```

--- a/README.md
+++ b/README.md
@@ -3,20 +3,35 @@
 
 ## Getting started
 
-First you will need to install Java and SBT if you haven't already.
-Create a new SBT project and add the ScalaJS plugin to your `plugins.sbt`.
-Then add the following line to your `build.sbt`.
-
-```scala
-libraryDependencies += "io.github.outwatch" %%% "outwatch" % "0.10.2"
+### g8 template
+For a quick start, use the following g8 template:
+```bash
+sbt new outwatch/seed.g8 -b update
 ```
 
-Please test the latest release candidate and report any issues and questions you encounter:
-There is a PR with a corresponding changelog: https://github.com/OutWatch/outwatch/blob/changelog/CHANGELOG.md
+In your newly created project folder, run:
+```bash
+sbt dev
+```
+
+and point your browser to http://localhost:8080.
+
+Changes to the code will trigger a recompile and automatically refresh the page in the browser.
+
+### manually
+First you will need to install Java and SBT if you haven't already.
+Create a new SBT project and add the ScalaJS and Scala-js-bundler plugin to your `plugins.sbt`:
+```scala
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.23")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.13.0")
+```
+Then add the following line to your `build.sbt`.
 
 ```scala
 libraryDependencies += "io.github.outwatch" %%% "outwatch" % "1.0.0-RC2"
 ```
+There is a PR with a corresponding changelog which also serves as documentation with examples: https://github.com/OutWatch/outwatch/blob/changelog/CHANGELOG.md
+
 
 If you are curious and want to try the state of the current `master` branch, add the following instead:
 
@@ -28,13 +43,13 @@ libraryDependencies += "com.github.outwatch" % "outwatch" % "master-SNAPSHOT"
 And you're done, you can now start building your own OutWatch app!
 Please check out the [documentation](https://outwatch.github.io/) on how to proceed.
 
+To configure hot reloading with webpack devserver, check out [build.sbt](https://github.com/OutWatch/seed.g8/blob/update/src/main/g8/build.sbt) and [webpack.config.dev.js](https://github.com/OutWatch/seed.g8/blob/update/src/main/g8/webpack.config.dev.js) from the [g8 template](https://github.com/OutWatch/seed.g8/tree/update).
 
 ## Three main goals of OutWatch
 
 1. Updating DOM efficiently without sacrificing abstraction => Virtual DOM
 2. Handling subscriptions automatically
 3. Removing or restricting the need for Higher Order Observables
-
 
 
 ## Bugs and Feedback

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To configure hot reloading with webpack devserver, check out [build.sbt](https:/
 ### Documentation
 There is a PR with a corresponding changelog which also serves as documentation with examples: https://github.com/OutWatch/outwatch/blob/changelog/CHANGELOG.md
 
-There is also the slightly outdated but conceptually still correct [documentation](https://outwatch.github.io/) (contributions welcome).
+There is also the slightly outdated but conceptually still correct [documentation](https://outwatch.github.io/) -  [https://github.com/OutWatch/outwatch.github.io](contributions welcome).
 
 ## Three main goals of OutWatch
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ### g8 template
 For a quick start, install `java`, `sbt`, `nodejs` and `yarn` and use the following g8 template:
 ```bash
-sbt new outwatch/seed.g8 -b update
+sbt new outwatch/seed.g8
 ```
 
 In your newly created project folder, run:
@@ -43,7 +43,7 @@ libraryDependencies += "com.github.outwatch" % "outwatch" % "master-SNAPSHOT"
 And you're done, you can now start building your own OutWatch app!
 Please check out the [documentation](https://outwatch.github.io/) on how to proceed.
 
-To configure hot reloading with webpack devserver, check out [build.sbt](https://github.com/OutWatch/seed.g8/blob/update/src/main/g8/build.sbt) and [webpack.config.dev.js](https://github.com/OutWatch/seed.g8/blob/update/src/main/g8/webpack.config.dev.js) from the [g8 template](https://github.com/OutWatch/seed.g8/tree/update).
+To configure hot reloading with webpack devserver, check out [build.sbt](https://github.com/OutWatch/seed.g8/blob/master/src/main/g8/build.sbt) and [webpack.config.dev.js](https://github.com/OutWatch/seed.g8/blob/master/src/main/g8/webpack.config.dev.js) from the [g8 template](https://github.com/OutWatch/seed.g8).
 
 ## Three main goals of OutWatch
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
-# OutWatch - Functional and reactive UIs with Rx, VirtualDom and Scala [![Typelevel incubator](https://img.shields.io/badge/typelevel-incubator-F51C2B.svg)](http://typelevel.org) [![Build Status](https://travis-ci.org/OutWatch/outwatch.svg?branch=master)](https://travis-ci.org/OutWatch/outwatch) [![Scala.js](http://scala-js.org/assets/badges/scalajs-0.6.15.svg)](http://scala-js.org) [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/OutWatch/Lobby)
+# OutWatch - Functional and reactive Web-Frontend Library with Reactive Programming, VirtualDom and Scala [![Typelevel incubator](https://img.shields.io/badge/typelevel-incubator-F51C2B.svg)](http://typelevel.org) [![Build Status](https://travis-ci.org/OutWatch/outwatch.svg?branch=master)](https://travis-ci.org/OutWatch/outwatch) [![Scala.js](http://scala-js.org/assets/badges/scalajs-0.6.15.svg)](http://scala-js.org) [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/OutWatch/Lobby)
 
+
+```scala
+import outwatch.dom._
+import outwatch.dom.dsl._
+import monix.execution.Scheduler.Implicits.global
+
+OutWatch.renderInto("#app", h1("Hello World")).unsafeRunSync()
+```
+
+Syntax is almost exactly as in [ScalaTags](http://www.lihaoyi.com/scalatags/) combined with Observables from [Monix](https://monix.io/).
+
+You can find more examples and features in the changelog: https://github.com/OutWatch/outwatch/blob/changelog/CHANGELOG.md
 
 ## Getting started
 
@@ -18,20 +30,18 @@ and point your browser to http://localhost:8080.
 
 Changes to the code will trigger a recompile and automatically refresh the page in the browser.
 
-### manually
-First you will need to install Java and SBT if you haven't already.
+### Manual usage
+Install `java`, `sbt` and  `nodejs`, if you haven't already.
 Create a new SBT project and add the ScalaJS and Scala-js-bundler plugin to your `plugins.sbt`:
 ```scala
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.23")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.13.0")
 ```
-Then add the following line to your `build.sbt`.
+Then add the outwatch dependency to your `build.sbt`.
 
 ```scala
 libraryDependencies += "io.github.outwatch" %%% "outwatch" % "1.0.0-RC2"
 ```
-There is a PR with a corresponding changelog which also serves as documentation with examples: https://github.com/OutWatch/outwatch/blob/changelog/CHANGELOG.md
-
 
 If you are curious and want to try the state of the current `master` branch, add the following instead:
 
@@ -40,10 +50,12 @@ resolvers += "jitpack" at "https://jitpack.io"
 libraryDependencies += "com.github.outwatch" % "outwatch" % "master-SNAPSHOT"
 ```
 
-And you're done, you can now start building your own OutWatch app!
-Please check out the [documentation](https://outwatch.github.io/) on how to proceed.
-
 To configure hot reloading with webpack devserver, check out [build.sbt](https://github.com/OutWatch/seed.g8/blob/master/src/main/g8/build.sbt) and [webpack.config.dev.js](https://github.com/OutWatch/seed.g8/blob/master/src/main/g8/webpack.config.dev.js) from the [g8 template](https://github.com/OutWatch/seed.g8).
+
+### Documentation
+There is a PR with a corresponding changelog which also serves as documentation with examples: https://github.com/OutWatch/outwatch/blob/changelog/CHANGELOG.md
+
+There is also the slightly outdated but conceptually still correct [documentation](https://outwatch.github.io/) (contributions welcome).
 
 ## Three main goals of OutWatch
 


### PR DESCRIPTION
I believe that a lot of newcomers still start using the outdated outwatch version `0.10.x`. They should use the new one instead.

fixes #84, #46 