### PR TITLE
tests: remove unsafeRunSync usage

### DIFF
--- a/src/test/scala/outwatch/AttributeSpec.scala
+++ b/src/test/scala/outwatch/AttributeSpec.scala
@@ -1,20 +1,24 @@
 package outwatch
 
+import cats.effect.IO
 import outwatch.dom._
 import outwatch.dom.dsl._
-
+import snabbdom.VNodeProxy
 import scala.scalajs.js
 
-class AttributeSpec extends JSDomSpec {
+class AttributeSpec extends JSDomAsyncSpec {
 
   "class attributes" should "be accumulated" in {
 
-    val node = input(
+    val node: IO[VNodeProxy] = input(
       className := "class1",
       cls := "class2"
-    ).map(_.toSnabbdom).unsafeRunSync()
+    ).map(_.toSnabbdom)
 
-    node.data.attrs.toList shouldBe List("class" -> "class1 class2")
+    for(n <- node) yield {
+      n.data.attrs.toList shouldBe List("class" -> "class1 class2")
+    }
+
   }
 
   "custom attributes" should "be able to be accumulated" in {
@@ -22,9 +26,12 @@ class AttributeSpec extends JSDomSpec {
     val node = input(
       attr("id").accum(",") := "foo1",
       attr("id").accum(",") := "foo2"
-    ).map(_.toSnabbdom).unsafeRunSync()
+    ).map(_.toSnabbdom)
 
-    node.data.attrs.toList shouldBe List("id" -> "foo1,foo2")
+    for(n <- node) yield {
+      n.data.attrs.toList shouldBe List("id" -> "foo1,foo2")
+    }
+
   }
 
   "data attributes" should "be able to be accumulated" in {
@@ -32,33 +39,44 @@ class AttributeSpec extends JSDomSpec {
     val node = input(
       data.foo.accum(",") := "foo1",
       data.foo.accum(",") := "foo2"
-    ).map(_.toSnabbdom).unsafeRunSync()
+    ).map(_.toSnabbdom)
 
-    node.data.attrs.toList shouldBe List("data-foo" -> "foo1,foo2")
+    for(n <- node) yield {
+      n.data.attrs.toList shouldBe List("data-foo" -> "foo1,foo2")
+    }
+
   }
 
   "data attribute" should "correctly render only Data" in {
+
     val node = input(
       data.geul := "bar",
       data.geuli.gurk := "barz"
-    ).map(_.toSnabbdom).unsafeRunSync()
+    ).map(_.toSnabbdom)
 
-    node.data.attrs.toList should contain theSameElementsAs List(
-      "data-geul" -> "bar",
-      "data-geuli-gurk" -> "barz"
-    )
+    for(n <- node) yield {
+      n.data.attrs.toList should contain theSameElementsAs List(
+        "data-geul" -> "bar",
+        "data-geuli-gurk" -> "barz"
+      )
+    }
+
   }
 
   it should "correctly render only expanded data with dynamic content" in {
+
     val node = input(
       dataAttr("geul") := "bar",
       dataAttr("geuli-gurk") := "barz"
-    ).map(_.toSnabbdom).unsafeRunSync()
+    ).map(_.toSnabbdom)
 
-    node.data.attrs.toList should contain theSameElementsAs List(
-      "data-geul" -> "bar",
-      "data-geuli-gurk" -> "barz"
-    )
+    for(n <- node) yield {
+      n.data.attrs.toList should contain theSameElementsAs List(
+        "data-geul" -> "bar",
+        "data-geuli-gurk" -> "barz"
+      )
+    }
+
   }
 
   it should "not compile data.without suffix" in {
@@ -71,6 +89,7 @@ class AttributeSpec extends JSDomSpec {
 //   }
 
   "attr/prop/style" should "correctly render type" in {
+
     val node = tag("input")(
       attr("foo") := "foo",
       attr[Boolean]("boo", identity) := true,
@@ -81,134 +100,168 @@ class AttributeSpec extends JSDomSpec {
       contentEditable := false,
       unselectable := false,
       disabled := false
-    ).map(_.toSnabbdom).unsafeRunSync()
+    ).map(_.toSnabbdom)
 
-    node.data.attrs.toList should contain theSameElementsAs List(
-      "foo" -> "foo",
-      "boo" -> true,
-      "yoo" -> "yes",
-      "contenteditable" -> "false",
-      "unselectable" -> "off",
-      "disabled" -> false
-    )
-    node.data.props.toList should contain theSameElementsAs List(
-      "bar" -> "bar",
-      "num" -> 12
-    )
-    node.data.style.toList should contain theSameElementsAs List(
-      "baz" -> "baz"
-    )
+    for(n <- node) yield {
+
+      n.data.attrs.toList should contain theSameElementsAs List(
+        "foo" -> "foo",
+        "boo" -> true,
+        "yoo" -> "yes",
+        "contenteditable" -> "false",
+        "unselectable" -> "off",
+        "disabled" -> false
+      )
+      n.data.props.toList should contain theSameElementsAs List(
+        "bar" -> "bar",
+        "num" -> 12
+      )
+      n.data.style.toList should contain theSameElementsAs List(
+        "baz" -> "baz"
+      )
+    }
+
   }
 
   "optional attributes" should "correctly render" in {
+
     val node = input(
       data.foo :=? Option("bar"),
       data.bar :=? Option.empty[String]
-    ).map(_.toSnabbdom).unsafeRunSync()
+    ).map(_.toSnabbdom)
 
-    node.data.attrs.toList should contain theSameElementsAs List(
-      "data-foo" -> "bar"
-    )
+    for(n <- node) yield {
+      n.data.attrs.toList should contain theSameElementsAs List(
+        "data-foo" -> "bar"
+      )
+    }
+
   }
 
   "apply on vtree" should "correctly merge attributes" in {
+
     val node = input(
       data.a := "bar",
       data.a.gurke := "franz"
     )(
       data.a := "buh",
       data.a.tomate := "gisela"
-    ).map(_.toSnabbdom).unsafeRunSync()
+    ).map(_.toSnabbdom)
 
-    node.data.attrs.toList should contain theSameElementsAs List(
-      "data-a" -> "buh",
-      "data-a-gurke" -> "franz",
-      "data-a-tomate" -> "gisela"
-    )
+    for(n <- node) yield {
+      n.data.attrs.toList should contain theSameElementsAs List(
+        "data-a" -> "buh",
+        "data-a-gurke" -> "franz",
+        "data-a-tomate" -> "gisela"
+      )
+    }
+
   }
 
   it should "correctly merge styles written with style" in {
+
     val node = input(
       style("color") := "red",
       fontSize:= "5px"
     )(
       style("color") := "blue",
       border := "1px solid black"
-    ).map(_.toSnabbdom).unsafeRunSync()
+    ).map(_.toSnabbdom)
 
-    node.data.style.toList should contain theSameElementsAs List(
-      ("color", "blue"),
-      ("font-size", "5px"),
-      ("border", "1px solid black")
-    )
+    for(n <- node) yield {
+      n.data.style.toList should contain theSameElementsAs List(
+        ("color", "blue"),
+        ("font-size", "5px"),
+        ("border", "1px solid black")
+      )
+    }
+
   }
 
   it should "correctly merge styles" in {
+
     val node = input(
       color.red,
       fontSize:= "5px"
     )(
       color.blue,
       border := "1px solid black"
-    ).map(_.toSnabbdom).unsafeRunSync()
+    ).map(_.toSnabbdom)
 
-    node.data.style.toList should contain theSameElementsAs List(
-      ("color", "blue"),
-      ("font-size", "5px"),
-      ("border", "1px solid black")
-    )
+    for(n <- node) yield {
+      n.data.style.toList should contain theSameElementsAs List(
+        ("color", "blue"),
+        ("font-size", "5px"),
+        ("border", "1px solid black")
+      )
+    }
+
   }
 
   it should "correctly merge keys" in {
 
-    val node = input( attributes.key := "bumm")( attributes.key := "klapp").map(_.toSnabbdom).unsafeRunSync()
-    node.data.key.toList should contain theSameElementsAs List("klapp")
+    val node1 = input( attributes.key := "bumm")( attributes.key := "klapp").map(_.toSnabbdom)
+    val node2 = input()( attributes.key := "klapp").map(_.toSnabbdom)
+    val node3 = input( attributes.key := "bumm")().map(_.toSnabbdom)
 
-    val node2 = input()( attributes.key := "klapp").map(_.toSnabbdom).unsafeRunSync()
-    node2.data.key.toList should contain theSameElementsAs List("klapp")
-
-    val node3 = input( attributes.key := "bumm")().map(_.toSnabbdom).unsafeRunSync()
-    node3.data.key.toList should contain theSameElementsAs List("bumm")
+    (for(n1 <- node1; n2 <- node2; n3 <- node3) yield {
+      n1.data.key.toList should contain theSameElementsAs List("klapp")
+      n2.data.key.toList should contain theSameElementsAs List("klapp")
+      n3.data.key.toList should contain theSameElementsAs List("bumm")
+    })
   }
 
   "style attribute" should "render correctly" in {
-    val node = input(color.red).map(_.toSnabbdom).unsafeRunSync()
 
-    node.data.style.toList should contain theSameElementsAs List(
-      "color" -> "red"
-    )
+    val node = input(color.red).map(_.toSnabbdom)
+
+    for(n <- node) yield {
+      n.data.style.toList should contain theSameElementsAs List(
+        "color" -> "red"
+      )
+    }
   }
 
 
   "extended styles" should "convert correctly" in {
+
     val node = div(
       opacity := 0,
       opacity.delayed := 1,
       opacity.remove := 0,
       opacity.destroy := 0
-    ).map(_.toSnabbdom).unsafeRunSync()
+    ).map(_.toSnabbdom)
 
-    node.data.style("opacity") shouldBe "0"
-    node.data.style("delayed").asInstanceOf[js.Dictionary[String]].toMap shouldBe Map("opacity" -> "1")
-    node.data.style("remove").asInstanceOf[js.Dictionary[String]].toMap shouldBe Map("opacity" -> "0")
-    node.data.style("destroy").asInstanceOf[js.Dictionary[String]].toMap shouldBe Map("opacity" -> "0")
+    for(n <- node) yield {
+      n.data.style("opacity") shouldBe "0"
+      n.data.style("delayed").asInstanceOf[js.Dictionary[String]].toMap shouldBe Map("opacity" -> "1")
+      n.data.style("remove").asInstanceOf[js.Dictionary[String]].toMap shouldBe Map("opacity" -> "0")
+      n.data.style("destroy").asInstanceOf[js.Dictionary[String]].toMap shouldBe Map("opacity" -> "0")
+    }
   }
 
   "style accum" should "convert correctly" in {
+
     val node = div(
       transition := "transform .2s ease-in-out",
       transition.accum(",") := "opacity .2s ease-in-out"
-    ).map(_.toSnabbdom).unsafeRunSync()
+    ).map(_.toSnabbdom)
 
-    node.data.style.toMap shouldBe Map("transition" -> "transform .2s ease-in-out,opacity .2s ease-in-out")
+    for(n <- node) yield {
+      n.data.style.toMap shouldBe Map("transition" -> "transform .2s ease-in-out,opacity .2s ease-in-out")
+    }
+
   }
 
   "svg" should "should work with tags and attributes" in {
+
     import outwatch.dom.dsl.svg._
     val node = svg(
       path(fill := "red", d := "M 100 100 L 300 100 L 200 300 z")
-    ).map(_.toSnabbdom).unsafeRunSync()
+    ).map(_.toSnabbdom)
 
-    node.children.get.head.data.attrs.toMap shouldBe Map("fill" -> "red", "d" -> "M 100 100 L 300 100 L 200 300 z")
+    for(n <- node) yield {
+      n.children.get.head.data.attrs.toMap shouldBe Map("fill" -> "red", "d" -> "M 100 100 L 300 100 L 200 300 z")
+    }
   }
 }

--- a/src/test/scala/outwatch/MonixOpsSpec.scala
+++ b/src/test/scala/outwatch/MonixOpsSpec.scala
@@ -2,185 +2,205 @@ package outwatch
 
 import monix.reactive.subjects.PublishSubject
 
-class MonixOpsSpec extends JSDomSpec {
+class MonixOpsSpec extends JSDomAsyncSpec {
 
   "Observer" should "redirect" in {
-    val subject = PublishSubject[Int]
+
     var currentValue = 0
+
+    val subject = PublishSubject[Int]
     subject.foreach{currentValue = _}
 
     val redirected = subject.redirect[Int](_.map(_ + 1))
 
-    subject.onNext(5)
-    assert(currentValue == 5)
+    for {
+      _ <- subject.onNext(5)
+      _ <- currentValue shouldBe 5
+      _ <- redirected.onNext(5)
+      _ <- currentValue shouldBe 6
 
-    redirected.onNext(5)
-    assert(currentValue == 6)
+    } yield succeed
   }
 
   it should "redirectMap" in {
-    val subject = PublishSubject[Int]
+
     var currentValue = 0
+
+    val subject = PublishSubject[Int]
     subject.foreach{currentValue = _}
 
     val redirected = subject.redirectMap[Int](_ + 1)
 
-    subject.onNext(5)
-    assert(currentValue == 5)
+    for {
+      _ <- subject.onNext(5)
+      _ <- currentValue shouldBe 5
+      _ <- redirected.onNext(5)
+      _ <- currentValue shouldBe 6
 
-    redirected.onNext(5)
-    assert(currentValue == 6)
+    } yield succeed
   }
 
 
   "PublishSubject" should "transformObservable" in {
+
+    var currentValue = 0
+
     val subject = PublishSubject[Int]
     val mapped = subject.transformObservable(_.map(_ + 1))
-    var currentValue = 0
     mapped.foreach{currentValue = _}
 
+    for {
+      _ <- subject.onNext(5)
+      _ <- currentValue shouldBe 6
+      _ <- mapped.onNext(7)
+      _ <- currentValue shouldBe 8
 
-    subject.onNext(5)
-    assert(currentValue == 6)
-
-    mapped.onNext(7)
-    assert(currentValue == 8)
+    } yield succeed
   }
 
   "Subject" should "lens" in {
-    val handler = Handler.create[(String, Int)].unsafeRunSync()
-    val lensed = handler.lens[Int](("harals", 0))(_._2)((tuple, num) => (tuple._1, num))
+
 
     var handlerValue: (String, Int) = null
     var lensedValue: Int = -100
 
-    handler(handlerValue = _)
-    lensed(lensedValue = _)
+    for {
 
-    lensed.onNext(15)
-    lensedValue shouldBe 15
-    handlerValue shouldBe (("harals", 15))
+      handler <- Handler.create[(String, Int)].unsafeToFuture()
+       lensed = handler.lens[Int](("harals", 0))(_._2)((tuple, num) => (tuple._1, num))
+            _ = handler(handlerValue = _)
+            _ = lensed(lensedValue = _)
+            _ <- lensed.onNext(15)
+            _ <- lensedValue shouldBe 15
+            _ <- handlerValue shouldBe (("harals", 15))
+            _ <- handler.onNext(("peter", 12))
+            _ <- lensedValue shouldBe 12
+            _ <- handlerValue shouldBe (("peter", 12))
+            _ <- lensed.onNext(-1)
+            _ <- lensedValue shouldBe -1
+            _ <- handlerValue shouldBe (("peter", -1))
 
-    handler.onNext(("peter", 12))
-    lensedValue shouldBe 12
-    handlerValue shouldBe (("peter", 12))
-
-    lensed.onNext(-1)
-    lensedValue shouldBe -1
-    handlerValue shouldBe (("peter", -1))
+    } yield succeed
   }
 
   it should "mapObservable" in {
-    val handler = Handler.create[Int].unsafeRunSync()
-    val lensed = handler.mapObservable(_ - 1)
 
     var handlerValue: Int = -100
     var lensedValue: Int = -100
 
-    handler(handlerValue = _)
-    lensed(lensedValue = _)
+    for {
+      handler <- Handler.create[Int].unsafeToFuture()
+       lensed = handler.mapObservable(_ - 1)
+            _ = handler(handlerValue = _)
+            _ = lensed(lensedValue = _)
+            _ <- lensed.onNext(15)
+            _ <- lensedValue shouldBe 14
+            _ <- handlerValue shouldBe 15
+            _ <- handler.onNext(12)
+            _ <- lensedValue shouldBe 11
+            _ <- handlerValue shouldBe 12
 
-    lensed.onNext(15)
-    lensedValue shouldBe 14
-    handlerValue shouldBe 15
-
-    handler.onNext(12)
-    lensedValue shouldBe 11
-    handlerValue shouldBe 12
+    } yield succeed
   }
 
   it should "transformObservable" in {
-    val handler = Handler.create[Int].unsafeRunSync()
-    val lensed = handler.transformObservable(_.map(_ - 1))
 
     var handlerValue: Int = -100
     var lensedValue: Int = -100
 
-    handler(handlerValue = _)
-    lensed(lensedValue = _)
+    for {
+      handler <- Handler.create[Int].unsafeToFuture()
+       lensed = handler.transformObservable(_.map(_ - 1))
+            _ = handler(handlerValue = _)
+            _ = lensed(lensedValue = _)
+            _ <- lensed.onNext(15)
+            _ <- lensedValue shouldBe 14
+            _ <- handlerValue shouldBe 15
+            _ <- handler.onNext(12)
+            _ <- lensedValue shouldBe 11
+            _ <- handlerValue shouldBe 12
 
-    lensed.onNext(15)
-    lensedValue shouldBe 14
-    handlerValue shouldBe 15
-
-    handler.onNext(12)
-    lensedValue shouldBe 11
-    handlerValue shouldBe 12
+    } yield succeed
   }
 
   it should "mapObserver" in {
-    val handler = Handler.create[Int].unsafeRunSync()
-    val lensed = handler.mapObserver[Int](_ + 1)
 
     var handlerValue: Int = -100
     var lensedValue: Int = -100
 
-    handler(handlerValue = _)
-    lensed(lensedValue = _)
+    for {
+      handler <- Handler.create[Int].unsafeToFuture()
+        lensed = handler.mapObserver[Int](_ + 1)
+             _ = handler(handlerValue = _)
+             _ = lensed(lensedValue = _)
+             _ <- lensed.onNext(15)
+             _ <- lensedValue shouldBe 16
+             _ <- handlerValue shouldBe 16
+             _ <- handler.onNext(12)
+             _ <- lensedValue shouldBe 12
+             _ <- handlerValue shouldBe 12
 
-    lensed.onNext(15)
-    lensedValue shouldBe 16
-    handlerValue shouldBe 16
-
-    handler.onNext(12)
-    lensedValue shouldBe 12
-    handlerValue shouldBe 12
+    } yield succeed
   }
 
   it should "transformObserver" in {
-    val handler = Handler.create[Int].unsafeRunSync()
-    val lensed = handler.transformObserver[Int](_.map(_ + 1))
 
     var handlerValue: Int = -100
     var lensedValue: Int = -100
 
-    handler(handlerValue = _)
-    lensed(lensedValue = _)
+    for {
+      handler <- Handler.create[Int].unsafeToFuture()
+       lensed = handler.transformObserver[Int](_.map(_ + 1))
+            _ = handler(handlerValue = _)
+            _ = lensed(lensedValue = _)
+            _ <- lensed.onNext(15)
+            _ <- lensedValue shouldBe 16
+            _ <- handlerValue shouldBe 16
+            _ <- handler.onNext(12)
+            _ <- lensedValue shouldBe 12
+            _ <- handlerValue shouldBe 12
 
-    lensed.onNext(15)
-    lensedValue shouldBe 16
-    handlerValue shouldBe 16
-
-    handler.onNext(12)
-    lensedValue shouldBe 12
-    handlerValue shouldBe 12
+    } yield succeed
   }
 
   it should "mapSubject" in {
-    val handler = Handler.create[Int].unsafeRunSync()
-    val lensed = handler.mapHandler(_ - 1)(_ + 1)
 
     var handlerValue: Int = -100
     var lensedValue: Int = -100
 
-    handler(handlerValue = _)
-    lensed(lensedValue = _)
+    for {
+      handler <- Handler.create[Int].unsafeToFuture()
+       lensed = handler.mapHandler(_ - 1)(_ + 1)
+            _ = handler(handlerValue = _)
+            _ = lensed(lensedValue = _)
+            _ <- lensed.onNext(15)
+            _ <- lensedValue shouldBe 15
+            _ <- handlerValue shouldBe 16
+            _ <- handler.onNext(12)
+            _ <- lensedValue shouldBe 11
+            _ <- handlerValue shouldBe 12
 
-    lensed.onNext(15)
-    lensedValue shouldBe 15
-    handlerValue shouldBe 16
-
-    handler.onNext(12)
-    lensedValue shouldBe 11
-    handlerValue shouldBe 12
+    } yield succeed
   }
 
   it should "transformSubject" in {
-    val handler = Handler.create[Int].unsafeRunSync()
-    val lensed = handler.transformHandler(_.map(_ - 1))(_.map(_ + 1))
 
     var handlerValue: Int = -100
     var lensedValue: Int = -100
 
-    handler(handlerValue = _)
-    lensed(lensedValue = _)
+    for {
+      handler <- Handler.create[Int].unsafeToFuture()
+       lensed = handler.transformHandler(_.map(_ - 1))(_.map(_ + 1))
+            _ = handler(handlerValue = _)
+            _ = lensed(lensedValue = _)
+            _ <- lensed.onNext(15)
+            _ <- lensedValue shouldBe 15
+            _ <- handlerValue shouldBe 16
+            _ <- handler.onNext(12)
+            _ <- lensedValue shouldBe 11
+            _ <- handlerValue shouldBe 12
 
-    lensed.onNext(15)
-    lensedValue shouldBe 15
-    handlerValue shouldBe 16
+    } yield succeed
 
-    handler.onNext(12)
-    lensedValue shouldBe 11
-    handlerValue shouldBe 12
   }
 }

--- a/src/test/scala/outwatch/OutwatchSpec.scala
+++ b/src/test/scala/outwatch/OutwatchSpec.scala
@@ -1,6 +1,8 @@
 package outwatch
 
-
+import scala.language.implicitConversions
+import scala.concurrent.Future
+import cats.effect.IO
 import monix.execution.Ack.Continue
 import monix.execution.ExecutionModel.SynchronousExecution
 import monix.execution.schedulers.TrampolineScheduler
@@ -8,8 +10,8 @@ import monix.execution.{Cancelable, Scheduler}
 import monix.reactive.Observable
 import org.scalajs.dom.{document, window}
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest._
 import outwatch.Deprecated.IgnoreWarnings.initEvent
-
 
 trait EasySubscribe {
 
@@ -64,9 +66,9 @@ trait LocalStorageMock {
   }
 }
 
-abstract class JSDomSpec extends FlatSpec with Matchers with BeforeAndAfterEach with EasySubscribe with LocalStorageMock {
+trait OutwatchSpec extends Matchers with BeforeAndAfterEach with EasySubscribe with LocalStorageMock { self: Suite =>
 
-  implicit val scheduler = TrampolineScheduler(Scheduler.global, SynchronousExecution)
+  implicit val scheduler: TrampolineScheduler = TrampolineScheduler(Scheduler.global, SynchronousExecution)
 
   override def beforeEach(): Unit = {
 
@@ -80,4 +82,10 @@ abstract class JSDomSpec extends FlatSpec with Matchers with BeforeAndAfterEach 
     document.body.appendChild(root)
     ()
   }
+
+}
+
+abstract class JSDomSpec extends FlatSpec with OutwatchSpec
+abstract class JSDomAsyncSpec extends AsyncFlatSpec with OutwatchSpec {
+  implicit def ioAssertionToFutureAssertion(io: IO[Assertion]): Future[Assertion] = io.unsafeToFuture()
 }

--- a/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -1,108 +1,147 @@
 package outwatch
 
+import scala.scalajs.js
 import org.scalajs.dom.{document, html}
 import outwatch.Deprecated.IgnoreWarnings.initEvent
+import outwatch.dom.OutWatch
+import outwatch.dom.dsl._
+import cats.effect.IO
 import snabbdom.{DataObject, hFunction, patch}
 
-import scala.scalajs.js
+class SnabbdomSpec extends JSDomAsyncSpec {
 
-class SnabbdomSpec extends JSDomSpec {
   "The Snabbdom Facade" should "correctly patch the DOM" in {
+
     val message = "Hello World"
-    val vNode = hFunction("span#msg", DataObject(js.Dictionary(), js.Dictionary()), message)
 
-    val node = document.createElement("div")
-    document.body.appendChild(node)
+    for {
 
-    patch(node, vNode)
+       vNode <- IO(hFunction("span#msg", DataObject(js.Dictionary(), js.Dictionary()), message))
 
-    document.getElementById("msg").innerHTML shouldBe message
+        node <- IO {
+                val node = document.createElement("div")
+                document.body.appendChild(node)
+                node
+              }
 
-    val newMessage = "Hello Snabbdom!"
-    val newNode = hFunction("div#new", DataObject(js.Dictionary(), js.Dictionary()), newMessage)
+            _ <- IO(patch(node, vNode))
+          msg <- IO(document.getElementById("msg").innerHTML)
+            _ = msg shouldBe message
+       newMsg = "Hello Snabbdom!"
+      newNode <- IO(hFunction("div#new", DataObject(js.Dictionary(), js.Dictionary()), newMsg))
+            _ <- IO(patch(vNode, newNode))
+         nMsg <- IO(document.getElementById("new").innerHTML)
+            _ = nMsg shouldBe newMsg
 
-    patch(vNode, newNode)
+    } yield succeed
 
-    document.getElementById("new").innerHTML shouldBe newMessage
   }
 
   it should "correctly patch nodes with keys" in {
-    import outwatch.dom._
-    import outwatch.dom.dsl._
-
-    val clicks = Handler.create[Int](1).unsafeRunSync()
-    val nodes = clicks.map { i =>
-      div(
-        attributes.key := s"key-$i",
-        span(onClick(if (i == 1) 2 else 1) --> clicks,  s"This is number $i", id := "btn"),
-        input(id := "input")
-      )
-    }
-
-    val node = document.createElement("div")
-    node.id = "app"
-    document.body.appendChild(node)
-
-    OutWatch.renderInto("#app", div(nodes)).unsafeRunSync()
-
-    val inputEvt = document.createEvent("HTMLEvents")
-    initEvent(inputEvt)("input", false, true)
-
-    val clickEvt = document.createEvent("Events")
-    initEvent(clickEvt)("click", true, true)
 
     def inputElement() = document.getElementById("input").asInstanceOf[html.Input]
-    val btn = document.getElementById("btn")
 
-    inputElement().value = "Something"
-    inputElement().dispatchEvent(inputEvt)
-    btn.dispatchEvent(clickEvt)
+    Handler.create[Int](1).flatMap { clicks =>
 
-    inputElement().value shouldBe ""
+      val nodes = clicks.map { i =>
+        div(
+          attributes.key := s"key-$i",
+          span(onClick(if (i == 1) 2 else 1) --> clicks, s"This is number $i", id := "btn"),
+          input(id := "input")
+        )
+      }
+
+      for {
+
+               _ <- IO {
+                   val node = document.createElement("div")
+                   node.id = "app"
+                   document.body.appendChild(node)
+                   node
+                 }
+
+               _ <- OutWatch.renderInto("#app", div(nodes))
+
+        inputEvt <- IO {
+                    val inputEvt = document.createEvent("HTMLEvents")
+                    initEvent(inputEvt)("input", canBubbleArg = false, cancelableArg = true)
+                    inputEvt
+                  }
+
+        clickEvt <- IO {
+                    val clickEvt = document.createEvent("Events")
+                    initEvent(clickEvt)("click", canBubbleArg = true, cancelableArg = true)
+                    clickEvt
+                  }
+
+             btn <- IO(document.getElementById("btn"))
+
+              ie <- IO {
+                    inputElement().value = "Something"
+                    inputElement().dispatchEvent(inputEvt)
+                    btn.dispatchEvent(clickEvt)
+                    inputElement().value
+                  }
+               _ = ie shouldBe ""
+
+      } yield succeed
+
+    }
   }
 
   it should "handle keys with nested observables" in {
     import outwatch.dom._
     import outwatch.dom.dsl._
 
-    val a = Handler.create[Int](0).unsafeRunSync()
-    val b = Handler.create[Int](100).unsafeRunSync()
+    def getContent =
+      IO(document.getElementById("content").innerHTML)
 
-    val vtree = div(
-      a.map { a =>
-        div(
-          id := "content",
-          dsl.key := "bla",
-          a,
-          b.map { b => div(id := "meh", b) }
-        )
-      }
-    )
+    for {
+      a <- outwatch.Handler.create[Int](0)
+      b <- outwatch.Handler.create[Int](100)
+      vtree = div(
+              a.map { a =>
+                div(
+                  id := "content",
+                  dsl.key := "bla",
+                  a,
+                  b.map { b => div(id := "meh", b) }
+                )
+              }
+            )
+          _ <- OutWatch.renderInto("#app", vtree)
+          c1 <- getContent
+           _ <- IO.fromFuture(IO(a.onNext(1)))
+          c2 <- getContent
+           _ <- IO.fromFuture(IO(b.onNext(200)))
+          c3 <- getContent
+    } yield {
+      c1 shouldBe """0<div id="meh">100</div>"""
+      c2 shouldBe """1<div id="meh">100</div>"""
+      c3 shouldBe """1<div id="meh">200</div>"""
+    }
 
-    OutWatch.renderInto("#app", vtree).unsafeRunSync()
-
-    def content = document.getElementById("content").innerHTML
-
-    content shouldBe """0<div id="meh">100</div>"""
-
-    a.onNext(1)
-    content shouldBe """1<div id="meh">100</div>"""
-
-    b.onNext(200)
-    content shouldBe """1<div id="meh">200</div>"""
   }
 
   it should "correctly handle boolean attributes" in {
-    val message = "Hello World"
+
+    val message    = "Hello World"
     val attributes = js.Dictionary[dom.Attr.Value]("bool1" -> true, "bool0" -> false, "string1" -> "true", "string0" -> "false")
-    val vNode = hFunction("span#msg", DataObject(attributes, js.Dictionary()), message)
+    val expected   = s"""<span id="msg" bool1="" string1="true" string0="false">$message</span>"""
 
-    val node = document.createElement("div")
-    document.body.appendChild(node)
+    for {
 
-    patch(node, vNode)
+      vNode <- IO(hFunction("span#msg", DataObject(attributes, js.Dictionary()), message))
+       node <- IO {
+                val node = document.createElement("div")
+                document.body.appendChild(node)
+                node
+              }
+          _ <- IO(patch(node, vNode))
+       html <- IO(document.getElementById("msg").outerHTML)
+          _ = html shouldBe expected
 
-    val expected = s"""<span id="msg" bool1="" string1="true" string0="false">$message</span>"""
-    document.getElementById("msg").outerHTML shouldBe expected
+    } yield succeed
+
   }
 }


### PR DESCRIPTION
 - add `AsyncFlatSpec` from scalatest and introduce
   two variants of `JSDomSpec`.

 - refactor tests that rely on `unsafeRunSync` to
   use `unsafeToFuture` from scalatest. Furthermore,
   there is an implicit conversion from `IO[Assertion]`
   to `Future[Assertion]` in `JSDomAsyncSpec` that reduces
   usage of `unsafeToFuture` boilerplate.