### PR TITLE
Modifier stream with value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ...
 
+* Make Handler.create return a BehaviourSubject if there is a seed, otherwise create a ReplaceSubject.createLimited(1).
+
+* Introduce proper lifecycle hooks: `onDomMount` (called when a VNode is mounted into an element), `onDomUnmount` (called when a VNode is unmounted from an element), `onDomUpdate` (called when a VNode was updated in the same element). With only using snabbdom lifecycle hooks, we get incorrect behavior: onInsert and onDestroy are not sufficient to know when a node is inserted into the dom or removed from the dom. You also need to check onPostPatch and check whether you are patching against an older version of the same node or against a totally different node. For outwatch, this lead to leaking subscriptions because only onDestroy is handled, but a node could be removed via onPostPatch as well. The same was true for the managed subscription. Therefore, we added the new lifecycle events. They are built by putting a state into the VNodeProxy which can be accessed in onPostPatch hooks. So now, subscriptions do not leak anymore and application have proper hooks for accessing the dom element only when necessary. The snabbdom events were renamed to onSnabbdomInsert, onSnabbdomDestroy, etc. Old names were deprecated with a hint on using the new hooks.
+
+* Introduce AsValueObservable and AsObserver typeclasses for convenience. This allows to hook custom streaming libraries into Outwatch. You can use any type `Stream[_]` as an observable when you define an Instance of `AsValueObservable[Stream]` and use it as a sink when you define an instance of `AsObserver[Stream]`. The ValueObservable class allows to provide an optional initial value, if your stream implementation can access that synchronously
+
+* Fix leaking subscriptions when using custom snabbdom keys.
+
+* Fix leaking managed subscriptions when nodes are patched.
+
+* Faster patching and updating of streamed content. We now cache VNodes so they are not recalculated when they did not change. We fixed patches using outdated data. Furthermore, separation of VDomModifiers was made more efficient.
+
 * Update snabbdom to version 0.7.2.
 
 * Remove implicit scheduler from `Handler.create` methods.

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ crossScalaVersions := Seq("2.11.12", "2.12.6")
 
 
 libraryDependencies ++= Seq(
-  "io.monix"        %%% "monix"       % "3.0.0-M3",
+  "io.monix"        %%% "monix"       % "3.0.0-RC1",
   "org.scala-js"    %%% "scalajs-dom" % "0.9.6",
   "com.raquo"       %%% "domtypes" % "0.9",
   "org.typelevel" %%% "cats-core" % "1.1.0",

--- a/src/main/scala/outwatch/AsVDomModifier.scala
+++ b/src/main/scala/outwatch/AsVDomModifier.scala
@@ -2,7 +2,7 @@ package outwatch
 
 import cats.effect.IO
 import monix.reactive.Observable
-import outwatch.dom.{CompositeModifier, ModifierStreamReceiver, StringModifier, VDomModifier}
+import outwatch.dom.{CompositeModifier, ModifierStreamReceiver, StringVNode, VDomModifier}
 
 trait AsVDomModifier[-T] {
   def asVDomModifier(value: T): VDomModifier
@@ -21,23 +21,23 @@ object AsVDomModifier {
   }
 
   implicit object StringAsVDomModifier extends AsVDomModifier[String] {
-    def asVDomModifier(value: String): VDomModifier = IO.pure(StringModifier(value))
+    def asVDomModifier(value: String): VDomModifier = IO.pure(StringVNode(value))
   }
 
   implicit object IntAsVDomModifier extends AsVDomModifier[Int] {
-    def asVDomModifier(value: Int): VDomModifier = IO.pure(StringModifier(value.toString))
+    def asVDomModifier(value: Int): VDomModifier = IO.pure(StringVNode(value.toString))
   }
 
   implicit object DoubleAsVDomModifier extends AsVDomModifier[Double] {
-    def asVDomModifier(value: Double): VDomModifier = IO.pure(StringModifier(value.toString))
+    def asVDomModifier(value: Double): VDomModifier = IO.pure(StringVNode(value.toString))
   }
 
   implicit object LongAsVDomModifier extends AsVDomModifier[Long] {
-    def asVDomModifier(value: Long): VDomModifier = IO.pure(StringModifier(value.toString))
+    def asVDomModifier(value: Long): VDomModifier = IO.pure(StringVNode(value.toString))
   }
 
   implicit object BooleanAsVDomModifier extends AsVDomModifier[Boolean] {
-    def asVDomModifier(value: Boolean): VDomModifier = IO.pure(StringModifier(value.toString))
+    def asVDomModifier(value: Boolean): VDomModifier = IO.pure(StringVNode(value.toString))
   }
 
   implicit object ObservableRender extends AsVDomModifier[Observable[VDomModifier]] {

--- a/src/main/scala/outwatch/AsVDomModifier.scala
+++ b/src/main/scala/outwatch/AsVDomModifier.scala
@@ -2,7 +2,6 @@ package outwatch
 
 import cats.effect.IO
 import cats.syntax.functor._
-import monix.reactive.Observable
 import outwatch.dom.{AsValueObservable, CompositeModifier, ModifierStreamReceiver, StringVNode, VDomModifier, ValueObservable}
 
 trait AsVDomModifier[-T] {
@@ -40,10 +39,6 @@ object AsVDomModifier {
   implicit object BooleanAsVDomModifier extends AsVDomModifier[Boolean] {
     def asVDomModifier(value: Boolean): VDomModifier = IO.pure(StringVNode(value.toString))
   }
-
-  implicit def observableRender[T : AsVDomModifier]: AsVDomModifier[Observable[T]] = (valueStream: Observable[T]) => IO.pure(
-    ModifierStreamReceiver(ValueObservable(valueStream).map(VDomModifier(_)))
-  )
 
   implicit def valueObservableRender[T : AsVDomModifier, F[_] : AsValueObservable]: AsVDomModifier[F[T]] = (valueStream: F[T]) => IO.pure(
     ModifierStreamReceiver(ValueObservable(valueStream).map(VDomModifier(_)))

--- a/src/main/scala/outwatch/Handler.scala
+++ b/src/main/scala/outwatch/Handler.scala
@@ -3,19 +3,17 @@ package outwatch
 import cats.effect.IO
 import monix.execution.{Ack, Cancelable}
 import monix.reactive.observers.Subscriber
-import monix.reactive.subjects.PublishSubject
+import monix.reactive.subjects.{BehaviorSubject, ReplaySubject}
 import monix.reactive.{Observable, Observer}
 
 import scala.concurrent.Future
 
 object Handler {
-  def empty[T]():IO[Handler[T]] = IO(PublishSubject[T])
+  def empty[T]:IO[Handler[T]] = create[T]
 
-  def create[T]:IO[Handler[T]] = IO(PublishSubject[T])
+  def create[T]:IO[Handler[T]] = IO(ReplaySubject.createLimited(1))
 
-  def create[T](seed:T):IO[Handler[T]] = IO {
-      PublishSubject[T].transformObservable(_.startWith(seed :: Nil))
-  }
+  def create[T](seed:T):IO[Handler[T]] = IO(BehaviorSubject[T](seed))
 }
 
 object ProHandler {

--- a/src/main/scala/outwatch/MonixOps.scala
+++ b/src/main/scala/outwatch/MonixOps.scala
@@ -14,19 +14,19 @@ trait MonixOps {
   @deprecated("use ProHandler instead", "")
   type Pipe[-I, +O] = ProHandler[I,O]
 
-  implicit class RichObserver[I](observer: Observer[I])(implicit scheduler: Scheduler) {
-    def redirect[I2](f: Observable[I2] => Observable[I]): Observer[I2] = {
+  implicit class RichObserver[I](observer: Observer[I]) {
+    def redirect[I2](f: Observable[I2] => Observable[I])(implicit scheduler: Scheduler): Observer[I2] = {
       val subject = PublishSubject[I2]
       f(subject).subscribe(observer)
       subject
     }
 
-    def redirectMap[I2](f: I2 => I): Observer[I2] = redirect(_.map(f))
+    def redirectMap[I2](f: I2 => I)(implicit scheduler: Scheduler): Observer[I2] = redirect(_.map(f))
 
     @deprecated("use onNext instead.", "")
     def unsafeOnNext(nextValue: I) = observer.onNext(nextValue)
 
-    def <--(observable: Observable[I]): IO[Cancelable] = IO {
+    def <--(observable: Observable[I])(implicit scheduler: Scheduler): IO[Cancelable] = IO {
       observable.subscribe(observer)
     }
   }

--- a/src/main/scala/outwatch/MonixOps.scala
+++ b/src/main/scala/outwatch/MonixOps.scala
@@ -1,11 +1,9 @@
 package outwatch
 
 import cats.effect.IO
-import monix.execution.{Ack, Cancelable, Scheduler}
+import monix.execution.{Cancelable, Scheduler}
 import monix.reactive.subjects.PublishSubject
 import monix.reactive.{Observable, Observer}
-
-import scala.concurrent.Future
 
 trait MonixOps {
   type ProHandler[-I, +O] = Observable[O] with Observer[I]

--- a/src/main/scala/outwatch/MonixOps.scala
+++ b/src/main/scala/outwatch/MonixOps.scala
@@ -1,10 +1,11 @@
 package outwatch
 
 import cats.effect.IO
-import monix.execution.{Cancelable, Scheduler}
+import monix.execution.{Ack, Cancelable, Scheduler}
 import monix.reactive.subjects.PublishSubject
 import monix.reactive.{Observable, Observer}
 
+import scala.concurrent.Future
 
 trait MonixOps {
   type ProHandler[-I, +O] = Observable[O] with Observer[I]
@@ -14,7 +15,6 @@ trait MonixOps {
   type Sink[-A] = Observer[A]
   @deprecated("use ProHandler instead", "")
   type Pipe[-I, +O] = ProHandler[I,O]
-
 
   implicit class RichObserver[I](observer: Observer[I])(implicit scheduler: Scheduler) {
     def redirect[I2](f: Observable[I2] => Observable[I]): Observer[I2] = {

--- a/src/main/scala/outwatch/dom/AsObserver.scala
+++ b/src/main/scala/outwatch/dom/AsObserver.scala
@@ -1,0 +1,19 @@
+package outwatch.dom
+
+import monix.execution.Ack
+import monix.reactive.Observer
+import monix.reactive.subjects.Var
+
+trait AsObserver[-F[_]] {
+  def as[T](stream: F[_ >: T]): Observer[T]
+}
+
+object AsObserver {
+  implicit object variable extends AsObserver[Var] {
+    def as[T](stream: Var[_ >: T]): Observer[T] = new Observer.Sync[T] {
+      override def onNext(elem: T): Ack = stream := elem
+      override def onError(ex: Throwable): Unit = throw ex
+      override def onComplete(): Unit = ()
+    }
+  }
+}

--- a/src/main/scala/outwatch/dom/AsValueObservable.scala
+++ b/src/main/scala/outwatch/dom/AsValueObservable.scala
@@ -1,0 +1,31 @@
+package outwatch.dom
+
+import monix.reactive.Observable
+import monix.reactive.subjects.Var
+
+trait AsValueObservable[-F[_]] {
+  def as[T](stream: F[T]): ValueObservable[T]
+}
+
+trait AsValueObservableInstances0 {
+  implicit object observable extends AsValueObservable[Observable] {
+    def as[T](stream: Observable[T]): ValueObservable[T] = new ValueObservable[T] {
+      def observable: Observable[T] = stream
+      def value: Option[T] = None
+    }
+  }
+}
+
+object AsValueObservable extends AsValueObservableInstances0  {
+  implicit object valueObservable extends AsValueObservable[ValueObservable] {
+    def as[T](stream: ValueObservable[T]): ValueObservable[T] = stream
+  }
+
+  implicit object variable extends AsValueObservable[Var] {
+    def as[T](stream: Var[T]): ValueObservable[T] = new ValueObservable[T] {
+      def observable: Observable[T] = stream.drop(1)
+      def value: Option[T] = Some(stream.apply())
+    }
+  }
+}
+

--- a/src/main/scala/outwatch/dom/Compat.scala
+++ b/src/main/scala/outwatch/dom/Compat.scala
@@ -68,20 +68,20 @@ trait AttributesCompat extends OutWatchChildAttributesCompat { self: Attributes 
   @deprecated("Use onKeyDown instead", "0.11.0")
   lazy val keydown = onKeyDown
 
-  @deprecated("Use onInsert instead", "0.11.0")
-  lazy val insert = onInsert
+  @deprecated("Use onSnabbdomInsert instead", "0.11.0")
+  lazy val insert = onSnabbdomInsert
 
-  @deprecated("Use onPrePatch instead", "0.11.0")
-  lazy val prepatch = onPrePatch
+  @deprecated("Use onSnabbdomPrePatch instead", "0.11.0")
+  lazy val prepatch = onSnabbdomPrePatch
 
-  @deprecated("Use onUpdate instead", "0.11.0")
-  lazy val update = onUpdate
+  @deprecated("Use onSnabbdomUpdate instead", "0.11.0")
+  lazy val update = onSnabbdomUpdate
 
-  @deprecated("Use onPostPatch instead", "0.11.0")
-  lazy val postpatch = onPostPatch
+  @deprecated("Use onSnabbdomPostPatch instead", "0.11.0")
+  lazy val postpatch = onSnabbdomPostPatch
 
-  @deprecated("Use onDestroy instead", "0.11.0")
-  lazy val destroy = onDestroy
+  @deprecated("Use onSnabbdomDestroy instead", "0.11.0")
+  lazy val destroy = onSnabbdomDestroy
 }
 
 trait TagsCompat { self: Tags =>

--- a/src/main/scala/outwatch/dom/Implicits.scala
+++ b/src/main/scala/outwatch/dom/Implicits.scala
@@ -3,12 +3,17 @@ package outwatch.dom
 import cats.effect.IO
 import cats.syntax.apply._
 import com.raquo.domtypes.generic.keys
+import monix.reactive.Observer
 import outwatch.AsVDomModifier
 import outwatch.dom.helpers.BasicStyleBuilder
 
 trait Implicits {
 
   implicit def asVDomModifier[T](value: T)(implicit vm: AsVDomModifier[T]): VDomModifier = vm.asVDomModifier(value)
+
+  //TODO: would be better to have typeclass AsObserver on all functions using observer.
+  // but if we do this: emitter --> obs will not compile with sideeffects without type parameters
+  implicit def asObserver[T, F[_]](value: F[T])(implicit ao: AsObserver[F]): Observer[T] = ao.as(value)
 
   implicit class ioVTreeMerge(vnode: VNode) {
     def apply(args: VDomModifier*): VNode = vnode.flatMap(_.apply(args: _*))

--- a/src/main/scala/outwatch/dom/ManagedSubscriptions.scala
+++ b/src/main/scala/outwatch/dom/ManagedSubscriptions.scala
@@ -9,14 +9,14 @@ trait ManagedSubscriptions {
 
   def managed(subscription: IO[Cancelable])(implicit s: Scheduler): VDomModifier = {
     subscription.flatMap { sub: Cancelable =>
-      lifecycle.onDestroy --> sideEffect{sub.cancel()}
+      lifecycle.onSnabbdomDestroy --> sideEffect{sub.cancel()}
     }
   }
 
   def managed(sub1: IO[Cancelable], sub2: IO[Cancelable], subscriptions: IO[Cancelable]*)(implicit s: Scheduler): VDomModifier = {
     (sub1 :: sub2 :: subscriptions.toList).sequence.flatMap { subs: Seq[Cancelable] =>
       val composite = CompositeCancelable(subs: _*)
-      lifecycle.onDestroy --> sideEffect{composite.cancel()}
+      lifecycle.onSnabbdomDestroy --> sideEffect{composite.cancel()}
     }
   }
 

--- a/src/main/scala/outwatch/dom/OutwatchAttributes.scala
+++ b/src/main/scala/outwatch/dom/OutwatchAttributes.scala
@@ -1,5 +1,8 @@
 package outwatch.dom
 
+import snabbdom.VNodeProxy
+import monix.reactive.Observer
+import org.scalajs.dom.Element
 import outwatch.dom.helpers._
 import cats.effect.IO
 
@@ -13,26 +16,38 @@ trait OutwatchAttributes
 
 /** Outwatch component life cycle hooks. */
 trait OutWatchLifeCycleAttributes {
+  lazy val onDomMount = SimpleEmitterBuilder(DomMountHook)
+  lazy val onDomUnmount = SimpleEmitterBuilder(DomUnmountHook)
+  lazy val onDomUpdate = SimpleEmitterBuilder(DomUpdateHook)
+
   /**
     * Lifecycle hook for component insertion.
     *
     * This hook is invoked once the DOM element for a vnode has been inserted into the document
     * and the rest of the patch cycle is done.
     */
-  lazy val onInsert   = SimpleEmitterBuilder(InsertHook)
+  @deprecated("Consider using onDomMount instead for getting realiably notified whenever the element is mounted with this VNode. For the raw snabbdom event as before, you can use onSnabbdomInsert.", "")
+  lazy val onInsert   = onSnabbdomInsert
+  lazy val onSnabbdomInsert   = SimpleEmitterBuilder(InsertHook)
 
   /** Lifecycle hook for component prepatch. */
-  lazy val onPrePatch   = SimpleEmitterBuilder(PrePatchHook)
+  @deprecated("Consider using onDomUpdate instead for getting realiably notified whenever the element is updated with this VNode. For the raw snabbdom event as before, you can use onSnabbdomPrePatch.", "")
+  lazy val onPrePatch   = onSnabbdomPrePatch
+  lazy val onSnabbdomPrePatch   = SimpleEmitterBuilder(PrePatchHook)
 
   /** Lifecycle hook for component updates. */
-  lazy val onUpdate   = SimpleEmitterBuilder(UpdateHook)
+  @deprecated("Consider using onDomUpdate instead for getting realiably notified whenever the element is updated with this VNode. For the raw snabbdom event as before, you can use onSnabbdomUpdate.", "")
+  lazy val onUpdate   = onSnabbdomUpdate
+  lazy val onSnabbdomUpdate   = SimpleEmitterBuilder(UpdateHook)
 
   /**
     * Lifecycle hook for component postpatch.
     *
     *  This hook is invoked every time a node has been patched against an older instance of itself.
     */
-  lazy val onPostPatch   = SimpleEmitterBuilder(PostPatchHook)
+  @deprecated("Consider using onDomUpdate instead for getting realiably notified whenever the element is updated with this VNode. For the raw snabbdom event as before, you can use onSnabbdomPostPatch.", "")
+  lazy val onPostPatch   = onSnabbdomPostPatch
+  lazy val onSnabbdomPostPatch   = SimpleEmitterBuilder(PostPatchHook)
 
   /**
     * Lifecycle hook for component destruction.
@@ -40,7 +55,9 @@ trait OutWatchLifeCycleAttributes {
     * This hook is invoked on a virtual node when its DOM element is removed from the DOM
     * or if its parent is being removed from the DOM.
     */
-  lazy val onDestroy  = SimpleEmitterBuilder(DestroyHook)
+  @deprecated("Consider using onDomUnmount instead for getting realiably notified whenever an element is unmounted with this VNode. For the raw snabbdom event as before, you can use onSnabbdomDestroy.", "")
+  lazy val onDestroy  = onSnabbdomDestroy
+  lazy val onSnabbdomDestroy  = SimpleEmitterBuilder(DestroyHook)
 }
 
 /** Snabbdom Key Attribute */

--- a/src/main/scala/outwatch/dom/OutwatchAttributes.scala
+++ b/src/main/scala/outwatch/dom/OutwatchAttributes.scala
@@ -1,8 +1,5 @@
 package outwatch.dom
 
-import snabbdom.VNodeProxy
-import monix.reactive.Observer
-import org.scalajs.dom.Element
 import outwatch.dom.helpers._
 import cats.effect.IO
 

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -127,7 +127,7 @@ object StaticVNode {
 }
 
 
-final case class ModifierStreamReceiver(stream: Observable[VDomModifier], defaultValue: Modifier = EmptyModifier) extends ChildVNode
+final case class ModifierStreamReceiver(stream: Observable[VDomModifier], initialValue: Modifier = EmptyModifier) extends ChildVNode
 
 // Static Nodes
 private[outwatch] final case class StringVNode(string: String) extends AnyVal with StaticVNode {

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -141,13 +141,11 @@ private[outwatch] final case class VTree(nodeType: String, modifiers: Seq[Modifi
 
   def apply(args: VDomModifier*): VNode = args.sequence.map(args => copy(modifiers = modifiers ++ args))
 
+  private var proxy: VNodeProxy = null
   override def toSnabbdom(implicit s: Scheduler): VNodeProxy = {
-    SeparatedModifiers.from(modifiers).toSnabbdom(nodeType)
+    if (proxy == null) {
+      proxy = SeparatedModifiers.from(modifiers).toSnabbdom(nodeType)
+    }
+    proxy
   }
 }
-
-
-
-
-
-

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -12,18 +12,16 @@ import scala.concurrent.Future
 Modifier
   Property
     Attribute
-      TitledAttribute
-        Attr
-          BasicAttr
-          AccumAttr
-        Prop
-        Style
-          BasicStyle
-          DelayedStyle
-          RemoveStyle
-          DestroyStyle
-          AccumStyle
-      EmptyAttribute
+      Attr
+        BasicAttr
+        AccumAttr
+      Prop
+      Style
+        BasicStyle
+        DelayedStyle
+        RemoveStyle
+        DestroyStyle
+        AccumStyle
     Hook
       InsertHook
       PrePatchHook
@@ -37,7 +35,6 @@ Modifier
       StringVNode
       VTree
   Emitter
-  AttributeStreamReceiver
   CompositeModifier
   StringModifier
   EmptyModifier
@@ -51,9 +48,6 @@ sealed trait Modifier extends Any
 sealed trait Property extends Modifier
 
 final case class Emitter(eventType: String, trigger: Event => Future[Ack]) extends Modifier
-
-//TODO: the only difference to a ModifierStreamReceiver: it can be grouped by its attribute name and the only the last stream is taken into account. Is this a benefit or can we remove it?
-private[outwatch] final case class AttributeStreamReceiver(attribute: String, attributeStream: Observable[Attribute], defaultValue: Modifier = EmptyModifier) extends Modifier
 
 private[outwatch] final case class CompositeModifier(modifiers: Seq[Modifier]) extends Modifier
 
@@ -70,11 +64,11 @@ object Key {
   type Value = DataObject.KeyValue
 }
 
-sealed trait Attribute extends Property
+sealed trait Attribute extends Property {
+  val title: String
+}
 object Attribute {
   def apply(title: String, value: Attr.Value): Attribute = BasicAttr(title, value)
-
-  val empty: Attribute = EmptyAttribute
 }
 
 
@@ -84,14 +78,7 @@ sealed trait Hook[T] extends Property {
 
 // Attributes
 
-private[outwatch] case object EmptyAttribute extends Attribute
-
-sealed trait TitledAttribute extends Attribute {
-  val title: String
-}
-
-
-sealed trait Attr extends TitledAttribute {
+sealed trait Attr extends Attribute {
   val value: Attr.Value
 }
 object Attr {
@@ -105,12 +92,12 @@ final case class BasicAttr(title: String, value: Attr.Value) extends Attr
   */
 final case class AccumAttr(title: String, value: Attr.Value, accum: (Attr.Value, Attr.Value)=> Attr.Value) extends Attr
 
-final case class Prop(title: String, value: Prop.Value) extends TitledAttribute
+final case class Prop(title: String, value: Prop.Value) extends Attribute
 object Prop {
   type Value = DataObject.PropValue
 }
 
-sealed trait Style extends TitledAttribute {
+sealed trait Style extends Attribute {
   val value: String
 }
 object Style {

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -36,7 +36,6 @@ Modifier
       VTree
   Emitter
   CompositeModifier
-  StringModifier
   EmptyModifier
  */
 
@@ -52,8 +51,6 @@ final case class Emitter(eventType: String, trigger: Event => Future[Ack]) exten
 private[outwatch] final case class CompositeModifier(modifiers: Seq[Modifier]) extends Modifier
 
 case object EmptyModifier extends Modifier
-
-private[outwatch] final case class StringModifier(string: String) extends Modifier
 
 sealed trait ChildVNode extends Any with Modifier
 

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -1,7 +1,7 @@
 package outwatch.dom
 
 import monix.execution.{Ack, Scheduler}
-import monix.reactive.{Observable, Observer}
+import monix.reactive.Observer
 import org.scalajs.dom._
 import outwatch.dom.helpers.SeparatedModifiers
 import snabbdom.{DataObject, VNodeProxy}
@@ -148,7 +148,7 @@ private[outwatch] final case class VTree(nodeType: String, modifiers: Seq[Modifi
   private var proxy: VNodeProxy = null
   override def toSnabbdom(implicit s: Scheduler): VNodeProxy = {
     if (proxy == null) {
-      proxy = SeparatedModifiers.from(modifiers).toSnabbdom(nodeType)
+      proxy = SnabbdomModifiers.toSnabbdom(SeparatedModifiers.from(modifiers), nodeType)
     }
     proxy
   }

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -110,6 +110,10 @@ final case class DestroyStyle(title: String, value: String) extends Style
 
 // Hooks
 
+private[outwatch] final case class DomMountHook(observer: Observer[Element]) extends Hook[Element]
+private[outwatch] final case class DomUnmountHook(observer: Observer[Element]) extends Hook[Element]
+private[outwatch] final case class DomUpdateHook(observer: Observer[Element]) extends Hook[Element]
+
 private[outwatch] final case class InsertHook(observer: Observer[Element]) extends Hook[Element]
 private[outwatch] final case class PrePatchHook(observer: Observer[(Option[Element], Option[Element])])
   extends Hook[(Option[Element], Option[Element])]

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -53,7 +53,7 @@ sealed trait Property extends Modifier
 final case class Emitter(eventType: String, trigger: Event => Future[Ack]) extends Modifier
 
 //TODO: the only difference to a ModifierStreamReceiver: it can be grouped by its attribute name and the only the last stream is taken into account. Is this a benefit or can we remove it?
-private[outwatch] final case class AttributeStreamReceiver(attribute: String, attributeStream: Observable[Attribute]) extends Modifier
+private[outwatch] final case class AttributeStreamReceiver(attribute: String, attributeStream: Observable[Attribute], defaultValue: Modifier = EmptyModifier) extends Modifier
 
 private[outwatch] final case class CompositeModifier(modifiers: Seq[Modifier]) extends Modifier
 
@@ -142,7 +142,8 @@ object StaticVNode {
   val empty: StaticVNode = StringVNode("")
 }
 
-private[outwatch] final case class ModifierStreamReceiver(stream: Observable[VDomModifier]) extends AnyVal with ChildVNode
+
+final case class ModifierStreamReceiver(stream: Observable[VDomModifier], defaultValue: Modifier = EmptyModifier) extends ChildVNode
 
 // Static Nodes
 private[outwatch] final case class StringVNode(string: String) extends AnyVal with StaticVNode {

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -3,7 +3,7 @@ package outwatch.dom
 import monix.execution.{Ack, Scheduler}
 import monix.reactive.Observer
 import org.scalajs.dom._
-import outwatch.dom.helpers.SeparatedModifiers
+import outwatch.dom.helpers.{SeparatedModifiers, SnabbdomModifiers}
 import snabbdom.{DataObject, VNodeProxy}
 
 import scala.concurrent.Future

--- a/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -127,7 +127,7 @@ object StaticVNode {
 }
 
 
-final case class ModifierStreamReceiver(stream: Observable[VDomModifier], initialValue: Modifier = EmptyModifier) extends ChildVNode
+final case class ModifierStreamReceiver(stream: ValueObservable[VDomModifier]) extends AnyVal with ChildVNode
 
 // Static Nodes
 private[outwatch] final case class StringVNode(string: String) extends AnyVal with StaticVNode {

--- a/src/main/scala/outwatch/dom/ValueObservable.scala
+++ b/src/main/scala/outwatch/dom/ValueObservable.scala
@@ -1,0 +1,49 @@
+package outwatch.dom
+
+import cats.Functor
+import monix.reactive.Observable
+import monix.reactive.subjects.Var
+
+trait ValueObservable[+T] {
+  def observable: Observable[T]
+  def value: Option[T]
+}
+
+object ValueObservable {
+  implicit def functor: Functor[ValueObservable] = new Functor[ValueObservable] {
+    override def map[A, B](fa: ValueObservable[A])(f: A => B): ValueObservable[B] = new ValueObservable[B] {
+      def observable: Observable[B] = fa.observable.map(f)
+      def value: Option[B] = fa.value.map(f)
+    }
+  }
+
+  def apply[T](stream: Observable[T], initialValue: T): ValueObservable[T] = new ValueObservable[T] {
+    override def observable: Observable[T] = stream
+    override def value: Option[T] = Some(initialValue)
+  }
+  def apply[F[_], T](stream: F[T])(implicit asValueObservable: AsValueObservable[F]): ValueObservable[T] = asValueObservable.as(stream)
+}
+
+trait AsValueObservable[-F[_]] {
+  def as[T](stream: F[T]): ValueObservable[T]
+}
+
+object AsValueObservable {
+  implicit object valueObservable extends AsValueObservable[ValueObservable] {
+    def as[T](stream: ValueObservable[T]): ValueObservable[T] = stream
+  }
+
+  implicit object observable extends AsValueObservable[Observable] {
+    def as[T](stream: Observable[T]): ValueObservable[T] = new ValueObservable[T] {
+      def observable: Observable[T] = stream
+      def value: Option[T] = None
+    }
+  }
+
+  implicit object variable extends AsValueObservable[Var] {
+    def as[T](stream: Var[T]): ValueObservable[T] = new ValueObservable[T] {
+      def observable: Observable[T] = stream.drop(1)
+      def value: Option[T] = Some(stream.apply())
+    }
+  }
+}

--- a/src/main/scala/outwatch/dom/ValueObservable.scala
+++ b/src/main/scala/outwatch/dom/ValueObservable.scala
@@ -2,7 +2,6 @@ package outwatch.dom
 
 import cats.Functor
 import monix.reactive.Observable
-import monix.reactive.subjects.Var
 
 trait ValueObservable[+T] {
   def observable: Observable[T]
@@ -22,28 +21,4 @@ object ValueObservable {
     override def value: Option[T] = Some(initialValue)
   }
   def apply[F[_], T](stream: F[T])(implicit asValueObservable: AsValueObservable[F]): ValueObservable[T] = asValueObservable.as(stream)
-}
-
-trait AsValueObservable[-F[_]] {
-  def as[T](stream: F[T]): ValueObservable[T]
-}
-
-object AsValueObservable {
-  implicit object valueObservable extends AsValueObservable[ValueObservable] {
-    def as[T](stream: ValueObservable[T]): ValueObservable[T] = stream
-  }
-
-  implicit object observable extends AsValueObservable[Observable] {
-    def as[T](stream: Observable[T]): ValueObservable[T] = new ValueObservable[T] {
-      def observable: Observable[T] = stream
-      def value: Option[T] = None
-    }
-  }
-
-  implicit object variable extends AsValueObservable[Var] {
-    def as[T](stream: Var[T]): ValueObservable[T] = new ValueObservable[T] {
-      def observable: Observable[T] = stream.drop(1)
-      def value: Option[T] = Some(stream.apply())
-    }
-  }
 }

--- a/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -16,6 +16,9 @@ trait AttributeBuilder[-T, +A <: Attribute] extends Any {
   def <--(valueStream: Observable[T]): IO[AttributeStreamReceiver] = {
     IO.pure(AttributeStreamReceiver(name, valueStream.map(assign)))
   }
+  def <--(valueStream: Observable[T], defaultValue: T): IO[AttributeStreamReceiver] = {
+    IO.pure(AttributeStreamReceiver(name, valueStream.map(assign), assign(defaultValue)))
+  }
 }
 
 object AttributeBuilder {

--- a/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -16,8 +16,8 @@ trait AttributeBuilder[-T, +A <: Attribute] extends Any {
   def <--(valueStream: Observable[T]): IO[ModifierStreamReceiver] = {
     IO.pure(ModifierStreamReceiver(valueStream.map(v => IO.pure(assign(v)))))
   }
-  def <--(valueStream: Observable[T], defaultValue: T): IO[ModifierStreamReceiver] = {
-    IO.pure(ModifierStreamReceiver(valueStream.map(v => IO.pure(assign(v))), assign(defaultValue)))
+  def <--(valueStream: => Observable[T], initialValue: => T): IO[ModifierStreamReceiver] = IO {
+    ModifierStreamReceiver(valueStream.map(v => IO.pure(assign(v))), assign(initialValue))
   }
 }
 

--- a/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -13,11 +13,11 @@ trait AttributeBuilder[-T, +A <: Attribute] extends Any {
 
   def :=(value: T): IO[A] = IO.pure(assign(value))
   def :=?(value: Option[T]): Option[VDomModifier] = value.map(:=)
-  def <--(valueStream: Observable[T]): IO[AttributeStreamReceiver] = {
-    IO.pure(AttributeStreamReceiver(name, valueStream.map(assign)))
+  def <--(valueStream: Observable[T]): IO[ModifierStreamReceiver] = {
+    IO.pure(ModifierStreamReceiver(valueStream.map(v => IO.pure(assign(v)))))
   }
-  def <--(valueStream: Observable[T], defaultValue: T): IO[AttributeStreamReceiver] = {
-    IO.pure(AttributeStreamReceiver(name, valueStream.map(assign), assign(defaultValue)))
+  def <--(valueStream: Observable[T], defaultValue: T): IO[ModifierStreamReceiver] = {
+    IO.pure(ModifierStreamReceiver(valueStream.map(v => IO.pure(assign(v))), assign(defaultValue)))
   }
 }
 

--- a/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -14,8 +14,7 @@ trait AttributeBuilder[-T, +A <: Attribute] extends Any {
 
   def :=(value: T): IO[A] = IO.pure(assign(value))
   def :=?(value: Option[T]): Option[VDomModifier] = value.map(:=)
-  def <--(valueStream: Observable[T]): IO[ModifierStreamReceiver] = <--[Observable](valueStream)
-  def <--[F[+_] : AsValueObservable](valueStream: F[T]): IO[ModifierStreamReceiver] = {
+  def <--[F[_] : AsValueObservable](valueStream: F[_ <: T]): IO[ModifierStreamReceiver] = {
     IO.pure(ModifierStreamReceiver(ValueObservable(valueStream).map(v => IO.pure(assign(v)))))
   }
 }
@@ -120,7 +119,6 @@ object ChildrenStreamReceiverBuilder {
   )
 
   def <--[T](childrenStream: Observable[Seq[T]])(implicit r: AsVDomModifier[T]): IO[ModifierStreamReceiver] = IO.pure(
-//    ModifierStreamReceiver(AsValueObservable.observable.as(childrenStream.map(_.map(r.asVDomModifier))))
-    ???
+    ModifierStreamReceiver(AsValueObservable.observable.as(childrenStream.map(_.map(r.asVDomModifier))))
   )
 }

--- a/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -126,12 +126,12 @@ private[outwatch] class StreamableModifiers(modifiers: Seq[Modifier]) {
         }
       }
 
-      val value = handleStreamedModifier(initialValue) match {
-        case ContentKind.Dynamic(_, initialValue) => initialValue
-        case ContentKind.Static(mod) => mod
+      handleStreamedModifier(initialValue) match {
+        case ContentKind.Dynamic(initialObservable, mod) =>
+          ContentKind.Dynamic(Observable.merge(initialObservable.takeUntil(observable), observable), mod)
+        case ContentKind.Static(mod) =>
+          ContentKind.Dynamic(observable, mod)
       }
-
-      ContentKind.Dynamic(observable, value)
 
     case CompositeModifier(modifiers) if (modifiers.nonEmpty) =>
       val streamableModifiers = new StreamableModifiers(modifiers)

--- a/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -1,6 +1,5 @@
 package outwatch.dom.helpers
 
-import cats.effect.IO
 import monix.reactive.Observable
 import outwatch.dom._
 

--- a/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
+++ b/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
@@ -12,7 +12,7 @@ trait EmitterBuilder[E, O, R] extends Any {
 
   def transform[T](tr: Observable[O] => Observable[T]): EmitterBuilder[E, T, R]
 
-  def -->(observer: Observer[_ >: O])(implicit scheduler:Scheduler): IO[R]
+  def -->(observer: Observer[O])(implicit scheduler:Scheduler): IO[R]
 
   def apply[T](value: T): EmitterBuilder[E, T, R] = map(_ => value)
 
@@ -42,7 +42,7 @@ final case class TransformingEmitterBuilder[E, O, R] private[helpers](
     transformer = tr compose transformer
   )
 
-  def -->(observer: Observer[_ >: O])(implicit scheduler:Scheduler): IO[R] = {
+  def -->(observer: Observer[O])(implicit scheduler:Scheduler): IO[R] = {
     val redirected: Observer[E] = observer.redirect[E](transformer)
     create(redirected)
   }
@@ -53,7 +53,7 @@ final case class CustomEmitterBuilder[E, R](create: Observer[E] => IO[R]) extend
   def transform[T](tr: Observable[E] => Observable[T]): EmitterBuilder[E, T, R] =
     new TransformingEmitterBuilder[E, T, R](tr, create)
 
-  def -->(observer: Observer[_ >: E])(implicit scheduler:Scheduler): IO[R] = create(observer)
+  def -->(observer: Observer[E])(implicit scheduler:Scheduler): IO[R] = create(observer)
 }
 object SimpleEmitterBuilder {
   def apply[E, R](create: Observer[E] => R) = CustomEmitterBuilder[E, R](observer => IO.pure(create(observer)))

--- a/src/main/scala/outwatch/dom/helpers/QueuedCancelable.scala
+++ b/src/main/scala/outwatch/dom/helpers/QueuedCancelable.scala
@@ -1,0 +1,22 @@
+package outwatch.dom.helpers
+
+import monix.execution.Cancelable
+
+class QueuedCancelable extends Cancelable {
+  private var queue: List[Cancelable] = Nil
+
+  def enqueue(cancelable: Cancelable) = queue :+= cancelable
+  def dequeue(): Cancelable = {
+    if (queue.isEmpty) Cancelable.empty
+    else {
+      val res = queue.head
+      queue = queue.tail
+      res
+    }
+  }
+
+  def cancel() = {
+    queue.foreach(_.cancel())
+    queue = Nil
+  }
+}

--- a/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
+++ b/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
@@ -258,7 +258,7 @@ private[outwatch] trait SnabbdomModifiers { self: SeparatedModifiers =>
     // never contain streamable content and therefore we do not need to handle
     // them with Receivers.
     val (receivers, dataObject) = previousProxy.fold {
-      val receivers = Receivers(childrenWithKey, attributeReceivers)
+      val receivers = Receivers(childrenWithKey)
       (Option(receivers), createDataObject(receivers))
     } { p =>
       (None, updateDataObject(p.data))

--- a/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
+++ b/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
@@ -264,14 +264,16 @@ private[outwatch] trait SnabbdomModifiers { self: SeparatedModifiers =>
       (None, updateDataObject(p.data))
     }
 
-    val initialProxy = childrenWithKey match {
-      case Children.VNodes(vnodes, _) =>
-        val childProxies: js.Array[VNodeProxy] = vnodes.collect { case s: StaticVNode => s.toSnabbdom }(breakOut)
-        hFunction(nodeType, dataObject, childProxies)
-      case Children.StringModifiers(textChildren) =>
-        hFunction(nodeType, dataObject, textChildren.map(_.string).mkString)
-      case Children.Empty =>
+    val initialProxy = {
+      if (childrenWithKey.nodes.isEmpty) {
         hFunction(nodeType, dataObject)
+      } else if (childrenWithKey.hasVTree) {
+        val childProxies: js.Array[VNodeProxy] = childrenWithKey.nodes.collect { case s: StaticVNode => s.toSnabbdom }(breakOut)
+        hFunction(nodeType, dataObject, childProxies)
+      } else {
+        val textChildren: js.Array[String] = childrenWithKey.nodes.collect { case s: StringVNode => s.string }(breakOut)
+        hFunction(nodeType, dataObject, textChildren.mkString)
+      }
     }
 
     // we directly update this dataobject with default values from the receivers

--- a/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
+++ b/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
@@ -231,7 +231,7 @@ private[outwatch] object SnabbdomModifiers {
         mergeHooksPair(previousData.hook.prepatch, hooks.prepatch),
         mergeHooksPair(previousData.hook.update, hooks.update),
         mergeHooksPair(previousData.hook.postpatch, hooks.postpatch),
-        mergeHooksSingle(previousData.hook.destroy, hooks.destroy),
+        mergeHooksSingle(previousData.hook.destroy, hooks.destroy)
       ),
       key = keyOption.orUndefined orElse previousData.key
     )

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -1,6 +1,7 @@
 package outwatch
 
 import cats.effect.IO
+import monix.reactive.Observable
 
 package object dom extends Implicits with ManagedSubscriptions with SideEffects with MonixOps {
 

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -16,5 +16,8 @@ package object dom extends Implicits with ManagedSubscriptions with SideEffects 
     def apply(modifier: VDomModifier, modifier2: VDomModifier, modifiers: VDomModifier*): VDomModifier =
       (Seq(modifier, modifier2) ++ modifiers).sequence.map(CompositeModifier)
     def apply[T](t: T)(implicit as: AsVDomModifier[T]): VDomModifier = as.asVDomModifier(t)
+    def stream[T](stream: => Observable[VDomModifier], initialValue: => VDomModifier = IO.pure(EmptyModifier)) = IO.suspend {
+      initialValue.map(ModifierStreamReceiver(stream, _))
+    }
   }
 }

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -16,7 +16,7 @@ package object dom extends Implicits with ManagedSubscriptions with SideEffects 
     def apply(modifier: VDomModifier, modifier2: VDomModifier, modifiers: VDomModifier*): VDomModifier =
       (Seq(modifier, modifier2) ++ modifiers).sequence.map(CompositeModifier)
     def apply[T](t: T)(implicit as: AsVDomModifier[T]): VDomModifier = as.asVDomModifier(t)
-    def stream[T](stream: => Observable[VDomModifier], initialValue: => VDomModifier = IO.pure(EmptyModifier)) = IO.suspend {
+    def stream[T](stream: Observable[VDomModifier], initialValue: VDomModifier = IO.pure(EmptyModifier)) = IO.suspend {
       initialValue.map(ModifierStreamReceiver(stream, _))
     }
   }

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -1,7 +1,6 @@
 package outwatch
 
 import cats.effect.IO
-import monix.reactive.Observable
 
 package object dom extends Implicits with ManagedSubscriptions with SideEffects with MonixOps {
 

--- a/src/main/scala/outwatch/dom/package.scala
+++ b/src/main/scala/outwatch/dom/package.scala
@@ -16,8 +16,5 @@ package object dom extends Implicits with ManagedSubscriptions with SideEffects 
     def apply(modifier: VDomModifier, modifier2: VDomModifier, modifiers: VDomModifier*): VDomModifier =
       (Seq(modifier, modifier2) ++ modifiers).sequence.map(CompositeModifier)
     def apply[T](t: T)(implicit as: AsVDomModifier[T]): VDomModifier = as.asVDomModifier(t)
-    def stream[T](stream: Observable[VDomModifier], initialValue: VDomModifier = IO.pure(EmptyModifier)) = IO.suspend {
-      initialValue.map(ModifierStreamReceiver(stream, _))
-    }
   }
 }

--- a/src/main/scala/outwatch/util/SyntaxSugar.scala
+++ b/src/main/scala/outwatch/util/SyntaxSugar.scala
@@ -2,7 +2,7 @@ package outwatch.util
 
 import cats.effect.IO
 import monix.reactive.Observable
-import outwatch.dom.{Attribute, AttributeStreamReceiver, EmptyModifier}
+import outwatch.dom.{Attribute, ModifierStreamReceiver, EmptyModifier}
 
 
 object SyntaxSugar {

--- a/src/main/scala/outwatch/util/SyntaxSugar.scala
+++ b/src/main/scala/outwatch/util/SyntaxSugar.scala
@@ -2,16 +2,16 @@ package outwatch.util
 
 import cats.effect.IO
 import monix.reactive.Observable
-import outwatch.dom.{Attribute, AttributeStreamReceiver, TitledAttribute}
+import outwatch.dom.{Attribute, AttributeStreamReceiver, EmptyModifier}
 
 
 object SyntaxSugar {
 
   implicit class BooleanSelector(val values: Observable[Boolean]) extends AnyVal {
-    def ?=(attr: IO[TitledAttribute]): IO[AttributeStreamReceiver] = {
+    def ?=(attr: IO[Attribute]): IO[ModifierStreamReceiver] = {
       attr.map { attr =>
-        val attributes = values.map(b => if (b) attr else Attribute.empty)
-        AttributeStreamReceiver(attr.title, attributes)
+        val attributes = values.map(b => if (b) IO.pure(attr) else IO.pure(EmptyModifier))
+        ModifierStreamReceiver(attributes)
       }
     }
   }

--- a/src/main/scala/outwatch/util/SyntaxSugar.scala
+++ b/src/main/scala/outwatch/util/SyntaxSugar.scala
@@ -2,7 +2,7 @@ package outwatch.util
 
 import cats.effect.IO
 import monix.reactive.Observable
-import outwatch.dom.{Attribute, ModifierStreamReceiver, EmptyModifier}
+import outwatch.dom.{Attribute, EmptyModifier, ModifierStreamReceiver, ValueObservable}
 
 
 object SyntaxSugar {
@@ -11,7 +11,7 @@ object SyntaxSugar {
     def ?=(attr: IO[Attribute]): IO[ModifierStreamReceiver] = {
       attr.map { attr =>
         val attributes = values.map(b => if (b) IO.pure(attr) else IO.pure(EmptyModifier))
-        ModifierStreamReceiver(attributes)
+        ModifierStreamReceiver(ValueObservable(attributes))
       }
     }
   }

--- a/src/main/scala/snabbdom/hFunction.scala
+++ b/src/main/scala/snabbdom/hFunction.scala
@@ -5,7 +5,6 @@ import org.scalajs.dom._
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 import scala.scalajs.js.{UndefOr, |}
-import monix.execution.Cancelable
 
 @js.native
 @JSImport("snabbdom/h", JSImport.Namespace, globalFallback = "h")

--- a/src/main/scala/snabbdom/hFunction.scala
+++ b/src/main/scala/snabbdom/hFunction.scala
@@ -5,6 +5,7 @@ import org.scalajs.dom._
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 import scala.scalajs.js.{UndefOr, |}
+import monix.execution.Cancelable
 
 @js.native
 @JSImport("snabbdom/h", JSImport.Namespace, globalFallback = "h")
@@ -33,10 +34,10 @@ object hFunction {
 
 
 trait Hooks extends js.Object {
-  var insert: js.UndefOr[Hooks.HookSingleFn] //TODO: can we get rid of this var?
+  val insert: js.UndefOr[Hooks.HookSingleFn]
   val prepatch: js.UndefOr[Hooks.HookPairFn]
   val update: js.UndefOr[Hooks.HookPairFn]
-  var postpatch: js.UndefOr[Hooks.HookPairFn] //TODO: can we get rid of this var?
+  val postpatch: js.UndefOr[Hooks.HookPairFn]
   val destroy: js.UndefOr[Hooks.HookSingleFn]
 }
 
@@ -57,10 +58,10 @@ object Hooks {
     val _postpatch = postpatch
     val _destroy = destroy
     new Hooks {
-      var insert = _insert
+      val insert = _insert
       val prepatch = _prepatch
       val update = _update
-      var postpatch = _postpatch
+      val postpatch = _postpatch
       val destroy = _destroy
     }
   }
@@ -131,6 +132,8 @@ object patch {
   def apply(firstNode: org.scalajs.dom.Element, vNode: VNodeProxy): VNodeProxy = p(firstNode,vNode)
 }
 
+case class OutwatchState(id: Int, domUnmountHooks: js.UndefOr[Hooks.HookSingleFn])
+
 @js.native
 trait VNodeProxy extends js.Object {
   var sel: String
@@ -139,6 +142,8 @@ trait VNodeProxy extends js.Object {
   var elm: js.UndefOr[Element]
   var text: js.UndefOr[String]
   var key: js.UndefOr[DataObject.KeyValue]
+
+  var outwatchState: js.UndefOr[OutwatchState]
 }
 
 object VNodeProxy {

--- a/src/main/scala/snabbdom/hFunction.scala
+++ b/src/main/scala/snabbdom/hFunction.scala
@@ -33,10 +33,10 @@ object hFunction {
 
 
 trait Hooks extends js.Object {
-  var insert: js.UndefOr[Hooks.HookSingleFn] //TODO
+  var insert: js.UndefOr[Hooks.HookSingleFn] //TODO: can we get rid of this var?
   val prepatch: js.UndefOr[Hooks.HookPairFn]
   val update: js.UndefOr[Hooks.HookPairFn]
-  var postpatch: js.UndefOr[Hooks.HookPairFn]
+  var postpatch: js.UndefOr[Hooks.HookPairFn] //TODO: can we get rid of this var?
   val destroy: js.UndefOr[Hooks.HookSingleFn]
 }
 

--- a/src/main/scala/snabbdom/hFunction.scala
+++ b/src/main/scala/snabbdom/hFunction.scala
@@ -33,7 +33,7 @@ object hFunction {
 
 
 trait Hooks extends js.Object {
-  val insert: js.UndefOr[Hooks.HookSingleFn]
+  var insert: js.UndefOr[Hooks.HookSingleFn] //TODO
   val prepatch: js.UndefOr[Hooks.HookPairFn]
   val update: js.UndefOr[Hooks.HookPairFn]
   val postpatch: js.UndefOr[Hooks.HookPairFn]
@@ -57,7 +57,7 @@ object Hooks {
     val _postpatch = postpatch
     val _destroy = destroy
     new Hooks {
-      val insert = _insert
+      var insert = _insert
       val prepatch = _prepatch
       val update = _update
       val postpatch = _postpatch
@@ -133,12 +133,12 @@ object patch {
 
 @js.native
 trait VNodeProxy extends js.Object {
-  val sel: String
-  val data: DataObject
-  val children: js.UndefOr[js.Array[VNodeProxy]]
-  val elm: js.UndefOr[Element]
-  val text: js.UndefOr[String]
-  val key: js.UndefOr[DataObject.KeyValue]
+  var sel: String
+  var data: DataObject
+  var children: js.UndefOr[js.Array[VNodeProxy]]
+  var elm: js.UndefOr[Element]
+  var text: js.UndefOr[String]
+  var key: js.UndefOr[DataObject.KeyValue]
 }
 
 object VNodeProxy {

--- a/src/main/scala/snabbdom/hFunction.scala
+++ b/src/main/scala/snabbdom/hFunction.scala
@@ -36,7 +36,7 @@ trait Hooks extends js.Object {
   var insert: js.UndefOr[Hooks.HookSingleFn] //TODO
   val prepatch: js.UndefOr[Hooks.HookPairFn]
   val update: js.UndefOr[Hooks.HookPairFn]
-  val postpatch: js.UndefOr[Hooks.HookPairFn]
+  var postpatch: js.UndefOr[Hooks.HookPairFn]
   val destroy: js.UndefOr[Hooks.HookSingleFn]
 }
 
@@ -60,7 +60,7 @@ object Hooks {
       var insert = _insert
       val prepatch = _prepatch
       val update = _update
-      val postpatch = _postpatch
+      var postpatch = _postpatch
       val destroy = _destroy
     }
   }

--- a/src/test/scala/outwatch/DomEventSpec.scala
+++ b/src/test/scala/outwatch/DomEventSpec.scala
@@ -312,7 +312,7 @@ class DomEventSpec extends JSDomSpec {
           onClick --> sideEffect(_ => triggeredEventFunction += 1),
           onClick(1) --> sideEffect(triggeredIntFunction += _),
           onClick --> sideEffect { triggeredFunction += 1 },
-          onUpdate --> sideEffect((old, current) => triggeredFunction2 += 1),
+          onSnabbdomUpdate --> sideEffect((old, current) => triggeredFunction2 += 1),
           stream
         )
       )
@@ -485,8 +485,8 @@ class DomEventSpec extends JSDomSpec {
 
             onClick.filter(_ => true).value --> stringStream,
 
-            onInsert.asHtml --> htmlElementStream,
-            onUpdate.asSvg --> svgElementTupleStream
+            onSnabbdomInsert.asHtml --> htmlElementStream,
+            onSnabbdomUpdate.asSvg --> svgElementTupleStream
           ),
           ul(id := "items")
         )

--- a/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -20,7 +20,7 @@ class LifecycleHookSpec extends JSDomSpec {
     }
 
     val node = sink.flatMap { sink =>
-      div(onInsert --> sink)
+      div(onSnabbdomInsert --> sink)
     }
 
     switch shouldBe false
@@ -46,7 +46,7 @@ class LifecycleHookSpec extends JSDomSpec {
     val node = for {
       sink <- sink
       sink2 <- sink2
-      node <- div(onInsert --> sink)(onInsert --> sink2)
+      node <- div(onSnabbdomInsert --> sink)(onSnabbdomInsert --> sink2)
     } yield node
 
     switch shouldBe false
@@ -69,7 +69,7 @@ class LifecycleHookSpec extends JSDomSpec {
     }
 
     val node = sink.flatMap { sink =>
-      div(Observable(span(onDestroy --> sink), div("Hasdasd")))
+      div(Observable(span(onSnabbdomDestroy --> sink), div("Hasdasd")))
     }
 
     switch shouldBe false
@@ -96,7 +96,7 @@ class LifecycleHookSpec extends JSDomSpec {
     val node = for {
       sink <- sink
       sink2 <- sink2
-      node <- div(Observable(span(onDestroy --> sink)(onDestroy --> sink2), div("Hasdasd")))
+      node <- div(Observable(span(onSnabbdomDestroy --> sink)(onSnabbdomDestroy --> sink2), div("Hasdasd")))
     } yield node
 
     switch shouldBe false
@@ -124,7 +124,7 @@ class LifecycleHookSpec extends JSDomSpec {
     val node = for {
       sink1 <- sink1
       sink2 <- sink2
-      node <- div(message, onUpdate --> sink1)(onUpdate --> sink2)
+      node <- div(message, onSnabbdomUpdate --> sink1)(onSnabbdomUpdate --> sink2)
     } yield node
 
     OutWatch.renderInto("#app", node).unsafeRunSync()
@@ -146,7 +146,7 @@ class LifecycleHookSpec extends JSDomSpec {
     }
 
     val node = sink.flatMap { sink =>
-      div(Observable(span(onUpdate --> sink, "Hello"), span(onUpdate --> sink, "Hey")))
+      div(Observable(span(onSnabbdomUpdate --> sink, "Hello"), span(onSnabbdomUpdate --> sink, "Hey")))
     }
 
     switch shouldBe false
@@ -166,7 +166,7 @@ class LifecycleHookSpec extends JSDomSpec {
     }
 
     val node = sink.flatMap { sink =>
-      div(Observable(span("Hello")), span(attributes.key := "1", onPrePatch --> sink, "Hey"))
+      div(Observable(span("Hello")), span(attributes.key := "1", onSnabbdomPrePatch --> sink, "Hey"))
     }
 
     switch shouldBe false
@@ -191,7 +191,7 @@ class LifecycleHookSpec extends JSDomSpec {
     val node =  for {
       sink1 <- sink1
       sink2 <- sink2
-      node <- div(message, onPrePatch --> sink1)(onPrePatch --> sink2)
+      node <- div(message, onSnabbdomPrePatch --> sink1)(onSnabbdomPrePatch --> sink2)
     } yield node
 
     OutWatch.renderInto("#app", node).unsafeRunSync()
@@ -213,7 +213,7 @@ class LifecycleHookSpec extends JSDomSpec {
     }
 
     val node = sink.flatMap { sink =>
-      div(Observable.pure("message"), onPostPatch --> sink, "Hey")
+      div(Observable.pure("message"), onSnabbdomPostPatch --> sink, "Hey")
     }
 
     switch shouldBe false
@@ -239,7 +239,7 @@ class LifecycleHookSpec extends JSDomSpec {
     val node = for {
       sink1 <- sink1
       sink2 <- sink2
-      node <- div(message, onPostPatch --> sink1)(onPostPatch --> sink2)
+      node <- div(message, onSnabbdomPostPatch --> sink1)(onSnabbdomPostPatch --> sink2)
     } yield node
 
     OutWatch.renderInto("#app", node).unsafeRunSync()
@@ -285,11 +285,11 @@ class LifecycleHookSpec extends JSDomSpec {
       prepatchSink <- prepatchSink
       postpatchSink <- postpatchSink
       node <- div(message,
-        onInsert --> insertSink,
-        onPrePatch --> prepatchSink,
-        onUpdate --> updateSink,
-        onPostPatch --> postpatchSink,
-        onDestroy --> destroySink
+        onSnabbdomInsert --> insertSink,
+        onSnabbdomPrePatch --> prepatchSink,
+        onSnabbdomUpdate --> updateSink,
+        onSnabbdomPostPatch --> postpatchSink,
+        onSnabbdomDestroy --> destroySink
       )
     } yield node
 
@@ -320,8 +320,8 @@ class LifecycleHookSpec extends JSDomSpec {
       insertSink <- insertSink
       updateSink <- updateSink
       node <- div("Hello", messageList.map(_.map(span(_))),
-        onInsert --> insertSink,
-        onUpdate --> updateSink
+        onSnabbdomInsert --> insertSink,
+        onSnabbdomUpdate --> updateSink
       )
     } yield node
 
@@ -352,7 +352,7 @@ class LifecycleHookSpec extends JSDomSpec {
       insertSink <- insertSink
       updateSink <- updateSink
       destroySink <- destroySink
-      node <- div(span("Hello", onInsert --> insertSink, onUpdate --> updateSink, onDestroy --> destroySink),
+      node <- div(span("Hello", onSnabbdomInsert --> insertSink, onSnabbdomUpdate --> updateSink, onSnabbdomDestroy --> destroySink),
         message.map(span(_))
       )
     } yield node
@@ -387,7 +387,7 @@ class LifecycleHookSpec extends JSDomSpec {
       updateSink <- updateSink
       destroySink <- destroySink
       node <- div(messageList.map(_.map(span(_))),
-        span("Hello", onInsert --> insertSink, onUpdate --> updateSink, onDestroy --> destroySink)
+        span("Hello", onSnabbdomInsert --> insertSink, onSnabbdomUpdate --> updateSink, onSnabbdomDestroy --> destroySink)
       )
     } yield node
 
@@ -444,10 +444,10 @@ class LifecycleHookSpec extends JSDomSpec {
       Continue
     }
 
-    val divTagName = onInsert.map(_.tagName.toLowerCase).filter(_ == "div")
+    val divTagName = onSnabbdomInsert.map(_.tagName.toLowerCase).filter(_ == "div")
 
     val node = sink.flatMap { sink =>
-      div(onInsert("insert") --> sink,
+      div(onSnabbdomInsert("insert") --> sink,
         div(divTagName --> sink),
         span(divTagName --> sink)
       )
@@ -459,4 +459,268 @@ class LifecycleHookSpec extends JSDomSpec {
 
   }
 
+  "Lifecycle and subscription" should "with a snabbdom key" in {
+    var onSnabbdomInsertCount = 0
+    var onSnabbdomPrePatchCount = 0
+    var onSnabbdomPostPatchCount = 0
+    var onSnabbdomUpdateCount = 0
+    var onSnabbdomDestroyCount = 0
+    var innerHandlerCount = 0
+    var onDomMountList = List.empty[Int]
+    var onDomUnmountList = List.empty[Int]
+    var onDomUpdateList = List.empty[Int]
+
+    val innerHandler = Handler.create[Int].unsafeRunSync
+    val handler = Handler.create[(String, String)].unsafeRunSync
+    val otherHandler = Handler.create[String].unsafeRunSync
+
+    var counter = 0
+    val node = div(
+      id := "strings",
+      otherHandler.map(div(_)),
+      handler.map { case (keyText, text) =>
+        counter += 1
+        val c = counter
+        div(
+          dsl.key := keyText,
+          text,
+          innerHandler.map { i => innerHandlerCount += 1; i },
+          onSnabbdomInsert --> sideEffect { onSnabbdomInsertCount += 1 },
+          onSnabbdomPrePatch --> sideEffect { onSnabbdomPrePatchCount += 1 },
+          onSnabbdomPostPatch --> sideEffect { onSnabbdomPostPatchCount += 1 },
+          onSnabbdomUpdate --> sideEffect { onSnabbdomUpdateCount += 1 },
+          onSnabbdomDestroy --> sideEffect { onSnabbdomDestroyCount += 1 },
+          onDomMount --> sideEffect { onDomMountList :+= c },
+          onDomUnmount --> sideEffect { onDomUnmountList :+= c },
+          onDomUpdate --> sideEffect { onDomUpdateList :+= c }
+        )
+      }
+    )
+
+    OutWatch.renderInto("#app", node).unsafeRunSync()
+    val element = document.getElementById("strings")
+
+    element.innerHTML shouldBe ""
+    onSnabbdomInsertCount shouldBe 0
+    onSnabbdomPrePatchCount shouldBe 0
+    onSnabbdomPostPatchCount shouldBe 0
+    onSnabbdomUpdateCount shouldBe 0
+    onSnabbdomDestroyCount shouldBe 0
+    onDomMountList shouldBe Nil
+    onDomUnmountList shouldBe Nil
+    onDomUpdateList shouldBe Nil
+
+    handler.onNext(("key", "heinz"))
+    element.innerHTML shouldBe "<div>heinz</div>"
+    onSnabbdomInsertCount shouldBe 1
+    onSnabbdomPrePatchCount shouldBe 0
+    onSnabbdomPostPatchCount shouldBe 0
+    onSnabbdomUpdateCount shouldBe 0
+    onSnabbdomDestroyCount shouldBe 0
+    onDomMountList shouldBe List(1)
+    onDomUnmountList shouldBe Nil
+    onDomUpdateList shouldBe Nil
+
+    handler.onNext(("key", "golum"))
+    element.innerHTML shouldBe "<div>golum</div>"
+    onSnabbdomInsertCount shouldBe 1
+    onSnabbdomPrePatchCount shouldBe 1
+    onSnabbdomPostPatchCount shouldBe 1
+    onSnabbdomUpdateCount shouldBe 1
+    onSnabbdomDestroyCount shouldBe 0
+    onDomMountList shouldBe List(1, 2)
+    //    onDomUnmountList shouldBe List(1)
+    onDomUpdateList shouldBe Nil
+
+    handler.onNext(("key", "dieter"))
+    element.innerHTML shouldBe "<div>dieter</div>"
+    onSnabbdomInsertCount shouldBe 1
+    onSnabbdomPrePatchCount shouldBe 2
+    onSnabbdomPostPatchCount shouldBe 2
+    onSnabbdomUpdateCount shouldBe 2
+    onSnabbdomDestroyCount shouldBe 0
+    onDomMountList shouldBe List(1, 2, 3)
+    onDomUnmountList shouldBe List(1,2)
+    onDomUpdateList shouldBe Nil
+
+    handler.onNext(("nope", "dieter"))
+    element.innerHTML shouldBe "<div>dieter</div>"
+    onSnabbdomInsertCount shouldBe 2
+    onSnabbdomPrePatchCount shouldBe 2
+    onSnabbdomPostPatchCount shouldBe 2
+    onSnabbdomUpdateCount shouldBe 2
+    onSnabbdomDestroyCount shouldBe 1
+    onDomMountList shouldBe List(1, 2 ,3, 4)
+    onDomUnmountList shouldBe List(1,2,3)
+    onDomUpdateList shouldBe Nil
+
+    handler.onNext(("yes", "peter"))
+    element.innerHTML shouldBe "<div>peter</div>"
+    onSnabbdomInsertCount shouldBe 3
+    onSnabbdomPrePatchCount shouldBe 2
+    onSnabbdomPostPatchCount shouldBe 2
+    onSnabbdomUpdateCount shouldBe 2
+    onSnabbdomDestroyCount shouldBe 2
+    onDomMountList shouldBe List(1, 2, 3, 4, 5)
+    onDomUnmountList shouldBe List(1, 2, 3, 4)
+    onDomUpdateList shouldBe Nil
+
+    otherHandler.onNext("hi")
+    element.innerHTML shouldBe "<div>hi</div><div>peter</div>"
+    onSnabbdomInsertCount shouldBe 3
+    onSnabbdomPrePatchCount shouldBe 3
+    onSnabbdomPostPatchCount shouldBe 2
+    onSnabbdomUpdateCount shouldBe 2
+    onSnabbdomDestroyCount shouldBe 2
+    onDomMountList shouldBe List(1, 2, 3, 4, 5)
+    onDomUnmountList shouldBe List(1, 2, 3, 4)
+    onDomUpdateList shouldBe Nil
+
+    innerHandlerCount shouldBe 0
+
+    innerHandler.onNext(0)
+    element.innerHTML shouldBe "<div>hi</div><div>peter0</div>"
+    onSnabbdomInsertCount shouldBe 3
+    onSnabbdomPrePatchCount shouldBe 4
+    onSnabbdomPostPatchCount shouldBe 3
+    onSnabbdomUpdateCount shouldBe 3
+    onSnabbdomDestroyCount shouldBe 2
+    onDomMountList shouldBe List(1, 2, 3, 4, 5)
+    onDomUnmountList shouldBe List(1, 2, 3, 4)
+    onDomUpdateList shouldBe List(5)
+
+    innerHandlerCount shouldBe 1
+  }
+
+  it should "without a custom key" in {
+    var onSnabbdomInsertCount = 0
+    var onSnabbdomPrePatchCount = 0
+    var onSnabbdomPostPatchCount = 0
+    var onSnabbdomUpdateCount = 0
+    var onSnabbdomDestroyCount = 0
+    var innerHandlerCount = 0
+    var onDomMountList = List.empty[Int]
+    var onDomUnmountList = List.empty[Int]
+    var onDomUpdateList = List.empty[Int]
+
+    val innerHandler = Handler.create[Int].unsafeRunSync
+    val handler = Handler.create[String].unsafeRunSync
+    val otherHandler = Handler.create[String].unsafeRunSync
+
+    var counter = 0
+    val node = div(
+      id := "strings",
+      otherHandler.map(div(_)),
+      handler.map { text =>
+        counter += 1
+        val c = counter
+        div(
+          text,
+          innerHandler.map { i => innerHandlerCount += 1; i },
+          onSnabbdomInsert --> sideEffect { onSnabbdomInsertCount += 1 },
+          onSnabbdomPrePatch --> sideEffect { onSnabbdomPrePatchCount += 1 },
+          onSnabbdomPostPatch --> sideEffect { onSnabbdomPostPatchCount += 1 },
+          onSnabbdomUpdate --> sideEffect { onSnabbdomUpdateCount += 1 },
+          onSnabbdomDestroy --> sideEffect { onSnabbdomDestroyCount += 1 },
+          onDomMount --> sideEffect { onDomMountList :+= c },
+          onDomUnmount --> sideEffect { onDomUnmountList :+= c },
+          onDomUpdate --> sideEffect { onDomUpdateList :+= c }
+        )
+      }
+    )
+
+    OutWatch.renderInto("#app", node).unsafeRunSync()
+    val element = document.getElementById("strings")
+
+    element.innerHTML shouldBe ""
+    onSnabbdomInsertCount shouldBe 0
+    onSnabbdomPrePatchCount shouldBe 0
+    onSnabbdomPostPatchCount shouldBe 0
+    onSnabbdomUpdateCount shouldBe 0
+    onSnabbdomDestroyCount shouldBe 0
+    onDomMountList shouldBe Nil
+    onDomUnmountList shouldBe Nil
+    onDomUpdateList shouldBe Nil
+
+    handler.onNext("heinz")
+    element.innerHTML shouldBe "<div>heinz</div>"
+    onSnabbdomInsertCount shouldBe 1
+    onSnabbdomPrePatchCount shouldBe 0
+    onSnabbdomPostPatchCount shouldBe 0
+    onSnabbdomUpdateCount shouldBe 0
+    onSnabbdomDestroyCount shouldBe 0
+    onDomMountList shouldBe List(1)
+    onDomUnmountList shouldBe Nil
+    onDomUpdateList shouldBe Nil
+
+    handler.onNext("golum")
+    element.innerHTML shouldBe "<div>golum</div>"
+    onSnabbdomInsertCount shouldBe 2
+    onSnabbdomPrePatchCount shouldBe 0
+    onSnabbdomPostPatchCount shouldBe 0
+    onSnabbdomUpdateCount shouldBe 0
+    onSnabbdomDestroyCount shouldBe 1
+    onDomMountList shouldBe List(1,2)
+    onDomUnmountList shouldBe List(1)
+    onDomUpdateList shouldBe Nil
+
+    handler.onNext("dieter")
+    element.innerHTML shouldBe "<div>dieter</div>"
+    onSnabbdomInsertCount shouldBe 3
+    onSnabbdomPrePatchCount shouldBe 0
+    onSnabbdomPostPatchCount shouldBe 0
+    onSnabbdomUpdateCount shouldBe 0
+    onSnabbdomDestroyCount shouldBe 2
+    onDomMountList shouldBe List(1,2,3)
+    onDomUnmountList shouldBe List(1,2)
+    onDomUpdateList shouldBe Nil
+
+    handler.onNext("dieter")
+    element.innerHTML shouldBe "<div>dieter</div>"
+    onSnabbdomInsertCount shouldBe 4
+    onSnabbdomPrePatchCount shouldBe 0
+    onSnabbdomPostPatchCount shouldBe 0
+    onSnabbdomUpdateCount shouldBe 0
+    onSnabbdomDestroyCount shouldBe 3
+    onDomMountList shouldBe List(1,2,3,4)
+    onDomUnmountList shouldBe List(1,2,3)
+    onDomUpdateList shouldBe Nil
+
+    handler.onNext("peter")
+    element.innerHTML shouldBe "<div>peter</div>"
+    onSnabbdomInsertCount shouldBe 5
+    onSnabbdomPrePatchCount shouldBe 0
+    onSnabbdomPostPatchCount shouldBe 0
+    onSnabbdomUpdateCount shouldBe 0
+    onSnabbdomDestroyCount shouldBe 4
+    onDomMountList shouldBe List(1,2,3,4,5)
+    onDomUnmountList shouldBe List(1,2,3,4)
+    onDomUpdateList shouldBe Nil
+
+    otherHandler.onNext("hi")
+    element.innerHTML shouldBe "<div>hi</div><div>peter</div>"
+    onSnabbdomInsertCount shouldBe 5
+    onSnabbdomPrePatchCount shouldBe 1
+    onSnabbdomPostPatchCount shouldBe 0
+    onSnabbdomUpdateCount shouldBe 0
+    onSnabbdomDestroyCount shouldBe 4
+    onDomMountList shouldBe List(1, 2, 3, 4, 5)
+    onDomUnmountList shouldBe List(1, 2, 3, 4)
+    onDomUpdateList shouldBe Nil
+
+    innerHandlerCount shouldBe 0
+
+    innerHandler.onNext(0)
+    element.innerHTML shouldBe "<div>hi</div><div>peter0</div>"
+    onSnabbdomInsertCount shouldBe 5
+    onSnabbdomPrePatchCount shouldBe 2
+    onSnabbdomPostPatchCount shouldBe 1
+    onSnabbdomUpdateCount shouldBe 1
+    onSnabbdomDestroyCount shouldBe 4
+    onDomMountList shouldBe List(1, 2, 3, 4, 5)
+    onDomUnmountList shouldBe List(1, 2, 3, 4)
+    onDomUpdateList shouldBe List(5)
+
+    innerHandlerCount shouldBe 1
+  }
 }

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -216,7 +216,7 @@ class OutWatchDomSpec extends JSDomSpec {
     children.hasStream shouldBe true
     children.hasVTree shouldBe true
 
-    val proxy = modifiers.toSnabbdom("div")
+    val proxy = SnabbdomModifiers.toSnabbdom(modifiers, "div")
     proxy.key.isDefined shouldBe true
 
     proxy.children.get.length shouldBe 2
@@ -243,7 +243,7 @@ class OutWatchDomSpec extends JSDomSpec {
     children.hasStream shouldBe true
     children.hasVTree shouldBe true
 
-    val proxy = modifiers.toSnabbdom("div")
+    val proxy = SnabbdomModifiers.toSnabbdom(modifiers, "div")
     proxy.key.toOption  shouldBe Some(1234)
 
     proxy.children.get(0).key.toOption shouldBe Some(5678)

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -1007,7 +1007,7 @@ class OutWatchDomSpec extends JSDomSpec {
     val myHandler = Handler.create[VDomModifier].unsafeRunSync()
     val node = div(id := "strings",
       div(
-        onPrePatch --> sideEffect { (e1, e2) =>
+        onSnabbdomPrePatch --> sideEffect { (e1, e2) =>
           numPatches += 1
         },
         ValueObservable(myHandler, VDomModifier("initial"))
@@ -1084,7 +1084,7 @@ class OutWatchDomSpec extends JSDomSpec {
     val myHandler = Handler.create[VDomModifier]("initial").unsafeRunSync()
     val node = div(id := "strings",
       div(
-        onPrePatch --> sideEffect { (e1, e2) =>
+        onSnabbdomPrePatch --> sideEffect { (e1, e2) =>
           numPatches += 1
         },
         myHandler

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -30,14 +30,15 @@ class OutWatchDomSpec extends JSDomSpec {
       PostPatchHook(PublishSubject())
     )
 
-    val SeparatedProperties(att, hooks, keys) = properties.foldRight(SeparatedProperties())((p, sp) => p :: sp)
+    val seps = SeparatedModifiers.from(properties)
+    import seps.properties._
 
     hooks.insertHooks.length shouldBe 2
     hooks.prePatchHooks.length shouldBe 1
     hooks.updateHooks.length shouldBe 1
     hooks.postPatchHooks.length shouldBe 1
     hooks.destroyHooks.length shouldBe 1
-    att.attrs.length shouldBe 1
+    attributes.attrs.length shouldBe 1
     keys.length shouldBe 0
   }
 
@@ -59,10 +60,10 @@ class OutWatchDomSpec extends JSDomSpec {
       ModifierStreamReceiver(ValueObservable(Observable()))
     )
 
-    val SeparatedModifiers(properties, emitters, children) =
-      SeparatedModifiers.from(modifiers)
+    val seps = SeparatedModifiers.from(modifiers)
+    import seps._
 
-    emitters.emitters.length shouldBe 2
+    emitters.length shouldBe 2
     properties.attributes.attrs.length shouldBe 2
     children.nodes.length shouldBe 5
     children.hasStream shouldBe true
@@ -82,10 +83,10 @@ class OutWatchDomSpec extends JSDomSpec {
       div().unsafeRunSync()
     )
 
-    val SeparatedModifiers(properties, emitters, children) =
-      SeparatedModifiers.from(modifiers)
+    val seps = SeparatedModifiers.from(modifiers)
+    import seps._
 
-    emitters.emitters.length shouldBe 3
+    emitters.length shouldBe 3
     properties.attributes.attrs.length shouldBe 1
     children.nodes.length shouldBe 4
     children.hasStream shouldBe true
@@ -105,10 +106,10 @@ class OutWatchDomSpec extends JSDomSpec {
       StringVNode("text2")
     )
 
-    val SeparatedModifiers(properties, emitters, children) =
-      SeparatedModifiers.from(modifiers)
+    val seps = SeparatedModifiers.from(modifiers)
+    import seps._
 
-    emitters.emitters.length shouldBe 3
+    emitters.length shouldBe 3
     properties.attributes.attrs.length shouldBe 1
     children.nodes.length shouldBe 4
     children.hasStream shouldBe true
@@ -132,11 +133,11 @@ class OutWatchDomSpec extends JSDomSpec {
       StringVNode("text")
     )
 
-    val SeparatedModifiers(properties, emitters, children) =
-      SeparatedModifiers.from(modifiers)
+    val seps = SeparatedModifiers.from(modifiers)
+    import seps._
 
-    emitters.emitters.map(_.eventType) shouldBe List("click", "input", "keyup")
-    emitters.emitters.length shouldBe 3
+    emitters.map(_.eventType) shouldBe List("click", "input", "keyup")
+    emitters.length shouldBe 3
     properties.hooks.insertHooks.length shouldBe 1
     properties.hooks.prePatchHooks.length shouldBe 1
     properties.hooks.updateHooks.length shouldBe 1

--- a/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -1055,6 +1055,30 @@ class OutWatchDomSpec extends JSDomSpec {
     numPatches shouldBe 7
   }
 
+  it should "work for deeply nested handlers" in {
+    val a = Handler.create[Int](0).unsafeRunSync
+    val b = a.map(_.toString)
+
+    val node = 
+      div(
+        a.map(_ => 
+            div(
+              b.map(b =>
+                div(b)
+              )
+            )
+        )
+      )
+    
+    OutWatch.renderInto("#app", node).unsafeRunSync()
+
+    val element = document.getElementById("app")
+    element.innerHTML shouldBe "<div><div><div>0</div></div></div>"
+
+    a.onNext(1)
+    element.innerHTML shouldBe "<div><div><div>1</div></div></div>"
+  }
+
   it should "work for nested modifier stream receiver and empty default and start with" in {
     var numPatches = 0
     val myHandler = Handler.create[VDomModifier]("initial").unsafeRunSync()

--- a/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -2,11 +2,9 @@ package outwatch
 
 import org.scalajs.dom.{document, html}
 import outwatch.Deprecated.IgnoreWarnings.initEvent
-import outwatch.dom.helpers.OutwatchTracing
 import snabbdom.{DataObject, hFunction, patch}
 
 import scala.scalajs.js
-import scala.scalajs.js.JSON
 
 class SnabbdomSpec extends JSDomSpec {
   "The Snabbdom Facade" should "correctly patch the DOM" in {


### PR DESCRIPTION
This PR has become quite the collection of changes which we did when working on our application. When investigating performance issues, we saw that the number of snabbdom patches needed to render our initial page was really high (multiple hundred times depending on the number of items displayed). Furthermore, updates on small subcomponents were triggering multiple times.

When using a stream of VDomModifier, outwatch would always render the element with an `empty placeholder` first, and then apply updates in form of snabbdom patches. In our case, we always have a `current value` (because our state is modeled with scalarx, same holds if you are using monix Var). Therefore, we know that we are able to render our initial page without any patching, because we know the initial state.

This lead to the first part of this PR: Introducing an initial value for `ModifierStreamReceiver`. We can thereby render initially with a sane value if it is available. Otherwise, we can still default to `EmptyModifier` as we do now (when using an Observable without any initial value). The initial patching can thereby be circumvented.

Down the line, we saw that calculating the VNodeProxy was quite compute heavy in js and that we do it way too often. When an element has multiple streams, each stream can trigger an update. In the case that one stream triggers, outwatch would calculate the VNodeProxy of all of its children. So when multiple streams trigger, all children are reiterate on each of these triggers. This is why, we introduced a state in the VNode (it caches the VNodeProxy, so it can be reused efficiently). Caching is always ugly, but in this case it is quite safe: each VNode is only ever used once, because it is wrapped in IO.

Now, the cache enables us to fix another problem. Let's say we have something like this: `div ( numberObservable.map(number => span(number)) )`. When the div initialyl renders, it is empty, because there is no initial value. When the observable then triggers, it will update the div to contain some number. Everything fine. But now lets say, the div itself was also part of a stream. If the number observable changes, this is only known to the div. But no parent knows of these changes. Therefore, the initial render of the outer div will remove the inner span from the dom. And then the number observable will trigger, and fill the dom again. This is really a problem when working with virtual dom, because we lose all benefits of patching. We just remove and add the node again.

Therefore, we have added a very ugly mutation. On each update, the just introduced cache of the VNode is modified to carry the new value. Therefore every parent's cache will now also contain the updated value because it contains the same VNodeProxy. So rendering will not remove the things from dom which should actually still be there.

On the way, we have also removed `StringModifer`, which we know handle as a StringVNode. But it still behaves as before so that if there are only strings, only a string is send to snabbdom. Furthermore, the `AttributeStreamReceiver` was removed and replaced by the `ModifierStreamReceiver`. The only benefit of the AttributeStreamReceiver was that it could make the stream unique per element. But we cannot really benefit from this behaviour because it hides a problem from the user (double definition) and a normal ModifierStreamReceiver could still lead to duplicate attribute definitions.

Sorry for the long post and the many changes. But this was a longer effort and the changes are somehow intermingled and partly depend on each other. What do you think?