### PR TITLE
fix wrong order of mount and unmount when streamed

### DIFF
--- a/outwatch/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/outwatch/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -343,11 +343,11 @@ private[outwatch] object NativeModifiers {
       js.Array(
         h,
         InsertHook { _ => triggered = true },
-        PostPatchHook { (o, p) =>
+        UpdateHook { (o, p) =>
           if (triggered && o._id == p._id) isOpen = false
           triggered = true
         },
-        NextVDomModifier(PostPatchHook { (o, p) =>
+        NextVDomModifier(UpdateHook { (o, p) =>
           if (isOpen && o._id == p._id) h.trigger(p)
           isOpen = true
         })

--- a/outwatch/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/outwatch/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -494,22 +494,22 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
       domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update")
 
       innerHandler.onNext(VDomModifier(onDomPreUpdate foreach { domHooks :+= "inner-preupdate2" }, onDomUpdate foreach { domHooks :+= "inner-update2" }))
-      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "update", "inner-unmount")
+      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update")
 
       innerHandler.onNext(VDomModifier(Observable("inner")))
-      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "update", "inner-unmount", "preupdate", "update", "preupdate", "update")
+      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update", "preupdate", "update", "preupdate", "update")
 
       innerHandler.onNext(VDomModifier(onDomMount foreach { domHooks :+= "inner-mount2" }, onDomUnmount foreach { domHooks :+= "inner-unmount2" }, "something-else"))
-      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "update", "inner-unmount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount2")
+      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount2")
 
       modHandler.onNext(onDomMount foreach { domHooks :+= "mount2" })
-      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "update", "inner-unmount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount2", "mount2", "unmount", "inner-unmount2")
+      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount2", "unmount", "inner-unmount2", "mount2")
 
       modHandler.onNext(onDomUnmount foreach { domHooks :+= "unmount2" })
-      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "update", "inner-unmount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount2", "mount2", "unmount", "inner-unmount2")
+      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount2", "unmount", "inner-unmount2", "mount2")
 
       modHandler.onNext(VDomModifier.empty)
-      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "update", "inner-unmount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount2", "mount2", "unmount", "inner-unmount2", "unmount2")
+      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount2", "unmount", "inner-unmount2", "mount2", "unmount2")
     }
   }
 
@@ -532,16 +532,45 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
       domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update")
 
       modHandler.onNext(VDomModifier(onDomMount foreach { domHooks :+= "mount" }, onDomUnmount foreach { domHooks :+= "unmount" }))
-      domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "mount", "default-unmount", "inner-unmount")
+      domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "default-unmount", "inner-unmount", "mount")
 
       modHandler.onNext(onDomMount foreach { domHooks :+= "mount2" })
-      domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "mount", "default-unmount", "inner-unmount", "mount2", "unmount")
+      domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "default-unmount", "inner-unmount", "mount", "unmount", "mount2")
 
       modHandler.onNext(onDomUnmount foreach { domHooks :+= "unmount2" })
-      domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "mount", "default-unmount", "inner-unmount", "mount2", "unmount")
+      domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "default-unmount", "inner-unmount", "mount", "unmount", "mount2")
 
       modHandler.onNext(VDomModifier.empty)
-      domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "mount", "default-unmount", "inner-unmount", "mount2", "unmount", "unmount2")
+      domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "default-unmount", "inner-unmount", "mount", "unmount", "mount2", "unmount2")
+    }
+  }
+
+  it should "have unmount before mount hook when streamed" in {
+
+    var domHooks = List.empty[String]
+
+    val countHandler = PublishSubject[Int]()
+    val node = div(
+      countHandler.map { count =>
+        VDomModifier(
+          onDomMount.foreach { domHooks :+= "mount" + count },
+          onDomUnmount.foreach { domHooks :+= "unmount" + count },
+          div(
+            onDomMount.foreach { domHooks :+= "child-mount" + count },
+            onDomUnmount.foreach { domHooks :+= "child-unmount" + count }
+          )
+        )
+      }
+    )
+
+    OutWatch.renderInto("#app", node).map { _ =>
+      domHooks shouldBe List.empty
+
+      countHandler.onNext(1)
+      domHooks shouldBe List("mount1", "child-mount1")
+
+      countHandler.onNext(2)
+      domHooks shouldBe List("mount1", "child-mount1", "unmount1", "child-unmount1", "child-mount2", "mount2")
     }
   }
 


### PR DESCRIPTION
The logic of streamed unmount hooks has a flaw. It uses `PostPatchHooks` which are not guaranteed to be run before all mount hooks of the next patch-iteration. This PR now uses `UpdateHook` for mirroring streamed unmount hooks. This will always be done before any mount hook which is called from an insert or post patch hook. And importantly it also needs to be done after the `PrePatchHooks` because of thunks and because prepatch can be called more often than update by snabbdom.

Based on #273 