### PR TITLE
Fix typo in example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ div("Hello ", "World")
 #### Nesting
 ```scala
 div(span("Hey ", b("you"), "!"))
-// <div>Hey <b>you</b>!</div>
+// <div><span>Hey <b>you</b>!</span></div>
 ```
 
 


### PR DESCRIPTION
Nesting example meant to show nesting, drops an inner tag level.