### PR TITLE
downgrade cats-effect back to 0.10.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   "org.scala-js"    %%% "scalajs-dom" % "0.9.6",
   "com.raquo"       %%% "domtypes" % "0.9",
   "org.typelevel" %%% "cats-core" % "1.4.0",
-  "org.typelevel" %%% "cats-effect" % "1.0.0",
+  "org.typelevel" %%% "cats-effect" % "0.10.1",
   "org.scalatest" %%% "scalatest" % "3.0.5" % Test
 )
 


### PR DESCRIPTION
Fixes an incompatibility between cats-effect `1.0.0` and monix `3.0-RC1`, as reported by @ahjohannessen via gitter. We need to wait for monix `RC2` to upgrade.