### PR TITLE
Travis: use ScalaJS 0.6.32 (like in plugins)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jdk:
   - openjdk11
 
 env:
-  - SCALAJS_VERSION=0.6.28
+  - SCALAJS_VERSION=0.6.32
   # - SCALAJS_VERSION=1.0.0-M8
 
 


### PR DESCRIPTION
Travis was running the old version...