### PR TITLE
Rename thunk methods

### DIFF
--- a/outwatch/src/main/scala/outwatch/dom/VDomModifier.scala
+++ b/outwatch/src/main/scala/outwatch/dom/VDomModifier.scala
@@ -84,8 +84,8 @@ sealed trait BasicVNode extends VNode {
   def apply(args: VDomModifier*): BasicVNode
   def prepend(args: VDomModifier*): BasicVNode
   def thunk(key: Key.Value)(arguments: Any*)(renderFn: => VDomModifier): ThunkVNode = ThunkVNode(this, key, arguments.toJSArray, () => renderFn)
-  def conditional(key: Key.Value)(shouldRender: Boolean)(renderFn: => VDomModifier): ConditionalVNode = ConditionalVNode(this, key, shouldRender, () => renderFn)
-  @inline def static(key: Key.Value)(renderFn: => VDomModifier): ConditionalVNode = conditional(key)(false)(renderFn)
+  def thunkConditional(key: Key.Value)(shouldRender: Boolean)(renderFn: => VDomModifier): ConditionalVNode = ConditionalVNode(this, key, shouldRender, () => renderFn)
+  @inline def thunkStatic(key: Key.Value)(renderFn: => VDomModifier): ConditionalVNode = thunkConditional(key)(false)(renderFn)
 }
 final case class ThunkVNode(baseNode: BasicVNode, key: Key.Value, arguments: js.Array[Any], renderFn: () => VDomModifier) extends VNode {
   def apply(args: VDomModifier*): ThunkVNode = copy(baseNode = baseNode(args))

--- a/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -2231,7 +2231,7 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
     val node = div(
       id := "strings",
       myThunk.map { _ =>
-        b.static("component") {
+        b.thunkStatic("component") {
           renderFnCounter += 1
           myString.map { str =>
             p(dsl.key := str, str)
@@ -2399,7 +2399,7 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
       id := "strings",
       myThunk.map { _ =>
         div(
-          b.static("component") {
+          b.thunkStatic("component") {
             renderFnCounter += 1
             myString.map { str =>
               div(
@@ -2843,7 +2843,7 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
         myList.map(_.indices.map { i =>
           val counter = renderFnCounter
           renderFnCounter += 1
-          div.static(i) {
+          div.thunkStatic(i) {
 
             val node = myList.map { list => list(i) }
             val syncedIcon = isSynced.map { isSynced =>


### PR DESCRIPTION
We have `thunk`, `thunkConditional` and `thunkStatic`. This PR renames `conditional` and `static` methods to make more clear that these methods are using thunks as well.

* `thunk(key)(dependencies*)(modifier)`
* `conditional` -> `thunkConditional(key)(shouldRender)(modifier)`
* `static` -> `thunkStatic(key)(modifier)`