### PR TITLE
remove stopImmediatePropagation from API (see #217)

### DIFF
--- a/outwatch/src/main/scala/outwatch/EmitterBuilder.scala
+++ b/outwatch/src/main/scala/outwatch/EmitterBuilder.scala
@@ -244,7 +244,6 @@ object EmitterBuilder {
     def onlyOwnEvents: EmitterBuilder[O, R] = builder.filter(ev => ev.currentTarget == ev.target)
     def preventDefault: EmitterBuilder.Sync[O, R] = builder.map { e => e.preventDefault; e }
     def stopPropagation: EmitterBuilder.Sync[O, R] = builder.map { e => e.stopPropagation; e }
-    def stopImmediatePropagation: EmitterBuilder.Sync[O, R] = builder.map { e => e.stopImmediatePropagation; e }
   }
 
   @inline implicit class TargetAsInput[O <: Event, R](builder: EmitterBuilder.Sync[O, R]) {

--- a/tests/src/test/scala/outwatch/DomEventSpec.scala
+++ b/tests/src/test/scala/outwatch/DomEventSpec.scala
@@ -702,33 +702,6 @@ class DomEventSpec extends JSDomAsyncSpec {
     }
   }
 
-  it should "stopImmediatePropagation" in {
-    // stopImmediatePropagation is supported in jsdom since version 9.12
-    // https://github.com/jsdom/jsdom/blob/master/Changelog.md#9120
-    pending
-
-    var triggeredFirst = false
-    var triggeredSecond = false
-    val node = div(
-      idAttr := "click",
-      onClick.stopImmediatePropagation foreach {triggeredFirst = true},
-      onClick foreach {triggeredSecond = true}
-    )
-
-    OutWatch.renderInto[IO]("#app", node).map { _ =>
-
-      val event = new Event("click", new EventInit {
-        bubbles = true
-        cancelable = false
-      })
-      document.getElementById("click").dispatchEvent(event)
-
-      triggeredFirst shouldBe true
-      triggeredSecond shouldBe false
-
-    }
-  }
-
   "Global dom events" should "return an observable" in {
     var clicked = 0
     val sub = events.window.onClick.foreach { _ =>


### PR DESCRIPTION
Snabbdom registers only one event listener for each occurring `eventType` in a VNode. This is why, we cannot implement #217 with snabbdom. Multiple handlers, will still yield only one event listener. Then, the dom cannot stop immediate propagation on these handlers.