### PR TITLE
Make outwatch work with scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ inThisBuild(Seq(
 
   scalaVersion := "2.12.6",
 
-  crossScalaVersions := Seq("2.11.12", "2.12.6"),
+  crossScalaVersions := Seq("2.11.12", "2.12.6", "2.13.0-M5"),
 
   licenses += ("Apache 2", url("https://www.apache.org/licenses/LICENSE-2.0.txt")),
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.14.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")


### PR DESCRIPTION
Notify me if there is anything I missed.  
Since the lib does not contain any custom collection implementations, staying on `2.12` for the build should be fine.