### PR TITLE
Multiple changes to Store

### DIFF
--- a/outwatch/src/main/scala/outwatch/dom/OutWatch.scala
+++ b/outwatch/src/main/scala/outwatch/dom/OutWatch.scala
@@ -40,8 +40,8 @@ object OutWatch {
   @deprecated("Use renderInto instead (or renderReplace)", "0.11.0")
   def render(querySelector: String, vNode: VNode)(implicit s: Scheduler): IO[Unit] = renderInto(querySelector, vNode)
 
-  def renderWithStore[S, A](
-    initialState: S, reducer: Store.Reducer[S, A], querySelector: String, root: VNode
+  def renderWithStore[M, A](
+    initialState: M, reducer: Store.Reducer[M, A], querySelector: String, root: VNode
   )(implicit s: Scheduler): IO[Unit] =
     Store.renderWithStore(initialState, reducer, querySelector, root)
 }

--- a/outwatch/src/main/scala/outwatch/dom/OutWatch.scala
+++ b/outwatch/src/main/scala/outwatch/dom/OutWatch.scala
@@ -40,8 +40,8 @@ object OutWatch {
   @deprecated("Use renderInto instead (or renderReplace)", "0.11.0")
   def render(querySelector: String, vNode: VNode)(implicit s: Scheduler): IO[Unit] = renderInto(querySelector, vNode)
 
-  def renderWithStore[M, A](
-    initialState: M, reducer: Store.Reducer[M, A], querySelector: String, root: VNode
+  def renderWithStore[A, M](
+    initialState: M, reducer: Store.Reducer[A, M], querySelector: String, root: VNode
   )(implicit s: Scheduler): IO[Unit] =
     Store.renderWithStore(initialState, reducer, querySelector, root)
 }

--- a/outwatch/src/main/scala/outwatch/dom/OutWatch.scala
+++ b/outwatch/src/main/scala/outwatch/dom/OutWatch.scala
@@ -41,7 +41,11 @@ object OutWatch {
   def render(querySelector: String, vNode: VNode)(implicit s: Scheduler): IO[Unit] = renderInto(querySelector, vNode)
 
   def renderWithStore[A, M](
-    initialState: M, reducer: Store.Reducer[A, M], querySelector: String, root: VNode
+    initialAction: A,
+    initialState: M,
+    reducer: Store.Reducer[A, M],
+    querySelector: String,
+    root: VNode
   )(implicit s: Scheduler): IO[Unit] =
-    Store.renderWithStore(initialState, reducer, querySelector, root)
+    Store.renderWithStore(initialAction, initialState, reducer, querySelector, root)
 }

--- a/outwatch/src/main/scala/outwatch/util/Store.scala
+++ b/outwatch/src/main/scala/outwatch/util/Store.scala
@@ -23,8 +23,8 @@ object Store {
     implicit def justState[M, A](f: (M, A) => M): Reducer[M, A] = Reducer { (s: M, a: A) => (f(s, a), Observable.empty) }
 
     implicit def stateAndOptionIO[M, A](f: (M, A) => (M, Option[IO[A]])): Reducer[M, A] =  Reducer { (s: M, a: A) =>
-      val (mewState, effect) = f(s, a)
-      (mewState, effect.fold[Observable[A]](Observable.empty)(Observable.fromIO))
+      val (newState, effect) = f(s, a)
+      (newState, effect.fold[Observable[A]](Observable.empty)(Observable.fromIO))
     }
   }
 

--- a/outwatch/src/main/scala/outwatch/util/Store.scala
+++ b/outwatch/src/main/scala/outwatch/util/Store.scala
@@ -15,19 +15,52 @@ import scala.util.control.NonFatal
 
 object Store {
 
+  /**
+   * A Function that applies an Action onto the Stores current state.
+   * @param reducer The reducing function
+   * @tparam A The Action Type
+   * @tparam M The Model Type
+   */
   case class Reducer[A, M](reducer: (M, A) => (M, Observable[A]))
 
   object Reducer {
+    /**
+     * Creates a Reducer which yields a new State, as-well as an Observable of Effects
+     * Effects are Actions which will be executed after the Action that caused them to occur.
+     * This is accomplished by subscribing to the Effects Observable within the stores scan loop.
+     *
+     * CAUTION: There is currently a bug which causes the Effect-States to emit,
+     * before the State of the action that caused the effects is emitted.
+     * However, this only effects immediate emissions of the Effects Observable, delayed emissions should be fine.
+     * @param f The Reducing Function returning the (Model, Effects) tuple.
+     */
     implicit def stateAndEffects[A, M](f: (M, A) => (M, Observable[A])): Reducer[A, M] = Reducer(f)
 
+    /**
+     * Creates a reducer which just transforms the state, without additional effects.
+     */
     implicit def justState[A, M](f: (M, A) => M): Reducer[A, M] = Reducer { (s: M, a: A) => (f(s, a), Observable.empty) }
 
+    /**
+     * Creates a Reducer with an optional IO effect.
+     */
     implicit def stateAndOptionIO[A, M](f: (M, A) => (M, Option[IO[A]])): Reducer[A, M] = Reducer { (s: M, a: A) =>
       val (newState, effect) = f(s, a)
       (newState, effect.fold[Observable[A]](Observable.empty)(Observable.fromIO))
     }
   }
 
+  /**
+   * Creates an IO[Store]
+   * A Store capules a scan operation on an Observable in an opinionated manner.
+   * An internal state is tansformed by a series of actions.
+   * The state will be the same for every subscriber.
+   * @param initialAction The Stores initial action. Useful for re-creating a store from memory.
+   * @param initialState The stores initial state. Similar to the initial accumulator on a fold / scan.
+   * @param reducer The Reducing funcion. Creates a new State from the previous state and an Action.
+   * @param recoverError An optional PartialFunctio for recovering the State when an Exception occurs in the Recuer.
+   * @return An Observable emitting a tuple of the current state and the action that caused that state.
+   */
   def create[A, M](
     initialAction: A,
     initialState: M,
@@ -65,10 +98,22 @@ object Store {
     out
   }
 
+  /**
+   * A global reference to a Store.
+   * Commonly used to implement the Redux Pattern.
+   */
   private val storeRef = STRef.empty
 
+  /**
+   * Get's a globally unique store.
+   * Commonly used to implement the Redux Pattern.
+   */
   def get[A, M]: IO[ProHandler[A, M]] = storeRef.asInstanceOf[STRef[ProHandler[A, M]]].getOrThrow(NoStoreException)
 
+  /**
+   * Renders an Application with a globally unique Store.
+   * Commonly used to implement the Redux Pattern.
+   */
   def renderWithStore[A, M](
     initialAction: A,
     initialState: M,

--- a/outwatch/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/outwatch/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -73,7 +73,7 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
     }
 
     val node: IO[VNode] = for {
-      store <- Store.create[State, Action](0, reduce _)
+      store <- Store.create[Action, State](0, reduce _)
     } yield div(
         div(
           button(id := "plus", "+", onClick(Plus) --> store),

--- a/outwatch/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/outwatch/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -61,24 +61,27 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
 
   "A simple counter application that uses Store" should "work as intended" in {
 
-    sealed trait Action
-    case object Plus extends Action
-    case object Minus extends Action
+    sealed trait CounterAction
+    case object Initial extends CounterAction
+    case object Plus extends CounterAction
+    case object Minus extends CounterAction
 
-    type State = Int
+    type CounterModel = Int
 
-    def reduce(state: State, action: Action): State = action match {
+    def reduce(state: CounterModel, action: CounterAction): CounterModel = action match {
+      case Initial => ???
       case Plus => state + 1
       case Minus => state - 1
     }
 
     val node: IO[VNode] = for {
-      store <- Store.create[Action, State](0, reduce _)
+      store <- Store.create[CounterAction, CounterModel](Initial, 0, reduce _)
+      state = store.collect { case (action@_, state) => state }
     } yield div(
         div(
           button(id := "plus", "+", onClick(Plus) --> store),
           button(id := "minus", "-", onClick(Minus) --> store),
-          span(id:="counter", store)
+          span(id:="counter", state)
         )
       )
 

--- a/outwatch/src/test/scala/outwatch/StoreSpec.scala
+++ b/outwatch/src/test/scala/outwatch/StoreSpec.scala
@@ -1,0 +1,92 @@
+package outwatch
+
+import monix.execution.ExecutionModel.SynchronousExecution
+import monix.execution.Scheduler
+import monix.execution.schedulers.TrampolineScheduler
+import org.scalatest.{FlatSpec, Matchers}
+import outwatch.util._
+
+class StoreSpec extends FlatSpec with Matchers {
+  implicit val scheduler = TrampolineScheduler(Scheduler.global, SynchronousExecution)
+
+  sealed trait CounterAction
+
+  case object Initial extends CounterAction
+  case object Plus extends CounterAction
+  case object Minus extends CounterAction
+
+  type Model = Int
+
+  def reduce(state: Model, action: CounterAction): Model = action match {
+    case Initial => ???
+    case Plus => state + 1
+    case Minus => state - 1
+  }
+
+  "A Store" should "emit its initial state to multiple subscribers" in {
+    val store = Store.create(Initial, 0, reduce _).unsafeRunSync()
+
+    var a: Option[Model] = None
+    var b: Option[Model] = None
+
+    store.foreach { case (action@_, state) =>
+      a = Some(state)
+    }
+
+    store.foreach { case (action@_, state) =>
+      b = Some(state)
+    }
+
+    a shouldBe Some(0)
+    b shouldBe Some(0)
+
+  }
+
+  "A Store" should "emit consecutive states to multiple subscribers" in {
+    val store = Store.create(Initial, 0, reduce _).unsafeRunSync()
+
+    var a: Option[Model] = None
+    var b: Option[Model] = None
+
+    store.foreach { case (action@_, state) =>
+      a = Some(state)
+    }
+
+    store.foreach { case (action@_, state) =>
+      b = Some(state)
+    }
+
+    store.onNext(Plus)
+
+    a shouldBe Some(1)
+    b shouldBe Some(1)
+
+    for (i <- 2 to 10) {
+      store.onNext(Plus)
+
+      a shouldBe Some(i)
+      b shouldBe Some(i)
+    }
+  }
+
+  "A Store" should "emit its current state to new subscribers" in {
+    val store = Store.create(Initial, 0, reduce _).unsafeRunSync()
+
+    for (i <- 1 to 10)
+      store.onNext(Plus)
+
+    var a: Option[Model] = None
+    var b: Option[Model] = None
+
+    store.foreach { case (action@_, state) =>
+      a = Some(state)
+    }
+
+    store.foreach { case (action@_, state) =>
+      b = Some(state)
+    }
+
+    a shouldBe Some(10)
+    b shouldBe Some(10)
+  }
+}


### PR DESCRIPTION
This PR makes the following changes to `Store` (in order of significance)

* Makes Store emit an (action -> state) tuple.
  * This tuple allows more granular control about *when* a view updates when the stores state changes.  
    Methods like `collect` can now be used to, not only capture certain state changes, but they can also react to the `Action` which caused that state.  
    This allows us to ignore all other Actions which are irrelevant to that specific view.  
    For example, if we were to move a draggable element using a mouse cursor, we could react just to events changing the position of the element, while discarding all other state updates.
    ```scala
    svg(
      rect(width := 10, height := 10,
        x <-- store.collect { case (MoveAction, state) => state.xPos },
        y <-- store.collect { case (MoveAction, state) => state.yPos }
      )
    )
    ```
  * This tuple can also be used to have other parts of the application react to an `Action`. This can be useful if we, for example want to collect numerous actions (and their resulting states) into a list, so that we can later undo them, as as is common in many applications, by, for example, hitting `ctrl + z`.
  * However this addition has some implications which have further consequences.
* Introduces a common Action base-trait;
  * Since we now emit an `(action -> state)` tuple in `Store`, we have 2 edge cases which need to be solved.
    * This PR Introduces a common starting Action: Noop;
      * When created, `Store` emits it's initial State once, to every subscriber. Since that state was not determined by an Action, a placeholder action is needed.
        It, `Noop` is inherited from the common `Action`.
    * This PR Introduces a common Error Action which carries error data.  
      * The `Error()` Action is used, when the reduction of an Action fails. It contains the errors data object.
* Changes the Store type parameter naming scheme, to use Model instead of State.
  * I propose the type parameters of store to be named `[A, M]`, meaning `[Action, Model]` (ordered by `In, Out]`, consistently, as the ordering is also used in `ProHandler`)
    I feel like this describes the usage of these a little better, since we do not actually have a state at compile time.  
    A runtime value should be named `val state: Model`
* Removes startWith by using the scan0 operator;

---

I am afraid, that I cannot really split this into multiple commits, without a lot of work being involved, since my original branch is unable to merge due to it being forked from the `new-io`  PR while it was still in progress.