### PR TITLE
[WIP] Let Handler/ProHandler be a ValueObservable

### DIFF
--- a/outwatch/src/main/scala/outwatch/Handler.scala
+++ b/outwatch/src/main/scala/outwatch/Handler.scala
@@ -16,8 +16,14 @@ object Handler {
   @inline def create[T]:IO[Handler[T]] = IO(unsafe[T])
   @inline def create[T](seed:T):IO[Handler[T]] = IO(unsafe[T](seed))
 
+  @inline def createDistinct[T](implicit e: cats.Eq[T]):IO[Handler[T]] = IO(unsafeDistinct)
+  @inline def createDistinct[T](seed:T)(implicit e: cats.Eq[T]):IO[Handler[T]] = IO(unsafeDistinct(seed))
+
   def unsafe[T]:Handler[T] = new BehaviorProHandler[T](None)
   def unsafe[T](seed:T):Handler[T] = new BehaviorProHandler[T](Some(seed))
+
+  def unsafeDistinct[T](implicit e: cats.Eq[T]):Handler[T] = new BehaviorProHandler[T](None).transformObservable(_.distinctUntilChanged)
+  def unsafeDistinct[T](seed:T)(implicit e: cats.Eq[T]):Handler[T] = new BehaviorProHandler[T](Some(seed)).transformObservable(_.distinctUntilChanged)
 
   @inline def apply[T,F[_]: AsValueObservable : AsObserver](handler: F[T]): Handler[T] = ProHandler(AsObserver(handler), ValueObservable.from(handler))
 }

--- a/outwatch/src/main/scala/outwatch/Handler.scala
+++ b/outwatch/src/main/scala/outwatch/Handler.scala
@@ -5,35 +5,45 @@ import monix.execution.{Ack, Cancelable, Scheduler}
 import monix.reactive.observers.Subscriber
 import monix.reactive.subjects.{BehaviorSubject, ReplaySubject}
 import monix.reactive.{Observable, Observer}
+import outwatch.dom.helpers.BehaviorProHandler
+import outwatch.dom.{AsObserver, AsValueObservable, ObservableWithInitialValue, ValueObservable}
 
 import scala.concurrent.Future
 
 object Handler {
-  def empty[T]:IO[Handler[T]] = create[T]
+  @inline def empty[T]:IO[Handler[T]] = create[T]
 
-  def create[T]:IO[Handler[T]] = IO(unsafe[T])
-  def create[T](seed:T):IO[Handler[T]] = IO(unsafe[T](seed))
+  @inline def create[T]:IO[Handler[T]] = IO(unsafe[T])
+  @inline def create[T](seed:T):IO[Handler[T]] = IO(unsafe[T](seed))
 
-  def unsafe[T]:Handler[T] = ReplaySubject.createLimited(1)
-  def unsafe[T](seed:T):Handler[T] = BehaviorSubject[T](seed)
+  def unsafe[T]:Handler[T] = new BehaviorProHandler[T](None)
+  def unsafe[T](seed:T):Handler[T] = new BehaviorProHandler[T](Some(seed))
+
+  @inline def apply[T,F[_]: AsValueObservable : AsObserver](handler: F[T]): Handler[T] = ProHandler(AsObserver(handler), ValueObservable.from(handler))
 }
 
 object ProHandler {
+  def create[I,O](seed: I, f: I => O): IO[ProHandler[I,O]] = for {
+    handler <- Handler.create[I](seed)
+  } yield handler.mapObservable[O](f)
+
   def create[I,O](f: I => O): IO[ProHandler[I,O]] = for {
     handler <- Handler.create[I]
   } yield handler.mapObservable[O](f)
 
-  def apply[I,O](observer:Observer[I], observable: Observable[O]):ProHandler[I,O] = new Observable[O] with Observer[I] {
+  @inline def apply[I,O,F[_]: AsValueObservable](observer:Observer[I], observable: F[O]):ProHandler[I,O] = apply(observer, ValueObservable.from(observable))
+  def apply[I,O](observer:Observer[I], valueObservable: ValueObservable[O]):ProHandler[I,O] = new ValueObservable[O] with Observer[I] {
     override def onNext(elem: I): Future[Ack] = observer.onNext(elem)
     override def onError(ex: Throwable): Unit = observer.onError(ex)
     override def onComplete(): Unit = observer.onComplete()
-    override def unsafeSubscribeFn(subscriber: Subscriber[O]): Cancelable = observable.unsafeSubscribeFn(subscriber)
+    override def value(): ObservableWithInitialValue[O] = valueObservable.value()
   }
-  def connectable[I,O](observer: Observer[I] with ReactiveConnectable, observable: Observable[O]):ProHandler[I,O] with ReactiveConnectable = new Observable[O] with Observer[I] with ReactiveConnectable {
+  @inline def connectable[I,O,F[_]: AsValueObservable](observer:Observer[I] with ReactiveConnectable, observable: F[O]):ProHandler[I,O] with ReactiveConnectable = connectable(observer, ValueObservable.from(observable))
+  def connectable[I,O](observer: Observer[I] with ReactiveConnectable, valueObservable: ValueObservable[O]):ProHandler[I,O] with ReactiveConnectable = new ValueObservable[O] with Observer[I] with ReactiveConnectable {
     override def onNext(elem: I): Future[Ack] = observer.onNext(elem)
     override def onError(ex: Throwable): Unit = observer.onError(ex)
     override def onComplete(): Unit = observer.onComplete()
     override def connect()(implicit scheduler: Scheduler): Cancelable = observer.connect()
-    override def unsafeSubscribeFn(subscriber: Subscriber[O]): Cancelable = observable.unsafeSubscribeFn(subscriber)
+    override def value(): ObservableWithInitialValue[O] = valueObservable.value()
   }
 }

--- a/outwatch/src/main/scala/outwatch/MonixOps.scala
+++ b/outwatch/src/main/scala/outwatch/MonixOps.scala
@@ -3,12 +3,13 @@ package outwatch
 import cats.effect.IO
 import monix.execution.{Ack, Cancelable, Scheduler}
 import monix.reactive.subjects.PublishSubject
-import monix.reactive.{Observable, Observer}
+import monix.reactive.{Observable, Observer, OverflowStrategy}
+import outwatch.dom.ValueObservable
 
 import scala.concurrent.Future
 
 trait MonixOps {
-  type ProHandler[-I, +O] = Observable[O] with Observer[I]
+  type ProHandler[-I, +O] = ValueObservable[O] with Observer[I]
   type Handler[T] = ProHandler[T,T]
 
   @deprecated("use monix.reactive.Observer instead", "")
@@ -60,18 +61,17 @@ trait MonixOps {
     def filterObserver(f: I => Boolean): ProHandler[I, O] = ProHandler(self.redirectFilter(f), self)
     def filterProHandler(write: I => Boolean)(read: O => Boolean): ProHandler[I, O] = ProHandler(self.redirectFilter(write), self.filter(read))
 
-    def transformObservable[O2](f: Observable[O] => Observable[O2]): ProHandler[I,O2] = ProHandler(self, f(self))
+    def transformObservable[O2](f: ValueObservable[O] => ValueObservable[O2]): ProHandler[I,O2] = ProHandler(self, f(self))
     def transformObserver[I2](f: Observable[I2] => Observable[I]): ProHandler[I2,O] with ReactiveConnectable = ProHandler.connectable(self.redirect(f), self)
-    def transformProHandler[I2, O2](write: Observable[I2] => Observable[I])(read: Observable[O] => Observable[O2]): ProHandler[I2,O2] with ReactiveConnectable = ProHandler.connectable(self.redirect(write), read(self))
+    def transformProHandler[I2, O2](write: Observable[I2] => Observable[I])(read: ValueObservable[O] => ValueObservable[O2]): ProHandler[I2,O2] with ReactiveConnectable = ProHandler.connectable(self.redirect(write), read(self))
 
     @deprecated("A Handler is already an Observer", "")
     def observer:Observer[I] = self
   }
 
   implicit class RichHandler[T](self: Handler[T]) {
-    def lens[S](seed: T)(read: T => S)(write: (T, S) => T)(implicit scheduler: Scheduler): Handler[S] with ReactiveConnectable = {
-      val redirected = self
-        .redirect[S](_.withLatestFrom(self.startWith(Seq(seed))){ case (a, b) => write(b, a) })
+    def lens[S](seed: T)(read: T => S)(write: (T, S) => T): Handler[S] with ReactiveConnectable = {
+      val redirected = self.redirect[S](_.withLatestFrom(self.startWith(seed :: Nil).observable){ case (a, b) => write(b, a) })
 
       ProHandler.connectable(redirected, self.map(read))
     }
@@ -79,8 +79,7 @@ trait MonixOps {
     def mapHandler[T2](write: T2 => T)(read: T => T2): Handler[T2] = ProHandler(self.redirectMap(write), self.map(read))
     def collectHandler[T2](write: PartialFunction[T2, T])(read: PartialFunction[T, T2]): Handler[T2] = ProHandler(self.redirectCollect(write), self.collect(read))
     def filterHandler(write: T => Boolean)(read: T => Boolean): Handler[T] = ProHandler(self.redirectFilter(write), self.filter(read))
-    def transformHandler[T2](write: Observable[T2] => Observable[T])(read: Observable[T] => Observable[T2]): Handler[T2] with ReactiveConnectable = ProHandler.connectable(self.redirect(write), read(self))
+    def transformHandler[T2](write: Observable[T2] => Observable[T])(read: ValueObservable[T] => ValueObservable[T2]): Handler[T2] with ReactiveConnectable = ProHandler.connectable(self.redirect(write), read(self))
   }
-
 }
 

--- a/outwatch/src/main/scala/outwatch/dom/AsObserver.scala
+++ b/outwatch/src/main/scala/outwatch/dom/AsObserver.scala
@@ -9,11 +9,17 @@ trait AsObserver[-F[_]] {
 }
 
 object AsObserver {
+  @inline def apply[T, F[_]](obs: F[T])(implicit asObserver: AsObserver[F]): Observer[T] = asObserver.as(obs)
+
   implicit object variable extends AsObserver[Var] {
     def as[T](stream: Var[_ >: T]): Observer[T] = new Observer.Sync[T] {
       override def onNext(elem: T): Ack = stream := elem
       override def onError(ex: Throwable): Unit = throw ex
       override def onComplete(): Unit = ()
     }
+  }
+
+  implicit object observer extends AsObserver[Observer] {
+    @inline def as[T](stream: Observer[_ >: T]): Observer[T] = stream
   }
 }

--- a/outwatch/src/main/scala/outwatch/dom/AsValueObservable.scala
+++ b/outwatch/src/main/scala/outwatch/dom/AsValueObservable.scala
@@ -1,5 +1,6 @@
 package outwatch.dom
 
+import monix.execution.Scheduler
 import monix.reactive.Observable
 import monix.reactive.subjects.Var
 
@@ -9,10 +10,7 @@ trait AsValueObservable[-F[_]] {
 
 trait AsValueObservableInstances0 {
   implicit object observable extends AsValueObservable[Observable] {
-    def as[T](stream: Observable[T]): ValueObservable[T] = new ValueObservable[T] {
-      def observable: Observable[T] = stream
-      def value: Option[T] = None
-    }
+    @inline def as[T](stream: Observable[T]): ValueObservable[T] = ValueObservable.from(stream)
   }
 }
 
@@ -22,10 +20,7 @@ object AsValueObservable extends AsValueObservableInstances0  {
   }
 
   implicit object variable extends AsValueObservable[Var] {
-    def as[T](stream: Var[T]): ValueObservable[T] = new ValueObservable[T] {
-      def observable: Observable[T] = stream.drop(1)
-      def value: Option[T] = Some(stream.apply())
-    }
+    @inline def as[T](stream: Var[T]): ValueObservable[T] = ValueObservable.from(stream)
   }
 }
 

--- a/outwatch/src/main/scala/outwatch/dom/OutwatchAttributes.scala
+++ b/outwatch/src/main/scala/outwatch/dom/OutwatchAttributes.scala
@@ -89,6 +89,7 @@ trait AttributeHelpers { self: Attributes =>
   @inline def style[T](key: String) = new BasicStyleBuilder[T](key)
 
   @inline def emitter[E](observable: Observable[E]): EmitterBuilder[E, VDomModifier] = EmitterBuilder.fromObservable(observable)
+  @inline def emitter[E](valueObservable: ValueObservable[E]): EmitterBuilder[E, VDomModifier] = EmitterBuilder.fromObservable(valueObservable.observable)
 }
 
 trait TagHelpers { self: Tags =>

--- a/outwatch/src/main/scala/outwatch/dom/ValueObservable.scala
+++ b/outwatch/src/main/scala/outwatch/dom/ValueObservable.scala
@@ -1,31 +1,226 @@
 package outwatch.dom
 
-import cats.Functor
-import monix.reactive.Observable
+import cats.Monad
+import monix.eval.Task
+import monix.execution.{Ack, Cancelable, CancelableFuture, Scheduler}
+import monix.reactive.observers.Subscriber
+import monix.reactive.subjects.Var
+import monix.reactive.{Observable, ObservableLike, Observer, OverflowStrategy}
+
+import scala.concurrent.Future
 
 trait ValueObservable[+T] { self =>
-  def observable: Observable[T]
-  def value: Option[T]
-  def map[B](f: T => B): ValueObservable[B] = new ValueObservable[B] {
-    def observable: Observable[B] = self.observable.map(f)
-    def value: Option[B] = self.value.map(f)
+
+  def value(): ObservableWithInitialValue[T]
+
+  final val observable: Observable[T] = (subscriber: Subscriber[T]) => self.value().observable.unsafeSubscribeFn(subscriber)
+
+  @inline final def transformHead[B >: T](f: Option[T] => Option[B]): ValueObservable[B] = transform[B](f, identity)
+  @inline final def transformTail[B >: T](f: Observable[T] => Observable[B]): ValueObservable[B] = transform[B](identity, f)
+  @inline final def transformWith[B](f: ObservableWithInitialValue[T] => ObservableWithInitialValue[B]): ValueObservable[B] = () => f(self.value())
+  @inline final def transform[B](transformHead: Option[T] => Option[B], transformTail: Observable[T] => Observable[B]): ValueObservable[B] = transformWith { v =>
+    ObservableWithInitialValue(transformHead(v.head), transformTail(v.tail))
   }
+
+  final def memoizeValue: ValueObservable[T] = new ValueObservable[T] {
+    private var cached: Observable[T] = null
+    override def value(): ObservableWithInitialValue[T] = {
+      if (cached == null) {
+        val v = self.value()
+        cached = v.tail
+        v
+      } else ObservableWithInitialValue(None, cached)
+    }
+  }
+
+  // the following methods are convenience methods that mimick that API of Observable on a ValueObservable
+
+  final def map[B](f: T => B): ValueObservable[B] = transformWith { v =>
+    ObservableWithInitialValue(v.head.map(f), v.tail.map(f))
+  }
+
+  final def scan[S](seed: => S)(op: (S, T) => S): ValueObservable[S] = transformWith { v =>
+    val mappedHeadValue = v.head.map(op(seed, _))
+    ObservableWithInitialValue(mappedHeadValue, v.tail.scan[S](mappedHeadValue.getOrElse(seed))(op))
+  }
+
+  final def collect[B](f: PartialFunction[T, B]): ValueObservable[B] = transform[B](_.collect(f), _.collect(f))
+  final def filter(f: T => Boolean): ValueObservable[T] = transform[T](_.filter(f), _.filter(f))
+
+  @inline final def +:[B >: T](elem: B): ValueObservable[B] = prepend(elem)
+  final def prepend[B >: T](elem: B): ValueObservable[B] = ValueObservable.from(observable, elem)
+
+  @inline final def :+[B >: T](elem: B): ValueObservable[B] = append(elem)
+  final def append[B >: T](elem: B): ValueObservable[B] = transformTail[B](_.append(elem))
+
+  final def startWith[B >: T](elems: Seq[B]): ValueObservable[B] = {
+    if (elems.isEmpty) this
+    else if (elems.size == 1) ValueObservable.from(observable, elems.head)
+    else ValueObservable.from(observable.startWith(elems.tail), elems.head)
+  }
+
+  final def distinctUntilChanged[TT >: T](implicit e: cats.Eq[TT]): ValueObservable[TT] = transformWith { v =>
+    v.copy(tail = v.observable.distinctUntilChanged[TT].tail)
+  }
+
+  final def distinctUntilChangedByKey[K](key: T => K)(implicit e: cats.Eq[K]): ValueObservable[T] = transformWith { v =>
+    v.copy(tail = v.observable.distinctUntilChangedByKey[K](key).tail)
+  }
+
+  @inline final def merge[B](implicit ev: T <:< ValueObservable[B], os: OverflowStrategy[B] = OverflowStrategy.Default): ValueObservable[B] = mergeMap[B](x => x)
+  final def mergeMap[B](f: T => ValueObservable[B])(implicit os: OverflowStrategy[B] = OverflowStrategy.Default): ValueObservable[B] = transformWith { v =>
+    v.head.fold(ObservableWithInitialValue(None, v.tail.mergeMap(v => f(v).observable))) { value =>
+      val headV = f(value).value()
+      headV.copy(tail = v.tail.map(v => f(v).observable).prepend(headV.tail).merge)
+    }
+  }
+
+  @inline final def flatten[B](implicit ev: T <:< ValueObservable[B]): ValueObservable[B] = concat
+  @inline final def concat[B](implicit ev: T <:< ValueObservable[B]): ValueObservable[B] = concatMap[B](x => x)
+  @inline final def flatMap[B](f: T => ValueObservable[B]): ValueObservable[B] = concatMap(f)
+  final def concatMap[B](f: T => ValueObservable[B]): ValueObservable[B] = transformWith { v =>
+    v.head.fold(ObservableWithInitialValue(None, v.tail.concatMap(v => f(v).observable))) { value =>
+      val headV = f(value).value()
+      headV.copy(tail = v.tail.map(v => f(v).observable).prepend(headV.tail).concat)
+    }
+  }
+
+  @inline final def switch[B](implicit ev: T <:< ValueObservable[B]): ValueObservable[B] = switchMap[B](x => x)
+  final def switchMap[B](f: T => ValueObservable[B]): ValueObservable[B] = transformWith { v =>
+    v.head.fold(ObservableWithInitialValue(None, v.tail.switchMap(v => f(v).observable))) { value =>
+      val headV = f(value).value()
+      headV.copy(tail = v.tail.map(v => f(v).observable).prepend(headV.tail).switch)
+    }
+  }
+
+  final def switchIfEmpty[B >: T](backup: Observable[B]): ValueObservable[B] = transformWith { v =>
+    val newTail = if (v.head.isEmpty) v.tail.switchIfEmpty[B](backup) else v.tail
+    ObservableWithInitialValue(v.head, newTail)
+  }
+
+  @inline def combineLatest[B](other: ValueObservable[B]): ValueObservable[(T, B)] = combineLatestMap(other)(_ -> _)
+  final def combineLatestMap[B, R](other: ValueObservable[B])(f: (T, B) => R): ValueObservable[R] = transformWith { v0 =>
+    val v1 = other.value()
+    val head = for {v0 <- v0.head; v1 <- v1.head } yield f(v0, v1)
+    val tail = v0.observable.combineLatest(v1.observable)
+    val tailWithoutHead = if (head.isEmpty) tail else tail.tail
+    ObservableWithInitialValue(head, tailWithoutHead.map[R](f.tupled))
+  }
+
+  final def withLatestFrom[B, R](o1: ValueObservable[B])(f: (T, B) => R): ValueObservable[R] = transformWith { v0 =>
+    val v1 = o1.value()
+    val head = for {v0 <- v0.head; v1 <- v1.head } yield f(v0, v1)
+    val tail = v0.tail.withLatestFrom(v1.observable)(f)
+    ObservableWithInitialValue(head, tail)
+  }
+  final def withLatestFrom2[B1, B2, R](o1: ValueObservable[B1], o2: ValueObservable[B2])(f: (T, B1, B2) => R): ValueObservable[R] = transformWith { v0 =>
+    val v1 = o1.value()
+    val v2 = o2.value()
+    val head = for {v0 <- v0.head; v1 <- v1.head; v2 <- v2.head } yield f(v0, v1, v2)
+    val tail = v0.tail.withLatestFrom2(v1.observable, v2.observable)(f)
+    ObservableWithInitialValue(head, tail)
+  }
+  final def withLatestFrom3[B1, B2, B3, R](o1: ValueObservable[B1], o2: ValueObservable[B2], o3: ValueObservable[B3])(f: (T, B1, B2, B3) => R): ValueObservable[R] = transformWith { v0 =>
+    val v1 = o1.value()
+    val v2 = o2.value()
+    val v3 = o3.value()
+    val head = for {v0 <- v0.head; v1 <- v1.head; v2 <- v2.head; v3 <- v3.head } yield f(v0, v1, v2, v3)
+    val tail = v0.tail.withLatestFrom3(v1.observable, v2.observable, v3.observable)(f)
+    ObservableWithInitialValue(head, tail)
+  }
+  final def withLatestFrom4[B1, B2, B3, B4, R](o1: ValueObservable[B1], o2: ValueObservable[B2], o3: ValueObservable[B3], o4: ValueObservable[B4])(f: (T, B1, B2, B3, B4) => R): ValueObservable[R] = transformWith { v0 =>
+    val v1 = o1.value()
+    val v2 = o2.value()
+    val v3 = o3.value()
+    val v4 = o4.value()
+    val head = for {v0 <- v0.head; v1 <- v1.head; v2 <- v2.head; v3 <- v3.head; v4 <- v4.head } yield f(v0, v1, v2, v3, v4)
+    val tail = v0.tail.withLatestFrom4(v1.observable, v2.observable, v3.observable, v4.observable)(f)
+    ObservableWithInitialValue(head, tail)
+  }
+  final def withLatestFrom5[B1, B2, B3, B4, B5, R](o1: ValueObservable[B1], o2: ValueObservable[B2], o3: ValueObservable[B3], o4: ValueObservable[B4], o5: ValueObservable[B5])(f: (T, B1, B2, B3, B4, B5) => R): ValueObservable[R] = transformWith { v0 =>
+    val v1 = o1.value()
+    val v2 = o2.value()
+    val v3 = o3.value()
+    val v4 = o4.value()
+    val v5 = o5.value()
+    val head = for {v0 <- v0.head; v1 <- v1.head; v2 <- v2.head; v3 <- v3.head; v4 <- v4.head; v5 <- v5.head } yield f(v0, v1, v2, v3, v4, v5)
+    val tail = v0.tail.withLatestFrom5(v1.observable, v2.observable, v3.observable, v4.observable, v5.observable)(f)
+    ObservableWithInitialValue(head, tail)
+  }
+  final def withLatestFrom6[B1, B2, B3, B4, B5, B6, R](o1: ValueObservable[B1], o2: ValueObservable[B2], o3: ValueObservable[B3], o4: ValueObservable[B4], o5: ValueObservable[B5], o6: ValueObservable[B6])(f: (T, B1, B2, B3, B4, B5, B6) => R): ValueObservable[R] = transformWith { v0 =>
+    val v1 = o1.value()
+    val v2 = o2.value()
+    val v3 = o3.value()
+    val v4 = o4.value()
+    val v5 = o5.value()
+    val v6 = o6.value()
+    val head = for {v0 <- v0.head; v1 <- v1.head; v2 <- v2.head; v3 <- v3.head; v4 <- v4.head; v5 <- v5.head; v6 <- v6.head } yield f(v0, v1, v2, v3, v4, v5, v6)
+    val tail = v0.tail.withLatestFrom6(v1.observable, v2.observable, v3.observable, v4.observable, v5.observable, v6.observable)(f)
+    ObservableWithInitialValue(head, tail)
+  }
+
+  @inline final def foreach(cb: T => Unit)(implicit s: Scheduler): CancelableFuture[Unit] = observable.foreach(cb)
+  @inline final def foreachL(cb: T => Unit): Task[Unit] = observable.foreachL(cb)
+  @inline final def subscribe(observer: Observer[T])(implicit s: Scheduler): Cancelable = observable.subscribe(observer)
+  @inline final def subscribe(subscriber: Subscriber[T]): Cancelable = observable.subscribe(subscriber)
+  @inline final def subscribe()(implicit s: Scheduler): Cancelable = observable.subscribe()
+  @inline final def subscribe(nextFn: T => Future[Ack])(implicit s: Scheduler): Cancelable = observable.subscribe(nextFn)
+  @inline final def subscribe(nextFn: T => Future[Ack], errorFn: Throwable => Unit)(implicit s: Scheduler): Cancelable = observable.subscribe(nextFn, errorFn)
+  @inline final def subscribe(nextFn: T => Future[Ack], errorFn: Throwable => Unit, completedFn: () => Unit)(implicit s: Scheduler): Cancelable = observable.subscribe(nextFn, errorFn, completedFn)
+  @inline final def subscribeOn(scheduler: Scheduler): Observable[T] = observable.subscribeOn(scheduler)
+
+  final def takeUntil(trigger: Observable[Any]): ValueObservable[T] = transformTail(_.takeUntil(trigger))
+  final def takeWhile(p: T => Boolean): ValueObservable[T] = transformWith { v =>
+    v.head.fold(ObservableWithInitialValue(None, v.tail.takeWhile(p))) { value =>
+      if (p(value)) ObservableWithInitialValue(Some(value), v.tail.takeWhile(p))
+      else ObservableWithInitialValue(None, Observable.empty)
+    }
+  }
+
+  final def take(n: Long): ValueObservable[T] = if (n <= 0) ValueObservable.empty else transformWith { v =>
+    val tailN = if (v.head.isEmpty) n else n - 1
+    ObservableWithInitialValue(v.head, v.tail.take(tailN))
+  }
+
+  final def doOnNext(cb: T => Task[Unit]): ValueObservable[T] = transformTail(_.doOnNext(cb))
+  final def doOnError(cb: Throwable => Task[Unit]): ValueObservable[T] = transformTail(_.doOnError(cb))
+  final def doOnComplete(cb: Task[Unit]): ValueObservable[T] = transformTail(_.doOnComplete(cb))
+  final def doOnSubscribe(cb: Task[Unit]): ValueObservable[T] = transformTail(_.doOnSubscribe(cb))
+  final def doOnEarlyStop(cb: Task[Unit]): ValueObservable[T] = transformTail(_.doOnEarlyStop(cb))
+  final def doOnStart(cb: T => Task[Unit]): ValueObservable[T] = transformTail(_.doOnStart(cb))
+  final def doNextAck(cb: (T, Ack) => Task[Unit]): ValueObservable[T] = transformTail(_.doOnNextAck(cb))
+  final def doOnSubscriptionCancel(cb: Task[Unit]): ValueObservable[T] = transformTail(_.doOnSubscriptionCancel(cb))
+
+  final def share(implicit s: Scheduler): ValueObservable[T] = transformTail(_.share).memoizeValue
 }
 
 object ValueObservable {
-  implicit def functor: Functor[ValueObservable] = new Functor[ValueObservable] {
-    override def map[A, B](fa: ValueObservable[A])(f: A => B): ValueObservable[B] = fa.map(f)
+  implicit object monad extends Monad[ValueObservable] {
+    @inline override def map[A, B](fa: ValueObservable[A])(f: A => B): ValueObservable[B] = fa.map(f)
+    @inline override def pure[A](x: A): ValueObservable[A] = ValueObservable[A](x)
+    @inline override def flatMap[A, B](fa: ValueObservable[A])(f: A => ValueObservable[B]): ValueObservable[B] = fa.flatMap(f)
+    override def tailRecM[A, B](a: A)(f: A => ValueObservable[Either[A, B]]): ValueObservable[B] = f(a).flatMap {
+      case Left(a) => tailRecM(a)(f)
+      case Right(b) => ValueObservable(b)
+    }
   }
 
-  def apply[T](stream: Observable[T]): ValueObservable[T] = new ValueObservable[T] {
-    override def observable: Observable[T] = stream
-    override def value: Option[T] = None
+  implicit object observableLike extends ObservableLike[ValueObservable] {
+    @inline override def toObservable[A](fa: ValueObservable[A]): Observable[A] = fa.observable
   }
 
-  def apply[T](stream: Observable[T], initialValue: T): ValueObservable[T] = new ValueObservable[T] {
-    override def observable: Observable[T] = stream
-    override def value: Option[T] = Some(initialValue)
-  }
+  @inline def empty: ValueObservable[Nothing] = apply()
+  @inline def apply[T](): ValueObservable[T] = from[T](Observable.empty)
+  @inline def apply[T](initialValue: T): ValueObservable[T] = from[T](Observable.empty, initialValue)
+  @inline def apply[T](initialValue: T, value: T, values: T*): ValueObservable[T] = from[T](Observable.fromIterable(value :: values.toList), initialValue)
+  @inline def from[T](stream: Observable[T]): ValueObservable[T] = fromOption(stream, None)
+  @inline def from[T](stream: Observable[T], initialValue: T): ValueObservable[T] = fromOption(stream, Some(initialValue))
+  def fromOption[T](stream: Observable[T], initialValue: Option[T]): ValueObservable[T] = () => ObservableWithInitialValue(initialValue, stream)
+  def from[T](stream: Var[T]): ValueObservable[T] = () => ObservableWithInitialValue(Some(stream.apply()), stream.drop(1))
 
-  @inline def apply[F[_], T](stream: F[T])(implicit asValueObservable: AsValueObservable[F]): ValueObservable[T] = asValueObservable.as(stream)
+  @inline def from[F[_], T](stream: F[T])(implicit asValueObservable: AsValueObservable[F]): ValueObservable[T] = asValueObservable.as(stream)
+}
+
+final case class ObservableWithInitialValue[+T](head: Option[T], tail: Observable[T]) {
+  def observable: Observable[T] = head.fold(tail)(tail.prepend)
 }

--- a/outwatch/src/main/scala/outwatch/dom/helpers/BehaviorProHandler.scala
+++ b/outwatch/src/main/scala/outwatch/dom/helpers/BehaviorProHandler.scala
@@ -1,0 +1,113 @@
+package outwatch.dom.helpers
+
+import monix.execution.Ack.Stop
+import monix.execution.{Ack, Cancelable}
+import monix.reactive.observers.Subscriber
+import monix.reactive.{Observable, Observer}
+import outwatch.dom.{ObservableWithInitialValue, ValueObservable}
+
+import scala.collection.mutable
+import scala.concurrent.{Future, Promise}
+import scala.util.Success
+import scala.util.control.NonFatal
+
+private[outwatch] final class BehaviorProHandler[A](initialValue: Option[A]) extends ValueObservable[A] with Observer[A] { self =>
+
+  private var cached: Option[A] = initialValue
+  private val subscribers: mutable.Set[Subscriber[A]] = new mutable.HashSet
+  private var isDone: Boolean = false
+  private var errorThrown: Throwable = null
+
+  private val tailObservable: Observable[A] = (subscriber: Subscriber[A]) => {
+    if (errorThrown != null) {
+      subscriber.onError(errorThrown)
+      Cancelable.empty
+    } else if (isDone) {
+      Cancelable.empty
+    } else {
+      subscribers += subscriber
+      Cancelable { () => subscribers -= subscriber }
+    }
+  }
+
+  def value(): ObservableWithInitialValue[A] = ObservableWithInitialValue(cached, tailObservable)
+
+  override def onNext(elem: A): Future[Ack] = if (isDone) Stop else {
+    cached = Some(elem)
+    sendToSubscribers(subscribers, elem)
+  }
+
+  override def onError(ex: Throwable): Unit = if (!isDone) {
+    isDone = true
+    errorThrown = ex
+    subscribers.foreach(_.onError(ex))
+  }
+
+  override def onComplete(): Unit = if (!isDone) {
+    isDone = true
+    subscribers.foreach(_.onComplete())
+  }
+
+  private def sendToSubscribers(subscribers: mutable.Set[Subscriber[A]], elem: A): Future[Ack] = {
+    // counter that's only used when we go async, hence the null
+    var result: PromiseCounter[Ack.Continue.type] = null
+
+    subscribers.foreach { subscriber =>
+      import subscriber.scheduler
+
+      val ack = try subscriber.onNext(elem) catch {
+        case ex if NonFatal(ex) => Future.failed(ex)
+      }
+
+      // if execution is synchronous, takes the fast-path
+      if (ack.isCompleted) {
+        // subscriber canceled or triggered an error? then remove
+        if (ack != Ack.Continue && ack.value.get != Ack.Continue.AsSuccess)
+          subscribers -= subscriber
+      }
+      else {
+        // going async, so we've got to count active futures for final Ack
+        // the counter starts from 1 because zero implies isCompleted
+        if (result == null) result = new PromiseCounter(Ack.Continue, 1)
+        result.acquire()
+
+        ack.onComplete {
+          case Success(Ack.Continue) =>
+            result.countdown()
+          case _ =>
+            // subscriber canceled or triggered an error? then remove
+            subscribers -= subscriber
+            result.countdown()
+        }
+      }
+    }
+
+    // has fast-path for completely synchronous invocation
+    if (result == null) Ack.Continue else {
+      result.countdown()
+      result.future
+    }
+  }
+}
+
+private final class PromiseCounter[A](value: A, initial: Int) {
+  require(initial > 0, "length must be strictly positive")
+
+  private val promise = Promise[A]()
+  private var counter = initial
+
+  def future: Future[A] =
+    promise.future
+
+  def acquire(): Unit =
+    counter += 1
+
+  def countdown(): Unit = {
+    counter -= 1
+    val update = counter
+    if (update == 0) promise.success(value)
+  }
+
+  def success(value: A): Unit =
+    promise.success(value)
+}

--- a/outwatch/src/main/scala/outwatch/dom/helpers/Builder.scala
+++ b/outwatch/src/main/scala/outwatch/dom/helpers/Builder.scala
@@ -11,9 +11,8 @@ trait AttributeBuilder[-T, +A <: VDomModifier] extends Any {
 
   @inline def :=(value: T): A = assign(value)
   def :=?(value: Option[T]): Option[A] = value.map(assign)
-  def <--[F[_] : AsValueObservable](valueStream: F[_ <: T]): ModifierStreamReceiver = {
-    ModifierStreamReceiver(ValueObservable(valueStream).map(assign))
-  }
+  def <--[F[_] : AsValueObservable](valueStream: F[_ <: T]): ModifierStreamReceiver = ModifierStreamReceiver(ValueObservable.from(valueStream).map(assign))
+  def <--(valueStream: ValueObservable[T]): ModifierStreamReceiver = ModifierStreamReceiver(valueStream.map(assign))
 }
 
 object AttributeBuilder {
@@ -102,16 +101,16 @@ object KeyBuilder {
 
 object ChildStreamReceiverBuilder {
   def <--[T](valueStream: Observable[VDomModifier]): ModifierStreamReceiver =
-    ModifierStreamReceiver(AsValueObservable.observable.as(valueStream))
+    ModifierStreamReceiver(ValueObservable.from(valueStream))
 
   def <--[T](valueStream: Observable[T])(implicit r: AsVDomModifier[T]): ModifierStreamReceiver =
-    ModifierStreamReceiver(AsValueObservable.observable.as(valueStream.map(r.asVDomModifier)))
+    ModifierStreamReceiver(ValueObservable.from(valueStream.map(r.asVDomModifier)))
 }
 
 object ChildrenStreamReceiverBuilder {
   def <--(childrenStream: Observable[Seq[VDomModifier]]): ModifierStreamReceiver =
-    ModifierStreamReceiver(AsValueObservable.observable.as(childrenStream.map[VDomModifier](x => x)))
+    ModifierStreamReceiver(ValueObservable.from(childrenStream.map(VDomModifier(_))))
 
   def <--[T](childrenStream: Observable[Seq[T]])(implicit r: AsVDomModifier[T]): ModifierStreamReceiver =
-    ModifierStreamReceiver(AsValueObservable.observable.as(childrenStream.map(_.map(r.asVDomModifier))))
+    ModifierStreamReceiver(ValueObservable.from(childrenStream.map(x => VDomModifier(x.map(r.asVDomModifier)))))
 }

--- a/outwatch/src/main/scala/outwatch/util/LocalStorage.scala
+++ b/outwatch/src/main/scala/outwatch/util/LocalStorage.scala
@@ -21,10 +21,10 @@ class Storage(domStorage: dom.Storage) {
       // We execute the write-action to the storage
       // and pass the written value through to the underlying subject h
       val connectable = h.transformHandler[Option[String]](o => transform(o).distinctUntilChanged) { input =>
-        input.doOnNext {
+        input.transformTail(_.doOnNext {
           case Some(data) => Task(storage.update(key, data))
           case None => Task(storage.remove(key))
-        }
+        })
       }
 
       connectable.connect()

--- a/outwatch/src/main/scala/outwatch/util/Store.scala
+++ b/outwatch/src/main/scala/outwatch/util/Store.scala
@@ -3,11 +3,10 @@ package outwatch.util
 import cats.effect.IO
 import monix.execution.Scheduler
 import monix.reactive.Observable
-import monix.reactive.subjects.PublishSubject
 import org.scalajs.dom
 import outwatch._
-import outwatch.dom.helpers.STRef
 import outwatch.dom.{OutWatch, VNode}
+import outwatch.dom.helpers.STRef
 
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -34,9 +33,7 @@ object Store {
   def create[State, Action](
     initialState: State,
     reducer: Reducer[State, Action]
-  )(implicit s: Scheduler): IO[ProHandler[Action, State]] = IO {
-
-      val subject = PublishSubject[Action]
+  )(implicit s: Scheduler): IO[ProHandler[Action, State]] = Handler.create[Action].map { subject =>
 
       val fold: (State, Action) => State = (state, action) => Try { // guard against reducer throwing an exception
         val (newState, effects) = reducer.reducer(state, action)

--- a/outwatch/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/outwatch/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -518,7 +518,7 @@ class LifecycleHookSpec extends JSDomSpec {
     val modHandler = PublishSubject[VDomModifier]()
     val innerHandler = PublishSubject[VDomModifier]()
     val otherHandler = PublishSubject[VDomModifier]()
-    val node = div(otherHandler, ValueObservable(modHandler, VDomModifier(onDomMount foreach { domHooks :+= "default-mount" }, onDomPreUpdate foreach { domHooks :+= "default-preupdate" }, onDomUpdate foreach { domHooks :+= "default-update" }, onDomUnmount foreach { domHooks :+= "default-unmount" }, innerHandler)))
+    val node = div(otherHandler, ValueObservable.from(modHandler, VDomModifier(onDomMount foreach { domHooks :+= "default-mount" }, onDomPreUpdate foreach { domHooks :+= "default-preupdate" }, onDomUpdate foreach { domHooks :+= "default-update" }, onDomUnmount foreach { domHooks :+= "default-unmount" }, innerHandler)))
 
     OutWatch.renderInto("#app", node).map { _ =>
       domHooks shouldBe List("default-mount")

--- a/outwatch/src/test/scala/outwatch/MonixOpsSpec.scala
+++ b/outwatch/src/test/scala/outwatch/MonixOpsSpec.scala
@@ -42,11 +42,11 @@ class MonixOpsSpec extends JSDomAsyncSpec {
   }
 
 
-  "PublishSubject" should "transformObservable" in {
+  "Handler" should "transformObservable" in {
 
     var currentValue = 0
 
-    val subject = PublishSubject[Int]
+    val subject = Handler.unsafe[Int]
     val mapped = subject.transformObservable(_.map(_ + 1))
     mapped.foreach{currentValue = _}
 

--- a/outwatch/src/test/scala/outwatch/OutwatchSpec.scala
+++ b/outwatch/src/test/scala/outwatch/OutwatchSpec.scala
@@ -12,10 +12,17 @@ import org.scalajs.dom.{document, window}
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import org.scalatest._
 import outwatch.Deprecated.IgnoreWarnings.initEvent
+import outwatch.dom.ValueObservable
 
 trait EasySubscribe {
 
-  implicit class Subscriber[T](obs: Observable[T]) {
+  implicit class SubscriberObservable[T](obs: Observable[T]) {
+    def apply(next: T => Unit)(implicit s: Scheduler): Cancelable = obs.subscribe { t =>
+      next(t)
+      Continue
+    }
+  }
+  implicit class SubscriberValueObservable[T](obs: ValueObservable[T]) {
     def apply(next: T => Unit)(implicit s: Scheduler): Cancelable = obs.subscribe { t =>
       next(t)
       Continue

--- a/outwatch/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/outwatch/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -22,7 +22,7 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
       handleMinus <- Handler.create[MouseEvent]
           plusOne = handlePlus.map(_ => 1)
          minusOne = handleMinus.map(_ => -1)
-            count = Observable.merge(plusOne, minusOne).scan(0)(_ + _).startWith(Seq(0))
+            count = ValueObservable(plusOne, minusOne).merge.scan(0)(_ + _).startWith(Seq(0))
 
              node = div(div(
                         button(id := "plus", "+", onClick --> handlePlus),
@@ -222,7 +222,7 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
       enterPressed = keyStream
         .filter(_.key == "Enter")
 
-      confirm = Observable(enterPressed, clickStream).merge
+      confirm: ValueObservable[String] = ValueObservable(enterPressed, clickStream).merge
         .withLatestFrom(textFieldStream)((_, input) => input)
 
     } yield div(
@@ -252,7 +252,7 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
       deletes = deleteHandler
         .map(removeFromList)
 
-      state = Observable(adds, deletes).merge
+      state = ValueObservable(adds, deletes).merge
         .scan(Vector[String]())((state, modify) => modify(state))
         .map(_.map(n => TodoComponent(n, deleteHandler)))
       textFieldComponent = TextFieldComponent("Todo: ", inputHandler)

--- a/outwatch/src/test/scala/outwatch/ValueObservableSpec.scala
+++ b/outwatch/src/test/scala/outwatch/ValueObservableSpec.scala
@@ -1,0 +1,534 @@
+package outwatch
+
+import monix.eval.Task
+import monix.execution.Ack
+import monix.reactive.Observable
+import monix.reactive.subjects.{BehaviorSubject, PublishSubject, ReplaySubject}
+import outwatch.dom.ValueObservable
+
+class ValueObservableSpec extends JSDomSpec {
+
+  "ValueObservable" should "map" in {
+
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[Int]
+
+    val obs = ValueObservable(1, 2, 3)
+    val m = obs.map{ x => mappedValue :+= x; x }
+    val v = m.value()
+    v.head shouldBe Some(1)
+    v.tail.foreach { x => currentValue :+= x }
+
+    mappedValue shouldBe List(1, 2, 3)
+    currentValue shouldBe List(2, 3)
+  }
+
+  it should "flatMap" in {
+
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[Int]
+
+    val obs = ValueObservable(1, 2, 3)
+    val m = obs.flatMap{ x => mappedValue :+= x; ValueObservable(x, x * 2) }
+    val v = m.value()
+    v.head shouldBe Some(1)
+    v.tail.foreach { x => currentValue :+= x }
+
+    mappedValue shouldBe List(1, 2, 3)
+    currentValue shouldBe List(2, 2, 4, 3, 6)
+  }
+
+  it should "scan" in {
+
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[String]
+
+    val obs = ValueObservable(1, 2, 3)
+    val m = obs.scan(""){ (x,y) => mappedValue :+= y; x + "+" + y.toString  }
+    val v = m.value()
+    v.head shouldBe Some("+1")
+    v.tail.foreach { x => currentValue :+= x }
+
+    mappedValue shouldBe List(1, 2, 3)
+    currentValue shouldBe List("+1+2", "+1+2+3")
+  }
+
+  it should "distinctUntilChanged" in {
+
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[Int]
+
+    val obs = ValueObservable(0, 0, 1, 2, 2, 1, 2, 3, 3, 3)
+    val m = obs.distinctUntilChanged(cats.Eq.fromUniversalEquals).map { x => mappedValue :+= x; x }
+    val v = m.value()
+    v.head shouldBe Some(0)
+    v.tail.foreach { x => currentValue :+= x }
+
+    mappedValue shouldBe List(0, 1, 2, 1, 2, 3)
+    currentValue shouldBe List(1, 2, 1, 2, 3)
+  }
+
+  it should "map empty" in {
+
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[Int]
+
+    val obs = ValueObservable.empty
+    val m = obs.map{ x => mappedValue :+= x; x }
+    val v = m.value()
+    v.head shouldBe None
+    v.tail.foreach { x => currentValue :+= x }
+
+    mappedValue shouldBe List.empty
+    currentValue shouldBe List.empty
+  }
+
+  it should "map single" in {
+
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[Int]
+
+    val obs = ValueObservable(1)
+    val m = obs.map{ x => mappedValue :+= x; x }
+    val v = m.value()
+    v.head shouldBe Some(1)
+    v.tail.foreach { x => currentValue :+= x }
+
+    mappedValue shouldBe List(1)
+    currentValue shouldBe List.empty
+  }
+
+  it should "map dual subscriptions" in {
+
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[Int]
+    var currentValue2 = List.empty[Int]
+
+    val obs = ValueObservable(1,2,3)
+    val m = obs.map{ x => mappedValue :+= x; x }
+    val v = m.value()
+    v.head shouldBe Some(1)
+    v.tail.foreach { x => currentValue :+= x }
+    v.tail.foreach { x => currentValue2 :+= x }
+
+    mappedValue shouldBe List(1,2,3,2,3)
+    currentValue shouldBe List(2,3)
+    currentValue2 shouldBe List(2,3)
+  }
+
+  it should "foreach" in {
+
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[Int]
+    var currentValue2 = List.empty[Int]
+
+    val obs = ValueObservable(1,2,3)
+    val m = obs.map{ x => mappedValue :+= x; x }
+    m.foreach { x => currentValue :+= x }
+    m.foreach { x => currentValue2 :+= x }
+
+    mappedValue shouldBe List(1,2,3,1,2,3)
+    currentValue shouldBe List(1,2,3)
+    currentValue2 shouldBe List(1,2,3)
+  }
+
+  "BehaviorProHandler" should "map" in {
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[Int]
+    var currentValue2 = List.empty[Int]
+
+    val obs = Handler.unsafe[Int](1)
+    val m = obs.map{ x => mappedValue :+= x; x }
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(2)
+      _ = m.foreach { x => currentValue2 :+= x }
+      Ack.Continue <- obs.onNext(3)
+      Ack.Continue <- obs.onNext(4)
+    } yield {
+      mappedValue shouldBe List(1,2,2,3,3,4,4)
+      currentValue shouldBe List(1,2,3,4)
+      currentValue2 shouldBe List(2,3,4)
+    }
+  }
+
+  it should "map dual subscriptions" in {
+
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[Int]
+    var currentValue2 = List.empty[Int]
+
+    val obs = Handler.unsafe[Int](1)
+    val m = obs.map{ x => mappedValue :+= x; x }
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(2)
+      _ = m.foreach { x => currentValue2 :+= x }
+      Ack.Continue <- obs.onNext(3)
+      Ack.Continue <- obs.onNext(4)
+    } yield {
+      mappedValue shouldBe List(1,2,2,3,3,4,4)
+      currentValue shouldBe List(1,2,3,4)
+      currentValue2 shouldBe List(2,3,4)
+    }
+  }
+
+  it should "scan dual subscriptions" in {
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[String]
+    var currentValue2 = List.empty[String]
+
+    val obs = Handler.unsafe[Int](1)
+    val m = obs.scan(""){ (x,y) => mappedValue :+= y; x + "+" + y.toString  }
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(2)
+      _ = m.foreach { x => currentValue2 :+= x }
+      Ack.Continue <- obs.onNext(3)
+      Ack.Continue <- obs.onNext(4)
+    } yield {
+      mappedValue shouldBe List(1, 2, 2, 3, 3, 4, 4)
+      currentValue shouldBe List("+1", "+1+2", "+1+2+3", "+1+2+3+4")
+      currentValue2 shouldBe List("+2", "+2+3", "+2+3+4")
+    }
+  }
+
+  it should "map dual subscriptions shared" in {
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[Int]
+    var currentValue2 = List.empty[Int]
+
+    val obs = Handler.unsafe[Int](1)
+    val m = obs.map{ x => mappedValue :+= x; x }.share
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(2)
+      _ = m.foreach { x => currentValue2 :+= x }
+      Ack.Continue <- obs.onNext(3)
+      Ack.Continue <- obs.onNext(4)
+    } yield {
+      mappedValue shouldBe List(1,2,3,4)
+      currentValue shouldBe List(1,2,3,4)
+      currentValue2 shouldBe List(3,4)
+    }
+  }
+
+  it should "scan dual subscriptions shared" in {
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[String]
+    var currentValue2 = List.empty[String]
+
+    val obs = Handler.unsafe[Int](1)
+    val m = obs.scan(""){ (x,y) => mappedValue :+= y; x + "+" + y.toString  }.share
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(2)
+      _ = m.foreach { x => currentValue2 :+= x }
+      Ack.Continue <- obs.onNext(3)
+      Ack.Continue <- obs.onNext(4)
+    } yield {
+      mappedValue shouldBe List(1, 2, 3, 4)
+      currentValue shouldBe List("+1", "+1+2", "+1+2+3", "+1+2+3+4")
+      currentValue2 shouldBe List("+1+2+3", "+1+2+3+4")
+    }
+  }
+
+  it should "map dual direct subscriptions shared" in {
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[Int]
+    var currentValue2 = List.empty[Int]
+
+    val obs = Handler.unsafe[Int](1)
+    val m = obs.map{ x => mappedValue :+= x; x }.share
+    m.foreach { x => currentValue :+= x }
+    m.foreach { x => currentValue2 :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(2)
+      Ack.Continue <- obs.onNext(3)
+      Ack.Continue <- obs.onNext(4)
+    } yield {
+      mappedValue shouldBe List(1,2,3,4)
+      currentValue shouldBe List(1,2,3,4)
+      currentValue2 shouldBe List(2,3,4)
+    }
+  }
+
+  it should "scan dual direct subscriptions shared" in {
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[String]
+    var currentValue2 = List.empty[String]
+
+    val obs = Handler.unsafe[Int](1)
+    val m = obs.scan(""){ (x,y) => mappedValue :+= y; x + "+" + y.toString  }.share
+    m.foreach { x => currentValue :+= x }
+    m.foreach { x => currentValue2 :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(2)
+      Ack.Continue <- obs.onNext(3)
+      Ack.Continue <- obs.onNext(4)
+    } yield {
+      mappedValue shouldBe List(1, 2, 3, 4)
+      currentValue shouldBe List("+1", "+1+2", "+1+2+3", "+1+2+3+4")
+      currentValue2 shouldBe List("+1+2", "+1+2+3", "+1+2+3+4")
+    }
+  }
+
+  it should "withLatestFrom" in {
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[(Int,Int)]
+
+    val obs = Handler.unsafe[Int](1)
+    val obs2 = Handler.unsafe[Int]
+    val m = obs.withLatestFrom(obs2){ (x,y) => mappedValue :+= x; (x,y) }
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(2)
+      Ack.Continue <- obs2.onNext(-1)
+      Ack.Continue <- obs2.onNext(-2)
+      Ack.Continue <- obs.onNext(3)
+      Ack.Continue <- obs2.onNext(-4)
+    } yield {
+      mappedValue shouldBe List(3)
+      currentValue shouldBe List((3,-2))
+    }
+  }
+
+  it should "withLatestFrom with seed" in {
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[(Int,Int)]
+
+    val obs = Handler.unsafe[Int](1)
+    val obs2 = Handler.unsafe[Int](0)
+    val m = obs.withLatestFrom(obs2){ (x,y) => mappedValue :+= x; (x,y) }
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(2)
+      Ack.Continue <- obs2.onNext(-1)
+      Ack.Continue <- obs2.onNext(-2)
+      Ack.Continue <- obs.onNext(3)
+    } yield {
+      mappedValue shouldBe List(1,2,3)
+      currentValue shouldBe List((1,0),(2,0),(3,-2))
+    }
+  }
+
+  it should "combineLatest" in {
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[(Int,Int)]
+
+    val obs = Handler.unsafe[Int](1)
+    val obs2 = Handler.unsafe[Int]
+    val m = obs.combineLatestMap(obs2){ (x,y) => mappedValue :+= x; (x,y) }
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(2)
+      Ack.Continue <- obs2.onNext(-1)
+      Ack.Continue <- obs2.onNext(-2)
+      Ack.Continue <- obs.onNext(3)
+    } yield {
+      mappedValue shouldBe List(2,2,3)
+      currentValue shouldBe List((2,-1),(2,-2),(3,-2))
+    }
+  }
+
+  it should "combineLatest with seed" in {
+    var mappedValue = List.empty[Int]
+    var currentValue = List.empty[(Int,Int)]
+
+    val obs = Handler.unsafe[Int](1)
+    val obs2 = Handler.unsafe[Int](0)
+    val m = obs.combineLatestMap(obs2){ (x,y) => mappedValue :+= x; (x,y) }
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(2)
+      Ack.Continue <- obs2.onNext(-1)
+      Ack.Continue <- obs2.onNext(-2)
+      Ack.Continue <- obs.onNext(3)
+    } yield {
+      mappedValue shouldBe List(1,2,2,2,3)
+      currentValue shouldBe List((1,0),(2,0),(2,-1),(2,-2),(3,-2))
+    }
+  }
+
+  it should "concat" in {
+    var currentValue = List.empty[Int]
+
+    val innerObs = Handler.unsafe[Int]
+    val obs = Handler.unsafe[ValueObservable[Int]](innerObs)
+    val m = obs.concat
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- innerObs.onNext(13)
+      Ack.Continue <- innerObs.onNext(14)
+      f0 = obs.onNext(ValueObservable(0))
+      Ack.Continue <- innerObs.onNext(15)
+      f1 = obs.onNext(ValueObservable(1))
+      _ = innerObs.onComplete()
+      Ack.Continue <- f0
+      Ack.Continue <- f1
+      Ack.Continue <- obs.onNext(ValueObservable(2))
+    } yield {
+      currentValue shouldBe List(13, 14, 15, 0, 1, 2)
+    }
+  }
+
+  it should "merge" in {
+    var currentValue = List.empty[Int]
+
+    val innerObs = Handler.unsafe[Int]
+    val obs = Handler.unsafe[ValueObservable[Int]](innerObs)
+    val m = obs.merge
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- innerObs.onNext(13)
+      Ack.Continue <- innerObs.onNext(14)
+      f0 = obs.onNext(ValueObservable(0))
+      Ack.Continue <- innerObs.onNext(15)
+      f1 = obs.onNext(ValueObservable(1))
+      _ = innerObs.onComplete()
+      Ack.Continue <- f0
+      Ack.Continue <- f1
+      Ack.Continue <- obs.onNext(ValueObservable(2))
+    } yield {
+      currentValue shouldBe List(13, 14, 0, 15, 1, 2)
+    }
+  }
+
+  it should "switch" in {
+    var currentValue = List.empty[Int]
+
+    val innerObs = Handler.unsafe[Int]
+    val obs = Handler.unsafe[ValueObservable[Int]](innerObs)
+    val m = obs.switch
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- innerObs.onNext(13)
+      Ack.Continue <- innerObs.onNext(14)
+      Ack.Continue <- obs.onNext(ValueObservable(0))
+      Ack.Continue <- innerObs.onNext(15)
+      Ack.Continue <- obs.onNext(ValueObservable(1))
+      _ = innerObs.onComplete()
+      Ack.Continue <- obs.onNext(ValueObservable(2))
+    } yield {
+      currentValue shouldBe List(13, 14, 0, 1, 2)
+    }
+  }
+
+  it should "takeWhile with false seed" in {
+    var currentValue = List.empty[Int]
+
+    val obs = Handler.unsafe[Int](2)
+    val m = obs.takeWhile(_ < 0)
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(-3)
+      Ack.Continue <- obs.onNext(4)
+      Ack.Continue <- obs.onNext(1)
+    } yield {
+      currentValue shouldBe List.empty
+    }
+  }
+
+  it should "takeWhile with true seed" in {
+    var currentValue = List.empty[Int]
+
+    val obs = Handler.unsafe[Int](-1)
+    val m = obs.takeWhile(_ < 0)
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(-3)
+      Ack.Continue <- obs.onNext(4)
+      Ack.Continue <- obs.onNext(1)
+    } yield {
+      currentValue shouldBe List(-1, -3)
+    }
+  }
+
+  it should "takeWhile without seed" in {
+    var currentValue = List.empty[Int]
+
+    val obs = Handler.unsafe[Int]
+    val m = obs.takeWhile(_ < 0)
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(-3)
+      Ack.Continue <- obs.onNext(4)
+      Ack.Continue <- obs.onNext(1)
+    } yield {
+      currentValue shouldBe List(-3)
+    }
+  }
+
+  it should "doOnNext" in {
+    var doValue = List.empty[Int]
+    var currentValue = List.empty[Int]
+
+    val obs = Handler.unsafe[Int](1)
+    val m = obs.doOnNext(x => Task { doValue :+= x })
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(2)
+      Ack.Continue <- obs.onNext(3)
+    } yield {
+      currentValue shouldBe List(1,2,3)
+      doValue shouldBe List(1,2,3)
+    }
+  }
+
+  it should "doOnError" in {
+    var doCounter = 0
+    var currentValue = List.empty[Int]
+
+    val obs = Handler.unsafe[Int](1)
+    val m = obs.doOnError(_ => Task { doCounter += 1 })
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(2)
+      Ack.Continue <- obs.onNext(3)
+      _ = obs.onError(new Exception)
+    } yield {
+      currentValue shouldBe List(1,2,3)
+      doCounter shouldBe 0
+      obs.onError(new Exception)
+      doCounter shouldBe 1
+    }
+  }
+
+  it should "doOnComplete" in {
+    var doCounter = 0
+    var currentValue = List.empty[Int]
+
+    val obs = Handler.unsafe[Int](1)
+    val m = obs.doOnComplete(Task { doCounter += 1 })
+    m.foreach { x => currentValue :+= x }
+
+    for {
+      Ack.Continue <- obs.onNext(2)
+      Ack.Continue <- obs.onNext(3)
+    } yield {
+      currentValue shouldBe List(1,2,3)
+      doCounter shouldBe 0
+      obs.onComplete()
+      doCounter shouldBe 1
+    }
+  }
+}


### PR DESCRIPTION
This PR adds our own `BehaviorProHandler` which implements a `ValueObservable`. It is implemented very similar to the `BehaviorSubject` in monix. But it additionally exposes the current value of the stream, so we can access it synchronously. This is really nice from a performance perspective, because we can render the initial state of a reactive component without needing to patch the first emitted value of the observable.

We have implemented some common operations like map/filter/collect/scan... on the ValueObservable so you can transform the ValueObservable without losing the initial value downstream. There is an implicit from ValueObserable => Observable, so you can use complex observable methods directly on the ValueObserable and do not have to change your code there. 

Based on #247, so only look at the last four commits. Fixes #250 (though not directly by using Var).