### PR TITLE
Use snabbdom/tovnode for renderReplace

### DIFF
--- a/outwatch/src/main/scala/outwatch/dom/OutWatch.scala
+++ b/outwatch/src/main/scala/outwatch/dom/OutWatch.scala
@@ -26,7 +26,7 @@ object OutWatch {
   def renderReplace(element: dom.Element, vNode: VNode)(implicit s: Scheduler): IO[Unit] = for {
     node <- toSnabbdom(vNode)
     _ <- IO {
-      val elementNode = VNodeProxy.fromElement(element)
+      val elementNode = snabbdom.tovnode(element)
       patch(elementNode, node)
     }
   } yield ()

--- a/outwatch/src/main/scala/snabbdom/hFunction.scala
+++ b/outwatch/src/main/scala/snabbdom/hFunction.scala
@@ -198,13 +198,6 @@ object VNodeProxy {
     text = string
   }
 
-  def fromElement(element: Element): VNodeProxy = new VNodeProxy {
-    sel = element.tagName.toLowerCase
-    elm = element
-    text = ""
-    data = DataObject.empty
-  }
-
   def updateInto(source: VNodeProxy, target: VNodeProxy): Unit = if (source != target) {
     target.sel = source.sel
     target.key = source.key
@@ -268,4 +261,11 @@ object SnabbdomCustomProps extends js.Object {
 @JSImport("snabbdom/modules/style", JSImport.Namespace, globalFallback = "snabbdom_style")
 object SnabbdomStyle extends js.Object {
   val default: js.Any = js.native
+}
+
+
+@js.native
+@JSImport("snabbdom/tovnode", JSImport.Default)
+object tovnode extends js.Function1[Element, VNodeProxy] {
+  def apply(element: Element):VNodeProxy = js.native
 }


### PR DESCRIPTION
This is replacing the custom approach with the correct one. Before, renderReplace kept the attributes of the tag. Now the whole tag will be replaced correctly.