### PR TITLE
fix order of store emissions for observable actions

### DIFF
--- a/outwatch/src/test/scala/outwatch/StoreSpec.scala
+++ b/outwatch/src/test/scala/outwatch/StoreSpec.scala
@@ -3,7 +3,9 @@ package outwatch
 import monix.execution.ExecutionModel.SynchronousExecution
 import monix.execution.Scheduler
 import monix.execution.schedulers.TrampolineScheduler
-import org.scalatest.{FlatSpec, Matchers}
+import monix.reactive.Observable
+import org.scalatest.{AsyncFlatSpec, FlatSpec, Matchers}
+import outwatch.util.Store.Reducer
 import outwatch.util._
 
 class StoreSpec extends FlatSpec with Matchers {
@@ -42,7 +44,7 @@ class StoreSpec extends FlatSpec with Matchers {
 
   }
 
-  "A Store" should "emit consecutive states to multiple subscribers" in {
+  it should "emit consecutive states to multiple subscribers" in {
     val store = Store.create(Initial, 0, reduce _).unsafeRunSync()
 
     var a: Option[Model] = None
@@ -69,7 +71,7 @@ class StoreSpec extends FlatSpec with Matchers {
     }
   }
 
-  "A Store" should "emit its current state to new subscribers" in {
+  it should "emit its current state to new subscribers" in {
     val store = Store.create(Initial, 0, reduce _).unsafeRunSync()
 
     for (i <- 1 to 10)
@@ -88,5 +90,38 @@ class StoreSpec extends FlatSpec with Matchers {
 
     a shouldBe Some(10)
     b shouldBe Some(10)
+  }
+}
+
+class AsyncStoreSpec extends AsyncFlatSpec with Matchers {
+  implicit val scheduler = TrampolineScheduler(Scheduler.global, SynchronousExecution)
+
+  "A Store" should "emit action effects in order " in {
+    val reduce: Reducer[Int, Int] = new Reducer[Int, Int]({
+      case (state, 5) => (100, Observable(1, 2, 3))
+      case (state, action) => (state + action, Observable.empty)
+    })
+
+    val store = Store.create[Int, Int](0, 0, reduce).unsafeRunSync()
+
+    val storeList = store.toListL.runToFuture
+    for {
+      _ <- store.onNext(5)
+      _ <- store.onNext(13)
+      _ <- store.onNext(5)
+      _ = store.onComplete()
+      storeList <- storeList
+    } yield storeList shouldBe List(
+      (0,0),
+      (5,100),
+      (1,101),
+      (2,103),
+      (3,106),
+      (13,119),
+      (5,100),
+      (1,101),
+      (2,103),
+      (3,106)
+    )
   }
 }


### PR DESCRIPTION
I have changed the way store reduces observable actions in the Store. Previously the order of actions and the resulting state would not be deterministic leading to wrong results. Now, we use `flatScan` to force an order on the store emissions.

On another note: I would love to get rid of the subscribe and cancel on the first subscription (https://github.com/cornerman/outwatch/blob/3601d6cc63a5e6ef9a522fb713acdad98e9fa4a3/outwatch/src/main/scala/outwatch/util/Store.scala#L86). It fixes the obvious problem that late observer get the correct latest value from Store. But what if I suscribe, unsubscribe, and then again subscribe. Action send to store between the unsubscribe and the second subscribe would still be lost. Any ideas what we could? Does it make sense to make the store observable hot and give a way to the user cancel the store alltogether?

@Busti Can you check, whether this fixes the problem for you?

fixes #289