### PR TITLE
upgrade deps: upgrade monix / cats-effect etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk:
   - oraclejdk8
 scala:
    - 2.11.12
-   - 2.12.6
+   - 2.12.7
 node_js: 9
 
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -8,17 +8,17 @@ version := "0.11.1-SNAPSHOT"
 
 organization := "io.github.outwatch"
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.7"
 
-crossScalaVersions := Seq("2.11.12", "2.12.6")
+crossScalaVersions := Seq("2.11.12", "2.12.7")
 
 
 libraryDependencies ++= Seq(
-  "io.monix"        %%% "monix"       % "3.0.0-RC1",
+  "io.monix"        %%% "monix"       % "3.0.0-RC2-c84f485",
   "org.scala-js"    %%% "scalajs-dom" % "0.9.6",
   "com.raquo"       %%% "domtypes" % "0.9",
   "org.typelevel" %%% "cats-core" % "1.4.0",
-  "org.typelevel" %%% "cats-effect" % "0.10.1",
+  "org.typelevel" %%% "cats-effect" % "1.0.0",
   "org.scalatest" %%% "scalatest" % "3.0.5" % Test
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.4
+sbt.version = 1.2.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.13.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")

--- a/src/main/scala/outwatch/util/LocalStorage.scala
+++ b/src/main/scala/outwatch/util/LocalStorage.scala
@@ -52,7 +52,7 @@ class Storage(domStorage: dom.Storage) {
 
   def handler(key: String)(implicit scheduler: Scheduler): IO[Handler[Option[String]]] = {
     val storageEvents = storageEventsForKey(key)
-    subjectWithTransform(key, Observable.merge(_, storageEvents))
+    subjectWithTransform(key, Observable(_, storageEvents).merge)
   }
 }
 

--- a/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -22,7 +22,7 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
       handleMinus <- Handler.create[MouseEvent]
           plusOne = handlePlus.map(_ => 1)
          minusOne = handleMinus.map(_ => -1)
-            count = Observable.merge(plusOne, minusOne).scan(0)(_ + _).startWith(Seq(0))
+            count = Observable(plusOne, minusOne).merge.scan(0)(_ + _).startWith(Seq(0))
 
              node = div(div(
                         button(id := "plus", "+", onClick --> handlePlus),
@@ -222,7 +222,7 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
       enterPressed = keyStream
         .filter(_.key == "Enter")
 
-      confirm = Observable.merge(enterPressed, clickStream)
+      confirm = Observable(enterPressed, clickStream).merge
         .withLatestFrom(textFieldStream)((_, input) => input)
 
       div <- div(
@@ -253,7 +253,7 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
       deletes = deleteHandler
         .map(removeFromList)
 
-      state = Observable.merge(adds, deletes)
+      state = Observable(adds, deletes).merge
         .scan(Vector[String]())((state, modify) => modify(state))
         .map(_.map(n => TodoComponent(n, deleteHandler)))
       textFieldComponent = TextFieldComponent("Todo: ", inputHandler)


### PR DESCRIPTION
 - upgrade monix to cats-effect 1.0.0 compatible version
   and fix deprecated usage of `concat` and `merge` in
   monix 3.

 - fix tests in `LifecycleHookSpec` that broke as a result
   moving from monix RC1 to RC2. It is seems related to some
   acynchronicity issue wrt. future usage. Alexandru from
   monix said that there have been changes in
   `TrampolineExecutionContext` that might have introduced a
   bug.

   Moreover, `onNext` can be synchronous if the listeners are
   synchronous — this is an implementation detail and is not
   guaranteed.

 - bump scala / scalajs