### PR TITLE
Update scala-dom-types to v0.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ crossScalaVersions := Seq("2.11.12", "2.12.6")
 libraryDependencies ++= Seq(
   "io.monix"        %%% "monix"       % "3.0.0-M3",
   "org.scala-js"    %%% "scalajs-dom" % "0.9.6",
-  "com.raquo"       %%% "domtypes" % "0.7",
+  "com.raquo"       %%% "domtypes" % "0.9",
   "org.typelevel" %%% "cats-core" % "1.1.0",
   "org.typelevel" %%% "cats-effect" % "0.10.1",
   "org.scalatest" %%% "scalatest" % "3.0.5" % Test

--- a/src/main/scala/outwatch/Handler.scala
+++ b/src/main/scala/outwatch/Handler.scala
@@ -1,7 +1,7 @@
 package outwatch
 
 import cats.effect.IO
-import monix.execution.{Ack, Cancelable, Scheduler}
+import monix.execution.{Ack, Cancelable}
 import monix.reactive.observers.Subscriber
 import monix.reactive.subjects.PublishSubject
 import monix.reactive.{Observable, Observer}

--- a/src/main/scala/outwatch/dom/dsl.scala
+++ b/src/main/scala/outwatch/dom/dsl.scala
@@ -7,8 +7,6 @@ object dsl extends Attributes with Tags with Styles {
   }
   object attributes extends Attributes {
     object attrs extends HtmlAttrs
-    object reflected extends ReflectedAttrs
-    object props extends Props
     object events extends Events
     object outwatch extends OutwatchAttributes
     object lifecycle extends OutWatchLifeCycleAttributes

--- a/src/test/scala/outwatch/AttributeSpec.scala
+++ b/src/test/scala/outwatch/AttributeSpec.scala
@@ -79,7 +79,7 @@ class AttributeSpec extends JSDomSpec {
       prop("num") := 12,
       style("baz") := "baz",
       contentEditable := false,
-      autoComplete := false,
+      unselectable := false,
       disabled := false
     ).map(_.toSnabbdom).unsafeRunSync()
 
@@ -88,7 +88,7 @@ class AttributeSpec extends JSDomSpec {
       "boo" -> true,
       "yoo" -> "yes",
       "contenteditable" -> "false",
-      "autocomplete" -> "off",
+      "unselectable" -> "off",
       "disabled" -> false
     )
     node.data.props.toList should contain theSameElementsAs List(


### PR DESCRIPTION
The update introduces a new API which makes it impossible for now to separate attributes and reflected attributes. Our `Dsl` supported this with `outwatch.dom.dsl.attributes.attrs._`,  `outwatch.dom.dsl.attributes.reflected._` and  `outwatch.dom.dsl.attributes.props._`. I have now changed this to have `outwatch.dom.dsl.attributes.attrs._` contain all three (attributes, reflected attributes, properties). I think, this should be fine because I do not really see the use-case for such fine-granular import separation.