### PR TITLE
Fix SJS 1.8 update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -205,10 +205,16 @@ lazy val docs = project
       "REPOURL" -> "https://github.com/OutWatch/outwatch/blob/master",
       "js-mount-node" -> "docPreview"
     ),
-    libraryDependencies ++= Seq(
-      "org.scala-js" %% "scalajs-compiler" % scalaJSVersion cross CrossVersion.full,
-      "org.scala-js" %% "scalajs-linker" % scalaJSVersion
-    )
+    libraryDependencies += "org.scala-js" %% "scalajs-linker" % scalaJSVersion,
+    libraryDependencies += {
+      scalaBinaryVersion.value match {
+        // keep these pinned to mdoc.js Scala versions
+        // scala-steward:off
+        case "2.12" => "org.scala-js" %% "scalajs-compiler" % scalaJSVersion cross CrossVersion.constant("2.12.15")
+        case "2.13" => "org.scala-js" %% "scalajs-compiler" % scalaJSVersion cross CrossVersion.constant("2.13.6")
+        // scala-steward:on
+      }
+    }
   )
 
 lazy val root = project


### PR DESCRIPTION
Follow up to https://github.com/outwatch/outwatch/pull/563#issuecomment-1007982347.

This is ... not nice. I don't think it would be unreasonable to rollback to SJS 1.7 instead. Whatever works for you 👍 