### PR TITLE
Only run travis on jdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ scala:
   - 2.13.0
 
 jdk:
-  - openjdk8
   - openjdk11
 
 env:


### PR DESCRIPTION
Only run travis on jdk11, the tests are run only by node anyways.