### PR TITLE
Remove impurity around creation of a store

### DIFF
--- a/outwatch/src/main/scala/outwatch/util/Store.scala
+++ b/outwatch/src/main/scala/outwatch/util/Store.scala
@@ -55,7 +55,6 @@ object Store {
    * @param initialAction The Stores initial action. Useful for re-creating a store from memory.
    * @param initialState The stores initial state. Similar to the initial accumulator on a fold / scan.
    * @param reducer The Reducing funcion. Creates a new State from the previous state and an Action.
-   * @param recoverError An optional PartialFunctio for recovering the State when an Exception occurs in the Recuer.
    * @return An Observable emitting a tuple of the current state and the action that caused that state.
    */
   def create[F[_]: Sync, A, M](

--- a/outwatch/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/outwatch/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -75,7 +75,7 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
     }
 
     val node: IO[VNode] = for {
-      store <- Store.create[CounterAction, CounterModel](Initial, CounterModel(0, 0), reduce _)
+      store <- Store.create[IO, CounterAction, CounterModel](Initial, CounterModel(0, 0), reduce _)
       state = store.collect { case (action@_, state) => state }
     } yield div(
       div(

--- a/outwatch/src/test/scala/outwatch/StoreSpec.scala
+++ b/outwatch/src/test/scala/outwatch/StoreSpec.scala
@@ -1,5 +1,6 @@
 package outwatch
 
+import cats.effect.IO
 import monix.execution.ExecutionModel.SynchronousExecution
 import monix.execution.Scheduler
 import monix.execution.schedulers.TrampolineScheduler
@@ -24,7 +25,7 @@ class StoreSpec extends FlatSpec with Matchers {
   }
 
   "A Store" should "emit its initial state to multiple subscribers" in {
-    val store = Store.create(Initial, 0, reduce _).unsafeRunSync()
+    val store = Store.create[IO, CounterAction, Model](Initial, 0, reduce _).unsafeRunSync()
 
     var a: Option[Model] = None
     var b: Option[Model] = None
@@ -43,7 +44,7 @@ class StoreSpec extends FlatSpec with Matchers {
   }
 
   "A Store" should "emit consecutive states to multiple subscribers" in {
-    val store = Store.create(Initial, 0, reduce _).unsafeRunSync()
+    val store = Store.create[IO, CounterAction, Model](Initial, 0, reduce _).unsafeRunSync()
 
     var a: Option[Model] = None
     var b: Option[Model] = None
@@ -70,7 +71,7 @@ class StoreSpec extends FlatSpec with Matchers {
   }
 
   "A Store" should "emit its current state to new subscribers" in {
-    val store = Store.create(Initial, 0, reduce _).unsafeRunSync()
+    val store = Store.create[IO, CounterAction, Model](Initial, 0, reduce _).unsafeRunSync()
 
     for (i <- 1 to 10)
       store.onNext(Plus)


### PR DESCRIPTION
The use of Try / catchNonFatal / recover / get, is basically
a debug println. Here I simply remove this usage, and allow
the MonadError[F, Throwable] of Sync[F] to handle any thrown
exceptions.

I think the intention of the deleted code is primarily to log exceptions thrown by the passed reducer. This is the responsibility of the caller/creator of the store, and thus should be handled if necessary by the caller.