### PR TITLE
Update to Scala.js 1.8.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -212,6 +212,7 @@ lazy val docs = project
       "REPOURL" -> "https://github.com/OutWatch/outwatch/blob/master",
       "js-mount-node" -> "preview"
     ),
+    libraryDependencies += "org.scala-js" %% "scalajs-linker" % scalaJSVersion
   )
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -212,7 +212,10 @@ lazy val docs = project
       "REPOURL" -> "https://github.com/OutWatch/outwatch/blob/master",
       "js-mount-node" -> "preview"
     ),
-    libraryDependencies += "org.scala-js" %% "scalajs-linker" % scalaJSVersion
+    libraryDependencies ++= Seq(
+      "org.scala-js" %% "scalajs-compiler" % scalaJSVersion,
+      "org.scala-js" %% "scalajs-linker" % scalaJSVersion
+    )
   )
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -213,7 +213,7 @@ lazy val docs = project
       "js-mount-node" -> "preview"
     ),
     libraryDependencies ++= Seq(
-      "org.scala-js" %% "scalajs-compiler" % scalaJSVersion,
+      "org.scala-js" %% "scalajs-compiler" % scalaJSVersion cross CrossVersion.full,
       "org.scala-js" %% "scalajs-linker" % scalaJSVersion
     )
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.7.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.8.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.20.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.2")


### PR DESCRIPTION
Supersedes https://github.com/outwatch/outwatch/pull/551. This should hopefully get you unblocked while we wait for https://github.com/scalameta/mdoc/pull/597.