### PR TITLE
Fix warnings

### DIFF
--- a/bench/src/main/scala/Performance.scala
+++ b/bench/src/main/scala/Performance.scala
@@ -6,7 +6,7 @@ import monix.execution.ExecutionModel.SynchronousExecution
 import monix.execution.schedulers.TrampolineScheduler
 import monix.execution.Scheduler
 
-import org.scalajs.dom.{document, window}
+import org.scalajs.dom.document
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 

--- a/outwatch/src/main/scala/outwatch/dom/OutwatchAttributes.scala
+++ b/outwatch/src/main/scala/outwatch/dom/OutwatchAttributes.scala
@@ -25,7 +25,10 @@ trait OutWatchLifeCycleAttributes {
   private def proxyElementPairEmitter(f: js.Function2[VNodeProxy, VNodeProxy, Unit] => VDomModifier): Observer[(dom.Element, dom.Element)] => VDomModifier =
     obs => f((o,p) => o.elm.foreach(oe => p.elm.foreach(pe => obs.onNext((oe,pe)))))
   private def proxyElementPairOptionEmitter(f: js.Function2[VNodeProxy, VNodeProxy, Unit] => VDomModifier): Observer[(Option[dom.Element], Option[dom.Element])] => VDomModifier =
-    obs => f((o,p) => obs.onNext((o.elm.toOption, p.elm.toOption)))
+    obs => f((o,p) => {
+      obs.onNext((o.elm.toOption, p.elm.toOption))
+      ()
+    })
 
   lazy val onDomMount: SyncEmitterBuilder[dom.Element, VDomModifier] = EmitterBuilder.ofModifier(proxyElementEmitter(DomMountHook))
   lazy val onDomUnmount: SyncEmitterBuilder[dom.Element, VDomModifier] = EmitterBuilder.ofModifier(proxyElementEmitter(DomUnmountHook))

--- a/outwatch/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
+++ b/outwatch/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala
@@ -3,7 +3,6 @@ package outwatch.dom.helpers
 import cats.{Monoid, Functor, Bifunctor}
 import cats.effect.IO
 import monix.execution.{Cancelable, Scheduler}
-import monix.reactive.observers.Subscriber
 import monix.reactive.{Observable, Observer, OverflowStrategy}
 import org.scalajs.dom.{Element, Event, html, svg}
 import outwatch.ConnectableObserver
@@ -34,7 +33,13 @@ trait EmitterBuilder[+O, +R] { self =>
 }
 
 object EmitterBuilder {
-  @inline def apply[E <: Event](eventType: String): CustomEmitterBuilder[E, VDomModifier] = ofModifier[E](obs => Emitter(eventType, event => obs.onNext(event.asInstanceOf[E])))
+  @inline def apply[E <: Event](eventType: String): CustomEmitterBuilder[E, VDomModifier] = ofModifier[E](obs => 
+    Emitter(
+      eventType, 
+      event => {
+        obs.onNext(event.asInstanceOf[E])
+        ()
+      }))
 
   @inline def fromObservable[E](observable: Observable[E]): EmitterBuilder[E, VDomModifier] = new ObservableEmitterBuilder[E, VDomModifier](observable, managedAction)
 

--- a/outwatch/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
+++ b/outwatch/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
@@ -1,6 +1,5 @@
 package outwatch.dom.helpers
 
-import monix.execution.Ack.Continue
 import monix.execution.{Ack, Cancelable, Scheduler}
 import monix.reactive.{Observable, OverflowStrategy}
 import monix.reactive.subjects.PublishSubject

--- a/outwatch/src/main/scala/outwatch/util/Store.scala
+++ b/outwatch/src/main/scala/outwatch/util/Store.scala
@@ -86,15 +86,14 @@ object Store {
       }).get
     }
 
-    val sub = subject.subscribe()
-    subject.doOnSubscribeF(Task(sub.cancel))
-
     val out = subject.transformObservable(source =>
       source
         .scan0[(A, M)](initialAction -> initialState)(fold)
         .replay(1).refCount
     )
 
+    val sub = out.subscribe()
+    out.doOnSubscribeF(Task(sub.cancel))
 
     out
   }

--- a/outwatch/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/outwatch/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -1,6 +1,5 @@
 package outwatch
 
-import cats.effect.IO
 import monix.execution.Ack.Continue
 import monix.reactive.Observable
 import monix.reactive.subjects.PublishSubject

--- a/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -8,8 +8,8 @@ import org.scalajs.dom.window.localStorage
 import org.scalajs.dom.{document, html, Element}
 import outwatch.Deprecated.IgnoreWarnings.initEvent
 import outwatch.dom._
-import monix.execution.Ack.Continue
-import monix.reactive.{Observable, Observer}
+import monix.reactive.Observable
+import monix.reactive.Observer
 import outwatch.dom.helpers._
 import outwatch.dom.dsl._
 import outwatch.dom.helpers._
@@ -2066,8 +2066,6 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
     lastValue shouldBe null
 
     OutWatch.renderInto("#app", node).map { _ =>
-      val element = document.getElementById("strings")
-      val child = element.children(0)
       aCounter shouldBe 0
       bCounter shouldBe 0
       lastValue shouldBe null
@@ -2819,7 +2817,6 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
     )
 
     OutWatch.renderInto("#app", node).unsafeToFuture.flatMap { _ =>
-      val element = document.getElementById("strings")
       val editButton = document.getElementById("edit-button")
 
       for {
@@ -2869,7 +2866,6 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
     )
 
     OutWatch.renderInto("#app", node).unsafeToFuture.flatMap { _ =>
-      val element = document.getElementById("strings")
       val editButton = document.getElementById("edit-button")
 
       for {
@@ -2911,11 +2907,11 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
       _ = element.innerHTML shouldBe ""
 
       _ = sendEvent(element, "mousedown")
-      _ <- monix.eval.Task.unit.delayResult(0.1 seconds).toIO
+      _ <- monix.eval.Task.unit.delayResult(0.1 seconds).to[IO]
       _ = element.innerHTML shouldBe "yes"
 
       _ = sendEvent(element, "mouseup")
-      _ <- monix.eval.Task.unit.delayResult(0.1 seconds).toIO
+      _ <- monix.eval.Task.unit.delayResult(0.1 seconds).to[IO]
       _ = element.innerHTML shouldBe "no"
     } yield succeed
   }
@@ -2948,11 +2944,11 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
       _ = element.innerHTML shouldBe ""
 
       _ = sendEvent(element, "mousedown")
-      _ <- monix.eval.Task.unit.delayResult(0.1 seconds).toIO
+      _ <- monix.eval.Task.unit.delayResult(0.1 seconds).to[IO]
       _ = element.innerHTML shouldBe "yes"
 
       _ = sendEvent(element, "mouseup")
-      _ <- monix.eval.Task.unit.delayResult(0.1 seconds).toIO
+      _ <- monix.eval.Task.unit.delayResult(0.1 seconds).to[IO]
       _ = element.innerHTML shouldBe "no"
     } yield succeed
   }

--- a/outwatch/src/test/scala/outwatch/OutwatchSpec.scala
+++ b/outwatch/src/test/scala/outwatch/OutwatchSpec.scala
@@ -30,25 +30,23 @@ trait LocalStorageMock {
 
 
   if (js.isUndefined(window.localStorage)) {
-    js.Dynamic.global.window.updateDynamic("localStorage")(new js.Object {
+    val storageObject = new js.Object {
       private val map = new mutable.HashMap[String, String]
 
-      @SuppressWarnings(Array("unused"))
       def getItem(key: String): String = map.getOrElse(key, null)
 
-      @SuppressWarnings(Array("unused"))
       def setItem(key: String, value: String): Unit = {
         map += key -> value
       }
 
-      @SuppressWarnings(Array("unused"))
       def removeItem(key: String): Unit = {
         map -= key
       }
 
-      @SuppressWarnings(Array("unused"))
       def clear(): Unit = map.clear()
-    })
+    }
+
+    js.Dynamic.global.window.updateDynamic("localStorage")(storageObject)
   }
 
   def dispatchStorageEvent(key: String, newValue: String, oldValue: String): Unit = {

--- a/outwatch/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/outwatch/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -22,7 +22,7 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
       handleMinus <- Handler.create[MouseEvent]
           plusOne = handlePlus.map(_ => 1)
          minusOne = handleMinus.map(_ => -1)
-            count = Observable.merge(plusOne, minusOne).scan(0)(_ + _).startWith(Seq(0))
+            count = Observable(plusOne, minusOne).merge.scan(0)(_ + _).startWith(Seq(0))
 
              node = div(div(
                         button(id := "plus", "+", onClick --> handlePlus),


### PR DESCRIPTION
Most of these warnings are monix deprecation warnings brought in by #320 

A couple of them are a little suspect, as they appeared as discarded non-unit value warnings:

```scala
object EmitterBuilder {
  @inline def apply[E <: Event](eventType: String): CustomEmitterBuilder[E, VDomModifier] = ofModifier[E](obs => 
    Emitter(
      eventType, 
      event => {
        obs.onNext(event.asInstanceOf[E])
        ()
      }))
```

`onNext` creates a future, but I don't see any way that this future is waited on, as it's not returned or awaited.  Not suggesting it should be awaited here, just unclear to me how this sideeffect is ok in this context.

Below are a bunch of warnings that have been fixed:
```scala
sbt:OutWatch> test
[info] Updating ...
[info] Done updating.
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] Compiling 30 Scala sources to /home/projects/oss/outwatch/outwatch/target/scala-2.12/classes ...
[warn] /home/projects/oss/outwatch/outwatch/src/main/scala/outwatch/dom/OutwatchAttributes.scala:28:33: discarded non-Unit value
[warn]     obs => f((o,p) => obs.onNext((o.elm.toOption, p.elm.toOption)))
[warn]                                 ^
[warn] /home/projects/oss/outwatch/outwatch/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala:37:152: discarded non-Unit value
[warn]   @inline def apply[E <: Event](eventType: String): CustomEmitterBuilder[E, VDomModifier] = ofModifier[E](obs => Emitter(eventType, event => obs.onNext(event.asInstanceOf[E])))
[warn]                                                                                                                                                        ^
[warn] /home/projects/oss/outwatch/outwatch/src/main/scala/outwatch/dom/helpers/EmitterBuilder.scala:6:33: Unused import
[warn] import monix.reactive.observers.Subscriber
[warn]                                 ^
[warn] /home/projects/oss/outwatch/outwatch/src/main/scala/outwatch/dom/helpers/Snabbdom.scala:3:28: Unused import
[warn] import monix.execution.Ack.Continue
[warn]                            ^
[warn] /home/projects/oss/outwatch/outwatch/src/main/scala/outwatch/util/Store.scala:49:74: method fromIO in trait ObservableDeprecatedBuilders is deprecated (since 3.0.0): Switch to Observable.from
[warn]       (newState, effect.fold[Observable[A]](Observable.empty)(Observable.fromIO))
[warn]                                                                          ^
[warn] 5 warnings found
[info] Done compiling.
[info] Compiling 10 Scala sources to /home/projects/oss/outwatch/outwatch/target/scala-2.12/test-classes ...
[warn] /home/projects/oss/outwatch/outwatch/src/test/scala/outwatch/LifecycleHookSpec.scala:3:20: Unused import
[warn] import cats.effect.IO
[warn]                    ^
[warn] /home/projects/oss/outwatch/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala:11:28: Unused import
[warn] import monix.execution.Ack.Continue
[warn]                            ^
[warn] /home/projects/oss/outwatch/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala:2070:11: local val child in value $anonfun is never used
[warn]       val child = element.children(0)
[warn]           ^
[warn] /home/projects/oss/outwatch/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala:2822:11: local val element in value $anonfun is never used
[warn]       val element = document.getElementById("strings")
[warn]           ^
[warn] /home/projects/oss/outwatch/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala:2872:11: local val element in value $anonfun is never used
[warn]       val element = document.getElementById("strings")
[warn]           ^
[warn] /home/projects/oss/outwatch/outwatch/src/test/scala/outwatch/OutwatchSpec.scala:37:11: private method getItem in <$anon: scala.scalajs.js.Object> is never used
[warn]       def getItem(key: String): String = map.getOrElse(key, null)
[warn]           ^
[warn] /home/projects/oss/outwatch/outwatch/src/test/scala/outwatch/OutwatchSpec.scala:40:11: private method setItem in <$anon: scala.scalajs.js.Object> is never used
[warn]       def setItem(key: String, value: String): Unit = {
[warn]           ^
[warn] /home/projects/oss/outwatch/outwatch/src/test/scala/outwatch/OutwatchSpec.scala:45:11: private method removeItem in <$anon: scala.scalajs.js.Object> is never used
[warn]       def removeItem(key: String): Unit = {
[warn]           ^
[warn] /home/projects/oss/outwatch/outwatch/src/test/scala/outwatch/OutwatchSpec.scala:50:11: private method clear in <$anon: scala.scalajs.js.Object> is never used
[warn]       def clear(): Unit = map.clear()
[warn]           ^
[warn] /home/projects/oss/outwatch/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala:2914:58: method toIO in trait Extensions is deprecated (since 3.0.0-RC3): Switch to task.to[IO]
[warn]       _ <- monix.eval.Task.unit.delayResult(0.1 seconds).toIO
[warn]                                                          ^
[warn] /home/projects/oss/outwatch/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala:2918:58: method toIO in trait Extensions is deprecated (since 3.0.0-RC3): Switch to task.to[IO]
[warn]       _ <- monix.eval.Task.unit.delayResult(0.1 seconds).toIO
[warn]                                                          ^
[warn] /home/projects/oss/outwatch/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala:2951:58: method toIO in trait Extensions is deprecated (since 3.0.0-RC3): Switch to task.to[IO]
[warn]       _ <- monix.eval.Task.unit.delayResult(0.1 seconds).toIO
[warn]                                                          ^
[warn] /home/projects/oss/outwatch/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala:2955:58: method toIO in trait Extensions is deprecated (since 3.0.0-RC3): Switch to task.to[IO]
[warn]       _ <- monix.eval.Task.unit.delayResult(0.1 seconds).toIO
[warn]                                                          ^
[warn] /home/projects/oss/outwatch/outwatch/src/test/scala/outwatch/ScenarioTestSpec.scala:25:32: method merge in trait ObservableDeprecatedBuilders is deprecated (since 3.0.0): Switch to Observable(list).merge
[warn]             count = Observable.merge(plusOne, minusOne).scan(0)(_ + _).startWith(Seq(0))
[warn]                                ^
[warn] 14 warnings found
[info] Done compiling.
```