### PR TITLE
Really skip publishing bench project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,8 +89,7 @@ lazy val bench = project
   .enablePlugins(ScalaJSPlugin, ScalaJSBundlerPlugin)
   .dependsOn(outwatch)
   .settings(
-    publish := {},
-    publishLocal := {},
+    skip in publish := true,
 
     resolvers ++=
       ("jitpack" at "https://jitpack.io") ::


### PR DESCRIPTION
The current master mistakenly publishes the bench project, such that our jitpack dependencies break (because there are now multiple artifacts for outwatch in jitpack).

Thanks to @Busti for pointing this out!