### PR TITLE
remove ChildCommand's ChildId from dom package namespace

### DIFF
--- a/outwatch/src/main/scala/outwatch/dom/ChildCommand.scala
+++ b/outwatch/src/main/scala/outwatch/dom/ChildCommand.scala
@@ -10,6 +10,11 @@ import scala.scalajs.js
 
 sealed trait ChildCommand
 object ChildCommand {
+  sealed trait ChildId
+  object ChildId {
+    case class Key(key: outwatch.dom.Key.Value) extends ChildId
+    case class Element(elem: org.scalajs.dom.Element) extends ChildId
+  }
 
   case class Append(node: VNode) extends ChildCommand
   case class Prepend(node: VNode) extends ChildCommand
@@ -106,10 +111,3 @@ object ChildCommand {
     }
   }
 }
-
-sealed trait ChildId
-object ChildId {
-  case class Key(key: outwatch.dom.Key.Value) extends ChildId
-  case class Element(elem: org.scalajs.dom.Element) extends ChildId
-}
-

--- a/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -1908,10 +1908,10 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
       cmds.onNext(ChildCommand.Move(1, 2))
       element.innerHTML shouldBe """<b>Hello World</b><span>!</span><p>and friends</p>"""
 
-      cmds.onNext(ChildCommand.MoveId(ChildId.Key(42), 1))
+      cmds.onNext(ChildCommand.MoveId(ChildCommand.ChildId.Key(42), 1))
       element.innerHTML shouldBe """<b>Hello World</b><p>and friends</p><span>!</span>"""
 
-      cmds.onNext(ChildCommand.RemoveId(ChildId.Key(42)))
+      cmds.onNext(ChildCommand.RemoveId(ChildCommand.ChildId.Key(42)))
       element.innerHTML shouldBe """<b>Hello World</b><span>!</span>"""
     }
   }
@@ -1937,7 +1937,7 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
       "Questions?",
       div(
         id := "strings",
-        onClick.map(ev => ChildCommand.RemoveId(ChildId.Element(ev.target))) --> cmds,
+        onClick.map(ev => ChildCommand.RemoveId(ChildCommand.ChildId.Element(ev.target))) --> cmds,
         cmds
       )
     )
@@ -1950,10 +1950,10 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
 
       element.innerHTML shouldBe """<p id="id-2">Why so cheap?</p>"""
 
-      cmds.onNext(ChildCommand.InsertBeforeId(ChildId.Key("question-2"), div("spam")))
+      cmds.onNext(ChildCommand.InsertBeforeId(ChildCommand.ChildId.Key("question-2"), div("spam")))
       element.innerHTML shouldBe """<div>spam</div><p id="id-2">Why so cheap?</p>"""
 
-      cmds.onNext(ChildCommand.MoveId(ChildId.Key("question-2"), 0))
+      cmds.onNext(ChildCommand.MoveId(ChildCommand.ChildId.Key("question-2"), 0))
       element.innerHTML shouldBe """<p id="id-2">Why so cheap?</p><div>spam</div>"""
 
       sendEvent(document.getElementById("id-2"), "click")


### PR DESCRIPTION
We currently have `outwatch.dom.ChildId` defined for ChildCommands, which will be imported in many applications using outwatch (`import outwatch.dom._`). It occupies a very generic name, but it has a very specific usecase only for ChildCommands.

So, I have moved the `ChildId` type to the ChildCommand object.