### PR TITLE
Fix more unused parameter warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+import Options._
+
+
 inThisBuild(Seq(
   version := "0.11.1-SNAPSHOT",
 
@@ -20,48 +23,19 @@ inThisBuild(Seq(
 
 lazy val commonSettings = Seq(
   addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
-
   scalacOptions += {
     val local = baseDirectory.value.toURI
     val remote = s"https://raw.githubusercontent.com/OutWatch/outwatch/${git.gitHeadCommit.value.get}/"
     s"-P:scalajs:mapSourceURI:$local->$remote"
   },
-
-  scalacOptions ++=
-    "-encoding" :: "UTF-8" ::
-    "-unchecked" ::
-    "-deprecation" ::
-    "-explaintypes" ::
-    "-feature" ::
-    "-language:_" ::
-    "-Xfuture" ::
-    "-Xlint" ::
-    "-Ypartial-unification" ::
-    "-Yno-adapted-args" ::
-    "-Ywarn-infer-any" ::
-    "-Ywarn-value-discard" ::
-    "-Ywarn-nullary-override" ::
-    "-Ywarn-nullary-unit" ::
-    "-P:scalajs:sjsDefinedByDefault" ::
-    Nil,
-
-  scalacOptions ++= {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 12)) =>
-        "-Ywarn-extra-implicit" ::
-        "-Ywarn-unused:-explicits,-implicits,_" ::
-        Nil
-      case _             =>
-        "-Ywarn-unused" ::
-        "-Xexperimental" ::   // SAM conversion
-        Nil
-    }
-  }
 )
 
 lazy val outwatch = project
+  .in(file("outwatch"))
   .enablePlugins(ScalaJSPlugin, ScalaJSBundlerPlugin)
   .settings(commonSettings)
+  .settings(scalacOptions := allOptionsForVersion(scalaVersion.value, true))
+  .settings(scalacOptions in (Compile, console) := allOptionsForVersionConsole(scalaVersion.value))
   .settings(
     name := "OutWatch",
     normalizedName := "outwatch",
@@ -73,7 +47,9 @@ lazy val outwatch = project
       "org.typelevel" %%% "cats-core" % "1.6.0",
       "org.typelevel" %%% "cats-effect" % "1.3.0",
 
-      "org.scalatest" %%% "scalatest" % "3.0.8" % Test
+      "org.scalatest" %%% "scalatest" % "3.0.8" % Test,
+      compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.4.3" cross CrossVersion.full),
+      "com.github.ghik" % "silencer-lib" % "1.4.3" % Provided cross CrossVersion.full,
     ),
 
     npmDependencies in Compile ++= Seq(
@@ -107,7 +83,6 @@ lazy val outwatch = project
 
 lazy val bench = project
   .enablePlugins(ScalaJSPlugin, ScalaJSBundlerPlugin)
-  .settings(commonSettings)
   .dependsOn(outwatch)
   .settings(
     publish := {},

--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,12 @@ lazy val outwatch = project
   .in(file("outwatch"))
   .enablePlugins(ScalaJSPlugin, ScalaJSBundlerPlugin)
   .settings(commonSettings)
-  .settings(scalacOptions := allOptionsForVersion(scalaVersion.value, true))
-  .settings(scalacOptions in (Compile, console) := allOptionsForVersionConsole(scalaVersion.value))
+  .settings(scalacOptions ++=
+    CrossVersion.partialVersion(scalaVersion.value).map(v =>
+      allOptionsForVersion(s"${v._1}.${v._2}", true)
+    ).getOrElse(Nil)
+  )
+  .settings(scalacOptions in (Compile, console) ~= (_.diff(badConsoleFlags)))
   .settings(
     name := "OutWatch",
     normalizedName := "outwatch",

--- a/outwatch/src/main/scala/outwatch/MonixOps.scala
+++ b/outwatch/src/main/scala/outwatch/MonixOps.scala
@@ -1,6 +1,6 @@
 package outwatch
 
-import monix.execution.{Ack, Scheduler}
+import monix.execution.Ack
 import monix.reactive.subjects.PublishSubject
 import monix.reactive.{Observable, Observer}
 
@@ -52,7 +52,7 @@ trait MonixOps {
   }
 
   implicit class RichHandler[T](self: Handler[T]) {
-    def lens[S](seed: T)(read: T => S)(write: (T, S) => T)(implicit scheduler: Scheduler): Handler[S] with ReactiveConnectable = {
+    def lens[S](seed: T)(read: T => S)(write: (T, S) => T): Handler[S] with ReactiveConnectable = {
       val redirected = self
         .redirect[S](_.withLatestFrom(self.startWith(Seq(seed))){ case (a, b) => write(b, a) })
 

--- a/outwatch/src/main/scala/outwatch/dom/helpers/DomUtils.scala
+++ b/outwatch/src/main/scala/outwatch/dom/helpers/DomUtils.scala
@@ -29,7 +29,7 @@ private[outwatch] class SeparatedModifiers(
   val nextModifiers: js.UndefOr[js.Array[StaticVDomModifier]])
 
 private[outwatch] object SeparatedModifiers {
-  def from(modifiers: js.Array[StaticVDomModifier])(implicit scheduler: Scheduler): SeparatedModifiers = {
+  def from(modifiers: js.Array[StaticVDomModifier]): SeparatedModifiers = {
     var hasOnlyTextChildren = true
     var nextModifiers: js.UndefOr[js.Array[StaticVDomModifier]] = js.undefined
     var proxies: js.UndefOr[js.Array[VNodeProxy]] = js.undefined

--- a/outwatch/src/main/scala/outwatch/dom/helpers/NativeHelpers.scala
+++ b/outwatch/src/main/scala/outwatch/dom/helpers/NativeHelpers.scala
@@ -1,10 +1,12 @@
 package outwatch.dom.helpers
 
+import com.github.ghik.silencer.silent
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSBracketAccess
 
 @js.native
 private[outwatch] trait DictionaryRawApply[A] extends js.Object {
+  @silent("never used|dead code")
   @JSBracketAccess
   def apply(key: String): js.UndefOr[A] = js.native
 }

--- a/outwatch/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
+++ b/outwatch/src/main/scala/outwatch/dom/helpers/Snabbdom.scala
@@ -37,7 +37,7 @@ private[outwatch] object SnabbdomOps {
       ns = vNodeNS
     }
 
-  @inline private def createProxy(modifiers: SeparatedModifiers, nodeType: String, vNodeId: js.UndefOr[Int], vNodeNS: js.UndefOr[String])(implicit scheduler: Scheduler): VNodeProxy = {
+  @inline private def createProxy(modifiers: SeparatedModifiers, nodeType: String, vNodeId: js.UndefOr[Int], vNodeNS: js.UndefOr[String]): VNodeProxy = {
     val dataObject = createDataObject(modifiers, vNodeNS)
 
     @inline def newProxy(childProxies: js.UndefOr[js.Array[VNodeProxy]], string: js.UndefOr[String]) = new VNodeProxy {

--- a/outwatch/src/main/scala/outwatch/http/Http.scala
+++ b/outwatch/src/main/scala/outwatch/http/Http.scala
@@ -85,7 +85,7 @@ object Http {
   private def requestWithUrl(urls: Observable[String], requestType: HttpRequestType)(implicit s: Scheduler) =
     request(urls.map(url => Request(url)), requestType: HttpRequestType)
 
-  def single(request: Request, method: HttpRequestType)(implicit s: Scheduler): IO[Response] =
+  def single(request: Request, method: HttpRequestType): IO[Response] =
     IO.fromFuture(IO(ajax(request.copy(method = method.toString)))).map(toResponse)
 
   def getWithUrl(urls: Observable[String])(implicit s: Scheduler) = requestWithUrl(urls, Get)

--- a/outwatch/src/main/scala/outwatch/util/LocalStorage.scala
+++ b/outwatch/src/main/scala/outwatch/util/LocalStorage.scala
@@ -33,7 +33,7 @@ class Storage(domStorage: dom.Storage) {
     }
   }
 
-  private def storageEventsForKey(key: String)(implicit scheduler: Scheduler): Observable[Option[String]] =
+  private def storageEventsForKey(key: String): Observable[Option[String]] =
     // StorageEvents are only fired if the localStorage was changed in another window
     events.window.onStorage.collect {
       case e: StorageEvent if e.storageArea == domStorage && e.key == key =>
@@ -51,7 +51,7 @@ class Storage(domStorage: dom.Storage) {
 
   def handlerWithEventsOnly(key: String)(implicit scheduler: Scheduler): IO[Handler[Option[String]]] = {
     val storageEvents = storageEventsForKey(key)
-    subjectWithTransform(key, o => storageEvents)
+    subjectWithTransform(key, _ => storageEvents)
   }
 
   def handler(key: String)(implicit scheduler: Scheduler): IO[Handler[Option[String]]] = {

--- a/outwatch/src/main/scala/outwatch/util/WebSocket.scala
+++ b/outwatch/src/main/scala/outwatch/util/WebSocket.scala
@@ -2,7 +2,7 @@ package outwatch.util
 
 import cats.effect.IO
 import monix.execution.Ack.Continue
-import monix.execution.{Ack, Cancelable, Scheduler}
+import monix.execution.{Ack, Cancelable}
 import monix.reactive.OverflowStrategy.Unbounded
 import monix.reactive.{Observable, Observer}
 import org.scalajs.dom.{CloseEvent, Event, MessageEvent}
@@ -14,7 +14,7 @@ object WebSocket {
   implicit def toObservable(socket: WebSocket): Observable[MessageEvent] = socket.observable
 }
 
-final case class WebSocket private(url: String)(implicit s: Scheduler) {
+final case class WebSocket private(url: String) {
   val ws = new org.scalajs.dom.WebSocket(url)
 
   @deprecated("use observable instead", "")
@@ -22,7 +22,7 @@ final case class WebSocket private(url: String)(implicit s: Scheduler) {
   lazy val observable:Observable[MessageEvent] = Observable.create[MessageEvent](Unbounded)(observer => {
     ws.onmessage = (e: MessageEvent) => observer.onNext(e)
     ws.onerror = (e: Event) => observer.onError(new Exception(s"Error in WebSocket: $e"))
-    ws.onclose = (e: CloseEvent) => observer.onComplete()
+    ws.onclose = (_: CloseEvent) => observer.onComplete()
     Cancelable(() => ws.close())
   })
 

--- a/outwatch/src/main/scala/snabbdom/hFunction.scala
+++ b/outwatch/src/main/scala/snabbdom/hFunction.scala
@@ -1,17 +1,22 @@
 package snabbdom
 
+import com.github.ghik.silencer.silent
 import org.scalajs.dom._
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 import scala.scalajs.js.|
 
+
+
+@silent("dead code")
 @js.native
 @JSImport("snabbdom/h", JSImport.Namespace, globalFallback = "h")
 object hProvider extends js.Object {
   val default: hFunction = js.native
 }
 
+@silent
 @js.native
 trait hFunction extends js.Any {
   def apply(nodeType: String, dataObject: DataObject): VNodeProxy = js.native
@@ -220,34 +225,40 @@ object VNodeProxy {
 @js.native
 @JSImport("snabbdom", JSImport.Namespace, globalFallback = "snabbdom")
 object Snabbdom extends js.Object {
+  @silent("never used|dead code")
   def init(args: js.Array[Any]): js.Function2[Node | VNodeProxy, VNodeProxy, VNodeProxy] = js.native
 
 }
 
+@silent("unused|dead code")
 @js.native
 @JSImport("snabbdom/modules/class", JSImport.Namespace, globalFallback = "snabbdom_class")
 object SnabbdomClass extends js.Object {
   val default: js.Any = js.native
 }
 
+@silent("unused|dead code")
 @js.native
 @JSImport("snabbdom/modules/eventlisteners", JSImport.Namespace, globalFallback = "snabbdom_eventlisteners")
 object SnabbdomEventListeners extends js.Object{
   val default: js.Any = js.native
 }
 
+@silent("unused|dead code")
 @js.native
 @JSImport("snabbdom/modules/attributes", JSImport.Namespace, globalFallback = "snabbdom_attributes")
 object SnabbdomAttributes extends js.Object{
   val default: js.Any = js.native
 }
 
+@silent("unused|dead code")
 @js.native
 @JSImport("snabbdom/modules/props", JSImport.Namespace, globalFallback = "snabbdom_props")
 object SnabbdomProps extends js.Object{
   val default: js.Any = js.native
 }
 
+@silent("unused|dead code")
 @js.native
 @JSImport("snabbdom/modules/style", JSImport.Namespace, globalFallback = "snabbdom_style")
 object SnabbdomStyle extends js.Object {
@@ -255,6 +266,7 @@ object SnabbdomStyle extends js.Object {
 }
 
 
+@silent("unused")
 @js.native
 @JSImport("snabbdom/tovnode", JSImport.Default)
 object tovnode extends js.Function1[Element, VNodeProxy] {

--- a/outwatch/src/main/scala/snabbdom/hFunction.scala
+++ b/outwatch/src/main/scala/snabbdom/hFunction.scala
@@ -92,7 +92,7 @@ object thunk {
 
   private def initThunk(fn: () => VNodeProxy)(thunk: VNodeProxy): Unit = {
     for {
-      data <- thunk.data
+      _ <- thunk.data
     } {
       VNodeProxy.updateInto(source = fn(), target = thunk)
     }
@@ -266,7 +266,6 @@ object SnabbdomStyle extends js.Object {
 }
 
 
-@silent("unused")
 @js.native
 @JSImport("snabbdom/tovnode", JSImport.Default)
 object tovnode extends js.Function1[Element, VNodeProxy] {

--- a/outwatch/src/test/scala/outwatch/DomEventSpec.scala
+++ b/outwatch/src/test/scala/outwatch/DomEventSpec.scala
@@ -465,8 +465,8 @@ class DomEventSpec extends JSDomAsyncSpec {
 
     var docClicked = false
     var winClicked = false
-    events.window.onClick(ev => winClicked = true)
-    events.document.onClick(ev => docClicked = true)
+    events.window.onClick(_ => winClicked = true)
+    events.document.onClick(_ => docClicked = true)
 
     val node = div(button(id := "input", tpe := "checkbox"))
 
@@ -486,7 +486,7 @@ class DomEventSpec extends JSDomAsyncSpec {
 
   "EmitterOps" should "correctly work on events" in {
 
-    val node = Handler.create[String].flatMap { submit =>
+    val node = Handler.create[String].flatMap { _ =>
 
       for {
         stringStream <- Handler.create[String]

--- a/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/outwatch/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -13,7 +13,7 @@ import monix.reactive.Observer
 import outwatch.dom.helpers._
 import outwatch.dom.dsl._
 import outwatch.dom.helpers._
-import snabbdom.{DataObject, Hooks, hFunction}
+import snabbdom.{DataObject, Hooks, hFunction, VNodeProxy}
 import org.scalajs.dom.window.localStorage
 import org.scalatest.Assertion
 
@@ -23,6 +23,7 @@ import scala.scalajs.js
 import scala.scalajs.js.JSConverters._
 import scala.scalajs.js.JSON
 
+final case class Fixture(proxy: VNodeProxy)
 class OutWatchDomSpec extends JSDomAsyncSpec {
   implicit def ListToJsArray[T](list: Seq[T]): js.Array[T] = list.toJSArray
 
@@ -164,8 +165,8 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
     proxies.get.length shouldBe 1
   }
 
-  val fixture = new {
-    val proxy = hFunction(
+  val fixture = Fixture(
+    hFunction(
       "div",
       new DataObject {
         attrs = js.Dictionary[Attr.Value]("class" -> "red", "id" -> "msg")
@@ -173,7 +174,7 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
       },
       js.Array(hFunction("span", new DataObject { hook = Hooks.empty }, "Hello"))
     )
-  }
+  )
 
   it should "run effect modifiers once" in {
     val list = new collection.mutable.ArrayBuffer[String]
@@ -2822,9 +2823,9 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
       for {
         _ <- monix.eval.Task.unit.runToFuture
         _ = sendEvent(editButton, "click")
-        _ <- monix.eval.Task.unit.delayResult(1 seconds).runToFuture
+        _ <- monix.eval.Task.unit.delayResult(1.seconds).runToFuture
         _ = sendEvent(editButton, "click")
-        _ <- monix.eval.Task.unit.delayResult(1 seconds).runToFuture
+        _ <- monix.eval.Task.unit.delayResult(1.seconds).runToFuture
       } yield succeed
     }
   }
@@ -2871,9 +2872,9 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
       for {
         _ <- monix.eval.Task.unit.runToFuture
         _ = sendEvent(editButton, "click")
-        _ <- monix.eval.Task.unit.delayResult(1 seconds).runToFuture
+        _ <- monix.eval.Task.unit.delayResult(1.seconds).runToFuture
         _ = sendEvent(editButton, "click")
-        _ <- monix.eval.Task.unit.delayResult(1 seconds).runToFuture
+        _ <- monix.eval.Task.unit.delayResult(1.seconds).runToFuture
       } yield succeed
     }
   }
@@ -2907,11 +2908,11 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
       _ = element.innerHTML shouldBe ""
 
       _ = sendEvent(element, "mousedown")
-      _ <- monix.eval.Task.unit.delayResult(0.1 seconds).to[IO]
+      _ <- monix.eval.Task.unit.delayResult(0.1.seconds).to[IO]
       _ = element.innerHTML shouldBe "yes"
 
       _ = sendEvent(element, "mouseup")
-      _ <- monix.eval.Task.unit.delayResult(0.1 seconds).to[IO]
+      _ <- monix.eval.Task.unit.delayResult(0.1.seconds).to[IO]
       _ = element.innerHTML shouldBe "no"
     } yield succeed
   }
@@ -2944,11 +2945,11 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
       _ = element.innerHTML shouldBe ""
 
       _ = sendEvent(element, "mousedown")
-      _ <- monix.eval.Task.unit.delayResult(0.1 seconds).to[IO]
+      _ <- monix.eval.Task.unit.delayResult(0.1.seconds).to[IO]
       _ = element.innerHTML shouldBe "yes"
 
       _ = sendEvent(element, "mouseup")
-      _ <- monix.eval.Task.unit.delayResult(0.1 seconds).to[IO]
+      _ <- monix.eval.Task.unit.delayResult(0.1.seconds).to[IO]
       _ = element.innerHTML shouldBe "no"
     } yield succeed
   }

--- a/outwatch/src/test/scala/outwatch/StoreSpec.scala
+++ b/outwatch/src/test/scala/outwatch/StoreSpec.scala
@@ -74,8 +74,7 @@ class StoreSpec extends FlatSpec with Matchers {
   "A Store" should "emit its current state to new subscribers" in {
     val store = Store.create[IO, CounterAction, Model](Initial, 0, Reducer(reduce _)).unsafeRunSync()
 
-    for (i <- 1 to 10)
-      store.onNext(Plus)
+    (1 to 10).foreach(_ => store.onNext(Plus))
 
     var a: Option[Model] = None
     var b: Option[Model] = None

--- a/project/Options.scala
+++ b/project/Options.scala
@@ -1,0 +1,73 @@
+import sbt._
+import Keys._
+
+object Options {
+  val baseOptions = Seq(
+    "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
+    "-encoding", "utf-8",                // Specify character encoding used by source files.
+    "-explaintypes",                     // Explain type errors in more detail.
+    "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
+    "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
+    "-language:experimental.macros",     // Allow macro definition (besides implementation and application)
+    "-language:higherKinds",             // Allow higher-kinded types
+    "-language:implicitConversions",     // Allow definition of implicit functions called views
+    "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
+    "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
+    "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
+    "-Xfuture",                          // Turn on future language features.
+    "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
+    "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
+    "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
+    "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
+    "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
+    "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
+    "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
+    "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
+    "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+    "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
+    "-Xlint:option-implicit",            // Option.apply used implicit view.
+    "-Xlint:package-object-classes",     // Class or object defined in package object.
+    "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
+    "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
+    "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
+    "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
+    "-Xlint:unsound-match",              // Pattern match may not be typesafe.
+    "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+    "-Ypartial-unification",             // Enable partial unification in type constructor inference
+    "-Ywarn-dead-code",                  // Warn when dead code is identified.
+    "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
+    "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
+    "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
+    "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+    "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
+    "-Ywarn-numeric-widen",              // Warn when numerics are widened.
+    "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
+    "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
+    "-Ywarn-unused:locals",              // Warn if a local definition is unused.
+    "-Ywarn-unused:params",              // Warn if a value parameter is unused.
+    "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
+    "-Ywarn-unused:privates",            // Warn if a private member is unused.
+    "-Ywarn-value-discard",              // Warn when non-Unit expression results are unused.
+    "-P:silencer:checkUnused",           // Warn if silencer is used when no warning is suppressed
+  )
+
+  val badConsoleFlags = Seq("-Ywarn-unused:imports", "-Xfatal-warnings")
+
+  val versionBasedOptions = Map(
+    "2.12" -> Seq(
+    ),
+    "2.11" -> Seq(
+      "-Ywarn-unused",
+      "-Xexperimental"   // SAM conversion
+    )
+  )
+
+  val scalajsOptions = Seq(
+    "-P:scalajs:sjsDefinedByDefault",
+  )
+
+  def allOptionsForVersion(v: String, js: Boolean): Seq[String] =
+    baseOptions ++ (versionBasedOptions.get(v).getOrElse(Nil)) ++ (if(js) scalajsOptions else Nil)
+
+  def allOptionsForVersionConsole(v: String): Seq[String] = allOptionsForVersion(v, false).diff(badConsoleFlags)
+}

--- a/project/Options.scala
+++ b/project/Options.scala
@@ -12,49 +12,49 @@ object Options {
     "-language:higherKinds",             // Allow higher-kinded types
     "-language:implicitConversions",     // Allow definition of implicit functions called views
     "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
-    "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
-    "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
-    "-Xfuture",                          // Turn on future language features.
-    "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
-    "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
-    "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
-    "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
-    "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
-    "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
-    "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
-    "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
-    "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-    "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
-    "-Xlint:option-implicit",            // Option.apply used implicit view.
-    "-Xlint:package-object-classes",     // Class or object defined in package object.
-    "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
-    "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
-    "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
-    "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
-    "-Xlint:unsound-match",              // Pattern match may not be typesafe.
-    "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
     "-Ypartial-unification",             // Enable partial unification in type constructor inference
-    "-Ywarn-dead-code",                  // Warn when dead code is identified.
-    "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
-    "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
-    "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
-    "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-    "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
-    "-Ywarn-numeric-widen",              // Warn when numerics are widened.
-    "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
-    "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
-    "-Ywarn-unused:locals",              // Warn if a local definition is unused.
-    "-Ywarn-unused:params",              // Warn if a value parameter is unused.
-    "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
-    "-Ywarn-unused:privates",            // Warn if a private member is unused.
-    "-Ywarn-value-discard",              // Warn when non-Unit expression results are unused.
-    "-P:silencer:checkUnused",           // Warn if silencer is used when no warning is suppressed
   )
 
-  val badConsoleFlags = Seq("-Ywarn-unused:imports", "-Xfatal-warnings")
+  val badConsoleFlags = Seq("-P:silencer:checkUnused", "-Ywarn-unused:imports", "-Xfatal-warnings")
 
   val versionBasedOptions = Map(
     "2.12" -> Seq(
+      // "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
+      "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
+      "-Xfuture",                          // Turn on future language features.
+      "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
+      "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
+      "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
+      "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
+      "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
+      "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
+      "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
+      "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
+      "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+      "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
+      "-Xlint:option-implicit",            // Option.apply used implicit view.
+      "-Xlint:package-object-classes",     // Class or object defined in package object.
+      "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
+      "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
+      "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
+      "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
+      "-Xlint:unsound-match",              // Pattern match may not be typesafe.
+      "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+      "-Ywarn-dead-code",                  // Warn when dead code is identified.
+      "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
+      "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
+      "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
+      "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+      "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
+      "-Ywarn-numeric-widen",              // Warn when numerics are widened.
+      "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
+      "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
+      "-Ywarn-unused:locals",              // Warn if a local definition is unused.
+      "-Ywarn-unused:params",              // Warn if a value parameter is unused.
+      "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
+      "-Ywarn-unused:privates",            // Warn if a private member is unused.
+      "-Ywarn-value-discard",              // Warn when non-Unit expression results are unused.
+      "-P:silencer:checkUnused",           // Warn if silencer is used when no warning is suppressed
     ),
     "2.11" -> Seq(
       "-Ywarn-unused",
@@ -68,6 +68,4 @@ object Options {
 
   def allOptionsForVersion(v: String, js: Boolean): Seq[String] =
     baseOptions ++ (versionBasedOptions.get(v).getOrElse(Nil)) ++ (if(js) scalajsOptions else Nil)
-
-  def allOptionsForVersionConsole(v: String): Seq[String] = allOptionsForVersion(v, false).diff(badConsoleFlags)
 }


### PR DESCRIPTION
```
[error] /home/projects/oss/outwatch/outwatch/src/main/scala/outwatch/dom/helpers/NativeHelpers.scala:9:13: parameter value key in method apply is never used
[error]   def apply(key: String): js.UndefOr[A] = js.native
[error]             ^
[error] /home/projects/oss/outwatch/outwatch/src/main/scala/outwatch/dom/helpers/Snabbdom.scala:40:148: parameter value scheduler in method createProxy is never used
[error]   @inline private def createProxy(modifiers: SeparatedModifiers, nodeType: String, vNodeId: js.UndefOr[Int], vNodeNS: js.UndefOr[String])(implicit scheduler: Scheduler): VNodeProxy = {
[error]                                                                                                                                                    ^
[error] /home/projects/oss/outwatch/outwatch/src/main/scala/outwatch/http/Http.scala:88:66: parameter value s in method single is never used
[error]   def single(request: Request, method: HttpRequestType)(implicit s: Scheduler): IO[Response] =
[error]                                                                  ^
[error] /home/projects/oss/outwatch/outwatch/src/main/scala/outwatch/util/LocalStorage.scala:36:57: parameter value scheduler in method storageEventsForKey is never used
[error]   private def storageEventsForKey(key: String)(implicit scheduler: Scheduler): Observable[Option[String]] =
[error]                                                         ^
[error] /home/projects/oss/outwatch/outwatch/src/main/scala/outwatch/util/LocalStorage.scala:54:31: parameter value o in value $anonfun is never used
[error]     subjectWithTransform(key, o => storageEvents)
[error]                               ^
[error] /home/projects/oss/outwatch/outwatch/src/main/scala/outwatch/util/WebSocket.scala:17:58: parameter value s in class WebSocket is never used
[error] final case class WebSocket private(url: String)(implicit s: Scheduler) {
[error]                                                          ^
[error] /home/projects/oss/outwatch/outwatch/src/main/scala/outwatch/util/WebSocket.scala:25:20: parameter value e in value $anonfun is never used
[error]     ws.onclose = (e: CloseEvent) => observer.onComplete()
[error]                    ^
```

The js.native warnings are ignored explicitly using silencer. The win here is the several places an `implicit scheduler` is called for but not used.