### PR TITLE
add EmitterBuilder.ofNode and mapEmitter

### DIFF
--- a/outwatch/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
+++ b/outwatch/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
@@ -80,19 +80,21 @@ object EmitterBuilder {
   }
 
   implicit class ModifierActions[O](val builder: EmitterBuilder[O, VDomModifier]) extends AnyVal {
-    def useLatest[T](emitter: EmitterBuilder[T, VDomModifier]): EmitterBuilder[T, VDomModifier] = new CustomEmitterBuilder[T, VDomModifier]({ sink =>
+    def withLatest[T](emitter: EmitterBuilder[T, VDomModifier]): EmitterBuilder[(O, T), VDomModifier] = new CustomEmitterBuilder[(O, T), VDomModifier]({ sink =>
       IO {
         var lastValue: js.UndefOr[T] = js.undefined
         VDomModifier(
           emitter foreach { lastValue = _ },
-          builder.foreach { _ =>
+          builder.foreach { o =>
             lastValue.foreach { t =>
-              sink.onNext(t)
+              sink.onNext((o, t))
             }
           }
         )
       }
     })
+
+    def useLatest[T](emitter: EmitterBuilder[T, VDomModifier]): EmitterBuilder[T, VDomModifier] = withLatest(emitter).map(_._2)
   }
 }
 


### PR DESCRIPTION
This makes EmitterBuilders more useful. You can have an `EmitterBuilder[X, VNode]` via `EmitterBuilder.ofNode`. For VDomModifier, you can still use `EmitterBuilder.ofModifier`. Additionally, you may map over the result of an `EmitterBuilder` via `mapEmitter`.

~~We are restricting the EmitterBuilders to these two types, because we might need to handle a monix subscription when using observable-based EmitterBuilder transformations. And we can nicely handle these subscriptions for Nodes and Modifiers by using lifetime hooks. We could probably add another `EmitterBuilder.custom` method to have any type while handling the subscription yourself. But I am not sure whether this is really needed, because EmitterBuilders are usually used for Modifiers.~~

Update: I have added `EmitterBuilder.custom`:

```scala
def custom[E, R](f: ConnectableObserver[E] => R): EmitterBuilder[E,R]
```

So, `ConnectableObserver` is an observer that needs a subscription. Not every usage of an Emitterbuilders yields a subscription, but if you call `.transform` on the usage site, you will need a subscription for the observer to work. So, this interface just lets you handle this case every time. You can just run the subscription via `observer.connect(): Cancelable` which needs an implicit Scheduler.