### PR TITLE
add OutwatchTracing.error for detecting patching errors

### DIFF
--- a/outwatch/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
+++ b/outwatch/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
@@ -13,6 +13,9 @@ import scala.scalajs.js
 object OutwatchTracing {
   private[outwatch] val patchSubject = PublishSubject[VNodeProxy]()
   def patch: Observable[VNodeProxy] = patchSubject
+
+  private[outwatch] val errorSubject = PublishSubject[Throwable]()
+  def error: Observable[Throwable] = errorSubject
 }
 
 private[outwatch] object SnabbdomOps {
@@ -110,7 +113,10 @@ private[outwatch] object SnabbdomOps {
               Ack.Continue
             } else Ack.Stop
           },
-          error => dom.console.error(error.getMessage + "\n" + error.getStackTrace.mkString("\n"))
+          { error =>
+            OutwatchTracing.errorSubject.onNext(error)
+            dom.console.error(error.getMessage + "\n" + error.getStackTrace.mkString("\n"))
+          }
         ))
       }
 


### PR DESCRIPTION
Provides a way to get events about exceptions being thrown in your observable modifiers. You can trace them via `OutwatchTracing.error`. Maybe we should have a way to handle error with a PartialFunction. But this is a first step.

In an application, we use it to show an error page, because something is going wrong. As of now, we do not know what but that is better than nothing -- and definitely better than let the user wonder why some parts do not work anymore.

We can think of extending this and have a way to handle this per `VNode`. So you could define different error handling strategies: (1) just fail and log like now, (2) notify the application about an error and stop, (3) just continue and swallow the exception.

_Oh, maybe we should rename OutwatchTracing to camel-case OutWatchTracing to be aligned with the OutWatch object. Or have `OutWatch.tracing` as accessor?_ 