### PR TITLE
Remove hfunction from Snabbdom Facade

### DIFF
--- a/bench/yarn.lock
+++ b/bench/yarn.lock
@@ -3638,9 +3638,9 @@ signal-exit@^3.0.0:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-"snabbdom@git://github.com/cornerman/snabbdom.git#semver:0.7.4":
-  version "0.7.4"
-  resolved "git://github.com/cornerman/snabbdom.git#2814da5d929d432b9c3fc5ecf91ca03c72e17bbe"
+"snabbdom@git://github.com/outwatch/snabbdom.git#semver:0.7.5":
+  version "0.7.5"
+  resolved "git://github.com/outwatch/snabbdom.git#f92761a40914825d7b8f702f607f9d929f95033f"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"

--- a/build.sbt
+++ b/build.sbt
@@ -135,7 +135,7 @@ lazy val outwatch = project
     ),
 
     npmDependencies in Compile ++= Seq(
-      "snabbdom" -> "git://github.com/cornerman/snabbdom.git#semver:0.7.4"
+      "snabbdom" -> "git://github.com/outwatch/snabbdom.git#semver:0.7.5"
     )
   )
 

--- a/outwatch/src/main/scala/snabbdom/Snabbdom.scala
+++ b/outwatch/src/main/scala/snabbdom/Snabbdom.scala
@@ -7,35 +7,6 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 import scala.scalajs.js.|
 
-
-
-@silent("never used|dead code")
-@js.native
-@JSImport("snabbdom/h", JSImport.Namespace, globalFallback = "h")
-object hProvider extends js.Object {
-  val default: hFunction = js.native
-}
-
-@silent
-@js.native
-trait hFunction extends js.Any {
-  def apply(nodeType: String, dataObject: DataObject): VNodeProxy = js.native
-  def apply(nodeType: String, dataObject: DataObject, text: js.UndefOr[String]): VNodeProxy = js.native
-  def apply(nodeType: String, dataObject: DataObject, children: js.Array[VNodeProxy]): VNodeProxy = js.native
-}
-
-object hFunction {
-  def apply(nodeType: String, dataObject: DataObject): VNodeProxy = {
-    hProvider.default.apply(nodeType, dataObject)
-  }
-  def apply(nodeType: String, dataObject: DataObject, text: js.UndefOr[String]): VNodeProxy = {
-    hProvider.default.apply(nodeType, dataObject, text)
-  }
-  def apply(nodeType: String, dataObject: DataObject, children: js.Array[VNodeProxy]): VNodeProxy = {
-    hProvider.default.apply(nodeType, dataObject, children)
-  }
-}
-
 trait Hooks extends js.Object {
   var init: js.UndefOr[Hooks.HookSingleFn] = js.undefined
   var insert: js.UndefOr[Hooks.HookSingleFn] = js.undefined
@@ -80,7 +51,6 @@ object DataObject {
 // object thunkProvider extends js.Object {
 //   val default: thunkFunction = js.native
 // }
-
 // @js.native
 // trait thunkFunction extends js.Any {
 //   def apply(selector: String, renderFn: js.Function, argument: js.Array[Any]): VNodeProxy = js.native
@@ -264,7 +234,6 @@ object SnabbdomProps extends js.Object{
 object SnabbdomStyle extends js.Object {
   val default: js.Any = js.native
 }
-
 
 @js.native
 @JSImport("snabbdom/tovnode", JSImport.Default)

--- a/tests/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/tests/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -8,7 +8,9 @@ import org.scalajs.dom.window.localStorage
 import org.scalajs.dom.{document, html, Element}
 import outwatch.Deprecated.IgnoreWarnings.initEvent
 import monix.reactive.Observable
-import snabbdom.{DataObject, Hooks, hFunction, VNodeProxy}
+import outwatch.helpers._
+import outwatch.dsl._
+import snabbdom.{DataObject, Hooks, VNodeProxy}
 import org.scalajs.dom.window.localStorage
 import org.scalatest.Assertion
 
@@ -35,6 +37,18 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
     val event = document.createEvent("Events")
     initEvent(event)(eventType, canBubbleArg = true, cancelableArg = false)
     elem.dispatchEvent(event)
+  }
+
+  def newProxy(tagName: String, dataObject: DataObject, string: String) = new VNodeProxy {
+    sel = tagName
+    data = dataObject
+    text = string
+  }
+
+  def newProxy(tagName: String, dataObject: DataObject, childProxies: js.UndefOr[js.Array[VNodeProxy]] = js.undefined) = new VNodeProxy {
+    sel = tagName
+    data = dataObject
+    children = childProxies
   }
 
   "Properties" should "be separated correctly" in {
@@ -173,13 +187,13 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
   }
 
   val fixture = Fixture(
-    hFunction(
+    newProxy(
       "div",
       new DataObject {
         attrs = js.Dictionary[Attr.Value]("class" -> "red", "id" -> "msg")
         hook = Hooks.empty
       },
-      js.Array(hFunction("span", new DataObject { hook = Hooks.empty }, "Hello"))
+      js.Array(newProxy("span", new DataObject { hook = Hooks.empty }, "Hello"))
     )
   )
 
@@ -540,7 +554,7 @@ class OutWatchDomSpec extends JSDomAsyncSpec {
     )
 
     val attributes = js.Dictionary[Attr.Value]("a" -> true, "b" -> true, "c" -> false, "d" -> "true", "e" -> "true", "f" -> "false")
-    val expected = hFunction("div", new DataObject { attrs = attributes; hook = Hooks.empty })
+    val expected = newProxy("div", new DataObject { attrs = attributes; hook = Hooks.empty })
 
     val snabbdomNode = SnabbdomOps.toSnabbdom(vtree)
     snabbdomNode._id = js.undefined

--- a/tests/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/tests/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -13,13 +13,19 @@ import snabbdom._
 
 class SnabbdomSpec extends JSDomAsyncSpec {
 
+  def newProxy(tagName: String, dataObject: DataObject, string: String, keyOption: js.UndefOr[String] = js.undefined) = new VNodeProxy {
+    sel = tagName
+    data = dataObject
+    text = string
+    key = keyOption
+  }
+
   "The Snabbdom Facade" should "correctly patch the DOM" in {
 
     val message = "Hello World"
 
     for {
-
-       vNode <- IO(hFunction("span#msg", DataObject.empty, message))
+       vNode <- IO(newProxy("span", new DataObject { attrs = js.Dictionary[Attr.Value]("id" -> "msg") }, message))
 
         node <- IO {
                 val node = document.createElement("div")
@@ -31,7 +37,7 @@ class SnabbdomSpec extends JSDomAsyncSpec {
           msg <- IO(document.getElementById("msg").innerHTML)
             _ = msg shouldBe message
        newMsg = "Hello Snabbdom!"
-      newNode <- IO(hFunction("div#new", DataObject.empty, newMsg))
+      newNode <- IO(newProxy("span", new DataObject { attrs = js.Dictionary[Attr.Value]("id" -> "new") }, newMsg))
             _ <- IO(patch(vNode, newNode))
          nMsg <- IO(document.getElementById("new").innerHTML)
             _ = nMsg shouldBe newMsg
@@ -131,7 +137,7 @@ class SnabbdomSpec extends JSDomAsyncSpec {
 
     for {
 
-      vNode <- IO(hFunction("span#msg", new DataObject { attrs = attributes }, message))
+      vNode <- IO(newProxy("span", new DataObject { attrs = attributes }, message))
        node <- IO {
                 val node = document.createElement("div")
                 document.body.appendChild(node)
@@ -150,7 +156,7 @@ class SnabbdomSpec extends JSDomAsyncSpec {
 
     val renderFn: String => VNodeProxy = { message =>
       renderFnCounter += 1
-      hFunction("span#msg", new DataObject { key = "key" }, message)
+      newProxy("span", new DataObject { key = "key"; attrs = js.Dictionary[Attr.Value]("id" -> "msg") }, message, keyOption = "key")
     }
 
     val message = "Hello World"
@@ -161,14 +167,14 @@ class SnabbdomSpec extends JSDomAsyncSpec {
     renderFnCounter shouldBe 0
 
 
-    val vNode1 = thunk(js.undefined, "span#msg", "key", () => renderFn(message), js.Array(message))
+    val vNode1 = thunk(js.undefined, "span", "key", () => renderFn(message), js.Array(message))
     val p1 = patch(node, vNode1)
 
     renderFnCounter shouldBe 1
     document.getElementById("msg").innerHTML shouldBe message
 
 
-    val vNode2 = thunk(js.undefined, "span#msg", "key", () => renderFn(message), js.Array(message))
+    val vNode2 = thunk(js.undefined, "span", "key", () => renderFn(message), js.Array(message))
     val p2 = patch(p1, vNode2)
 
     renderFnCounter shouldBe 1
@@ -176,7 +182,7 @@ class SnabbdomSpec extends JSDomAsyncSpec {
 
 
     val newMessage = "Hello Snabbdom!"
-    val vNode3 = thunk(js.undefined, "span#msg", "key", () => renderFn(newMessage), js.Array(newMessage))
+    val vNode3 = thunk(js.undefined, "span", "key", () => renderFn(newMessage), js.Array(newMessage))
     val p3 = patch(p2, vNode3)
 
     p3 should not be null
@@ -189,7 +195,7 @@ class SnabbdomSpec extends JSDomAsyncSpec {
 
     val renderFn: String => VNodeProxy = { message =>
       renderFnCounter += 1
-      hFunction("span#msg", new DataObject { key = "key" }, message)
+      newProxy("span", new DataObject { key = "key"; attrs = js.Dictionary[Attr.Value]("id" -> "msg") }, message, keyOption = "key")
     }
 
     val message = "Hello World"
@@ -200,14 +206,14 @@ class SnabbdomSpec extends JSDomAsyncSpec {
     renderFnCounter shouldBe 0
 
 
-    val vNode1 = thunk.conditional(js.undefined, "span#msg", "key", () => renderFn(message), shouldRender = true)
+    val vNode1 = thunk.conditional(js.undefined, "span", "key", () => renderFn(message), shouldRender = true)
     val p1 = patch(node, vNode1)
 
     renderFnCounter shouldBe 1
     document.getElementById("msg").innerHTML shouldBe message
 
 
-    val vNode2 = thunk.conditional(js.undefined, "span#msg", "key", () => renderFn(message), shouldRender = false)
+    val vNode2 = thunk.conditional(js.undefined, "span", "key", () => renderFn(message), shouldRender = false)
     val p2 = patch(p1, vNode2)
 
     renderFnCounter shouldBe 1
@@ -215,7 +221,7 @@ class SnabbdomSpec extends JSDomAsyncSpec {
 
 
     val newMessage = "Hello Snabbdom!"
-    val vNode3 = thunk.conditional(js.undefined, "span#msg", "key", () => renderFn(newMessage), shouldRender = true)
+    val vNode3 = thunk.conditional(js.undefined, "span", "key", () => renderFn(newMessage), shouldRender = true)
     val p3 = patch(p2, vNode3)
 
     p3 should not be null


### PR DESCRIPTION
And update snabbdom fork to 0.7.5. Contains latest changes from snabbdom/snabbdom master-branch and remove parsing of selector tags to find encoded `#id.cls` in selector tags of snabbdom (we do not need this).

I have moved the snabbdom fork to our organization now: So the new dependency is from outwatch/snabbdom. The old dependency will keep on working because of githubs redirections.

Based on #355 