### PR TITLE
[WIP] Introduce generalized abstraction over streams via environment imports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,10 +125,12 @@ lazy val outwatchSnabbdom = project
     )
   )
 
+lazy val hummingbird = ProjectRef(file("../hummingbird"), "core")
+
 lazy val outwatch = project
   .in(file("outwatch"))
   .enablePlugins(ScalaJSPlugin, ScalaJSBundlerPlugin)
-  .dependsOn(outwatchSnabbdom, outwatchReactive)
+  .dependsOn(outwatchSnabbdom, outwatchReactive, hummingbird)
   .settings(commonSettings)
   .settings(
     name := "OutWatch",

--- a/outwatch/src/main/scala/outwatch/ChildCommand.scala
+++ b/outwatch/src/main/scala/outwatch/ChildCommand.scala
@@ -6,108 +6,127 @@ import colibri.{Source, Observable}
 
 import scala.scalajs.js
 
-sealed trait ChildCommand
-object ChildCommand {
-  sealed trait ChildId
-  object ChildId {
-    case class Key(key: outwatch.Key.Value) extends ChildId
-    case class Element(elem: org.scalajs.dom.Element) extends ChildId
-  }
+class CChildCommand(implicit env: Env) {
+  import env._
 
-  case class Append(node: VNode) extends ChildCommand
-  case class Prepend(node: VNode) extends ChildCommand
-  case class ReplaceAll(list: js.Array[VNode]) extends ChildCommand
-  case class Insert(index: Int, node: VNode) extends ChildCommand
-  case class Replace(index: Int, node: VNode) extends ChildCommand
-  case class Move(fromIndex: Int, toIndex: Int) extends ChildCommand
-  case class Remove(index: Int) extends ChildCommand
+  sealed trait ChildCommand
 
-  case class ReplaceId(id: ChildId, node: VNode) extends ChildCommand
-  case class InsertBeforeId(id: ChildId, node: VNode) extends ChildCommand
-  case class InsertBehindId(id: ChildId, node: VNode) extends ChildCommand
-  case class MoveId(fromId: ChildId, toIndex: Int) extends ChildCommand
-  case class MoveBeforeId(fromId: ChildId, toId: ChildId) extends ChildCommand
-  case class MoveBehindId(fromId: ChildId, toId: ChildId) extends ChildCommand
-  case class RemoveId(id: ChildId) extends ChildCommand
+  object ChildCommand {
+    sealed trait ChildId
 
-  def stream[F[_] : Source](valueStream: F[Seq[ChildCommand]], config: RenderConfig): VDomModifier = VDomModifier.delay {
+    object ChildId {
+      case class Key(key: outwatch.Key.Value) extends ChildId
 
-    val children = new js.Array[VNodeProxyNode]
+      case class Element(elem: org.scalajs.dom.Element) extends ChildId
+    }
 
-    Observable.map(valueStream) { cmds =>
-      val idToIndex: ChildId => Int = {
-        case ChildId.Key(key) => children.indexWhere { tree =>
-          tree.proxy.key.fold(false)((k: Key.Value) => k == key)
-        }
-        case ChildId.Element(element) => children.indexWhere { tree =>
-          tree.proxy.elm.fold(false)((e: Element) => e == element)
-        }
-      }
+    case class Append(node: VNode) extends ChildCommand
 
-      def isSaneIndex(index: Int): Boolean = index >= 0 && index < children.length
+    case class Prepend(node: VNode) extends ChildCommand
 
-      def replaceByIndex(index: Int, node: VNode): Unit = {
-        children(index) = VNodeProxyNode(SnabbdomOps.toSnabbdom(node, config))
-      }
+    case class ReplaceAll(list: js.Array[VNode]) extends ChildCommand
 
-      def moveByIndex(fromIndex: Int, toIndex: Int): Unit = {
-        if (isSaneIndex(fromIndex) && isSaneIndex(toIndex) && fromIndex != toIndex) {
-          val tree = children.remove(fromIndex)
-          children.insert(toIndex, tree)
-        }
-      }
+    case class Insert(index: Int, node: VNode) extends ChildCommand
 
-      def insertByIndex(index: Int, node: VNode): Unit = {
-        if (isSaneIndex(index)) {
-          children.insert(index, VNodeProxyNode(SnabbdomOps.toSnabbdom(node, config)))
-        }
-      }
+    case class Replace(index: Int, node: VNode) extends ChildCommand
 
-      def removeByIndex(index: Int): Unit = {
-        if (isSaneIndex(index)) {
-          children.remove(index)
-          ()
-        }
-      }
+    case class Move(fromIndex: Int, toIndex: Int) extends ChildCommand
 
-      cmds foreach {
-        case Append(node) =>
-          children.push(VNodeProxyNode(SnabbdomOps.toSnabbdom(node, config)))
-          ()
-        case Prepend(node) =>
-          children.prepend(VNodeProxyNode(SnabbdomOps.toSnabbdom(node, config)))
-        case ReplaceAll(list) =>
-          children.clear()
-          list.foreach { node =>
-            children.push(VNodeProxyNode(SnabbdomOps.toSnabbdom(node, config)))
+    case class Remove(index: Int) extends ChildCommand
+
+    case class ReplaceId(id: ChildId, node: VNode) extends ChildCommand
+
+    case class InsertBeforeId(id: ChildId, node: VNode) extends ChildCommand
+
+    case class InsertBehindId(id: ChildId, node: VNode) extends ChildCommand
+
+    case class MoveId(fromId: ChildId, toIndex: Int) extends ChildCommand
+
+    case class MoveBeforeId(fromId: ChildId, toId: ChildId) extends ChildCommand
+
+    case class MoveBehindId(fromId: ChildId, toId: ChildId) extends ChildCommand
+
+    case class RemoveId(id: ChildId) extends ChildCommand
+
+    def stream[F[_] : Source](valueStream: F[Seq[ChildCommand]], config: RenderConfig): VDomModifier = VDomModifier.delay {
+
+      val children = new js.Array[VNodeProxyNode]
+
+      Observable.map(valueStream) { cmds =>
+        val idToIndex: ChildId => Int = {
+          case ChildId.Key(key) => children.indexWhere { tree =>
+            tree.proxy.key.fold(false)((k: Key.Value) => k == key)
           }
-        case Insert(index, node) =>
-          insertByIndex(index, node)
-        case InsertBeforeId(id, node) =>
-          insertByIndex(idToIndex(id), node)
-        case InsertBehindId(id, node) =>
-          val index = idToIndex(id)
-          insertByIndex(if (index == -1) -1 else index + 1, node)
-        case Replace(index, node) =>
-          replaceByIndex(index, node)
-        case ReplaceId(id, node) =>
-          replaceByIndex(idToIndex(id), node)
-        case Move(fromIndex, toIndex) =>
-          moveByIndex(fromIndex, toIndex)
-        case MoveId(fromId, toIndex) =>
-          moveByIndex(idToIndex(fromId), toIndex)
-        case MoveBeforeId(fromId, toId) =>
-          moveByIndex(idToIndex(fromId), idToIndex(toId))
-        case MoveBehindId(fromId, toId) =>
-          val toIdx = idToIndex(toId)
-          moveByIndex(idToIndex(fromId), if (toIdx == -1) -1 else toIdx + 1)
-        case Remove(index) =>
-          removeByIndex(index)
-        case RemoveId(id) =>
-          removeByIndex(idToIndex(id))
-      }
+          case ChildId.Element(element) => children.indexWhere { tree =>
+            tree.proxy.elm.fold(false)((e: Element) => e == element)
+          }
+        }
 
-      CompositeModifier(children)
+        def isSaneIndex(index: Int): Boolean = index >= 0 && index < children.length
+
+        def replaceByIndex(index: Int, node: VNode): Unit = {
+          children(index) = VNodeProxyNode(SnabbdomOps.toSnabbdom(node, config))
+        }
+
+        def moveByIndex(fromIndex: Int, toIndex: Int): Unit = {
+          if (isSaneIndex(fromIndex) && isSaneIndex(toIndex) && fromIndex != toIndex) {
+            val tree = children.remove(fromIndex)
+            children.insert(toIndex, tree)
+          }
+        }
+
+        def insertByIndex(index: Int, node: VNode): Unit = {
+          if (isSaneIndex(index)) {
+            children.insert(index, VNodeProxyNode(SnabbdomOps.toSnabbdom(node, config)))
+          }
+        }
+
+        def removeByIndex(index: Int): Unit = {
+          if (isSaneIndex(index)) {
+            children.remove(index)
+            ()
+          }
+        }
+
+        cmds foreach {
+          case Append(node) =>
+            children.push(VNodeProxyNode(SnabbdomOps.toSnabbdom(node, config)))
+            ()
+          case Prepend(node) =>
+            children.prepend(VNodeProxyNode(SnabbdomOps.toSnabbdom(node, config)))
+          case ReplaceAll(list) =>
+            children.clear()
+            list.foreach { node =>
+              children.push(VNodeProxyNode(SnabbdomOps.toSnabbdom(node, config)))
+            }
+          case Insert(index, node) =>
+            insertByIndex(index, node)
+          case InsertBeforeId(id, node) =>
+            insertByIndex(idToIndex(id), node)
+          case InsertBehindId(id, node) =>
+            val index = idToIndex(id)
+            insertByIndex(if (index == -1) -1 else index + 1, node)
+          case Replace(index, node) =>
+            replaceByIndex(index, node)
+          case ReplaceId(id, node) =>
+            replaceByIndex(idToIndex(id), node)
+          case Move(fromIndex, toIndex) =>
+            moveByIndex(fromIndex, toIndex)
+          case MoveId(fromId, toIndex) =>
+            moveByIndex(idToIndex(fromId), toIndex)
+          case MoveBeforeId(fromId, toId) =>
+            moveByIndex(idToIndex(fromId), idToIndex(toId))
+          case MoveBehindId(fromId, toId) =>
+            val toIdx = idToIndex(toId)
+            moveByIndex(idToIndex(fromId), if (toIdx == -1) -1 else toIdx + 1)
+          case Remove(index) =>
+            removeByIndex(index)
+          case RemoveId(id) =>
+            removeByIndex(idToIndex(id))
+        }
+
+        CompositeModifier(children)
+      }
     }
   }
 }

--- a/outwatch/src/main/scala/outwatch/EmitterBuilder.scala
+++ b/outwatch/src/main/scala/outwatch/EmitterBuilder.scala
@@ -34,8 +34,8 @@ import scala.concurrent.duration.FiniteDuration
 // from the emitterbuilder.
 //
 
-class CEmitterBuilder(implicit cereal: Cereal) { lib =>
-  import cereal._
+class CEmitterBuilder(implicit env: Env) { lib =>
+  import env._
 
   sealed trait Execution
   sealed trait SyncExecution extends Execution
@@ -137,7 +137,6 @@ class CEmitterBuilder(implicit cereal: Cereal) { lib =>
 
     // @inline def mapResult[S](f: R => S): EmitterBuilderExecution[O, S, Exec] = new EmitterBuilder.MapResult[O, R, S, Exec](this, f)
   }
-
 
   type Sync[+O, +R] = EmitterBuilderExecution[O, R, SyncExecution]
 

--- a/outwatch/src/main/scala/outwatch/Env.scala
+++ b/outwatch/src/main/scala/outwatch/Env.scala
@@ -1,0 +1,43 @@
+package outwatch
+
+import hummingbird.syntax.{RxOps, TxOps}
+import hummingbird.{Cereal, syntax}
+
+class Env(implicit cereal: Cereal) {
+  implicit private val self: Env = this
+
+  type Rx[-T] = cereal.Rx[T]
+  implicit def iRx: syntax.Rx = cereal.iRx
+  implicit def rxOps[T](source: Rx[T]): RxOps[cereal.G, T] = cereal.rxOps(source)
+
+  type Tx[+T] = cereal.Tx[T]
+  implicit def iTx: syntax.Tx = cereal.iTx
+  implicit def txOps[T](source: Tx[T]): TxOps[cereal.H, T] = cereal.txOps(source)
+
+  type Cancelable = cereal.Cancelable
+
+  val CEmitterBuilder = new CEmitterBuilder
+  type EmitterBuilder[+O, +R] = CEmitterBuilder.EmitterBuilder[O, R]
+
+  val CVDomModifier = new CVDomModifier
+  type VDomModifier = CVDomModifier.VDomModifier
+  val VDomModifier: CVDomModifier.VDomModifier.type = CVDomModifier.VDomModifier
+  type VNode = CVDomModifier.VNode
+  val VNode: CVDomModifier.VNode.type = CVDomModifier.VNode
+  type VNodeProxyNode = CVDomModifier.VNodeProxyNode
+  val VNodeProxyNode: CVDomModifier.VNodeProxyNode.type = CVDomModifier.VNodeProxyNode
+  type CompositeModifier = CVDomModifier.CompositeModifier
+  val CompositeModifier: CVDomModifier.CompositeModifier.type = CVDomModifier.CompositeModifier
+  type StringVNode = CVDomModifier.StringVNode
+  val StringVNode: CVDomModifier.StringVNode.type = CVDomModifier.StringVNode
+  type SyncEffectModifier = CVDomModifier.SyncEffectModifier
+  val SyncEffectModifier: CVDomModifier.SyncEffectModifier.type = CVDomModifier.SyncEffectModifier
+  type StreamModifier = CVDomModifier.StreamModifier
+  val StreamModifier: CVDomModifier.StreamModifier.type = CVDomModifier.StreamModifier
+  type ChildCommandsModifier = CVDomModifier.ChildCommandsModifier
+  val ChildCommandsModifier: CVDomModifier.ChildCommandsModifier.type = CVDomModifier.ChildCommandsModifier
+
+  val CChildCommand = new CChildCommand
+  type ChildCommand = CChildCommand.ChildCommand
+  val ChildCommand: CChildCommand.ChildCommand.type = CChildCommand.ChildCommand
+}

--- a/outwatch/src/main/scala/outwatch/Render.scala
+++ b/outwatch/src/main/scala/outwatch/Render.scala
@@ -9,149 +9,180 @@ import scala.util.Success
 
 import cats.effect.Effect
 
-trait Render[-T] {
-  def render(value: T): VDomModifier
-}
+class CRender(implicit env: Env) {
+  import env._
 
-object Render {
-  @inline def apply[T](implicit render: Render[T]): Render[T] = render
-
-  implicit object JsArrayModifier extends Render[js.Array[VDomModifier]] {
-    @inline def render(value: js.Array[VDomModifier]): VDomModifier = CompositeModifier(value)
+  trait Render[-T] {
+    def render(value: T): VDomModifier
   }
 
-  @inline implicit def JsArrayModifierAs[T : Render]: Render[js.Array[T]] = new JsArrayRenderAsClass[T]
-  @inline private class JsArrayRenderAsClass[T : Render] extends Render[js.Array[T]] {
-    @inline def render(value: js.Array[T]) = iterableToModifierRender(value)
-  }
+  object Render {
+    @inline def apply[T](implicit render: Render[T]): Render[T] = render
 
-  implicit object ArrayModifier extends Render[Array[VDomModifier]] {
-    @inline def render(value: Array[VDomModifier]): VDomModifier = CompositeModifier(value)
-  }
+    implicit object JsArrayModifier extends Render[js.Array[VDomModifier]] {
+      @inline def render(value: js.Array[VDomModifier]): VDomModifier = CompositeModifier(value)
+    }
 
-  @inline implicit def ArrayModifierAs[T : Render]: Render[Array[T]] = new ArrayRenderAsClass[T]
-  @inline private class ArrayRenderAsClass[T : Render] extends Render[Array[T]] {
-    @inline def render(value: Array[T]) = iterableToModifierRender(value)
-  }
+    @inline implicit def JsArrayModifierAs[T: Render]: Render[js.Array[T]] = new JsArrayRenderAsClass[T]
 
-  implicit object SeqModifier extends Render[Seq[VDomModifier]] {
-    @inline def render(value: Seq[VDomModifier]): VDomModifier = CompositeModifier(value)
-  }
+    @inline private class JsArrayRenderAsClass[T: Render] extends Render[js.Array[T]] {
+      @inline def render(value: js.Array[T]) = iterableToModifierRender(value)
+    }
 
-  @inline implicit def SeqModifierAs[T : Render]: Render[Seq[T]] = new SeqRenderAsClass[T]
-  @inline private class SeqRenderAsClass[T : Render] extends Render[Seq[T]] {
-    @inline def render(value: Seq[T]) = iterableToModifierRender(value)
-  }
+    implicit object ArrayModifier extends Render[Array[VDomModifier]] {
+      @inline def render(value: Array[VDomModifier]): VDomModifier = CompositeModifier(value)
+    }
 
-  implicit object OptionModifier extends Render[Option[VDomModifier]] {
-    @inline def render(value: Option[VDomModifier]): VDomModifier = value.getOrElse(VDomModifier.empty)
-  }
+    @inline implicit def ArrayModifierAs[T: Render]: Render[Array[T]] = new ArrayRenderAsClass[T]
 
-  @inline implicit def OptionModifierAs[T : Render]: Render[Option[T]] = new OptionRenderAsClass[T]
-  @inline private class OptionRenderAsClass[T : Render] extends Render[Option[T]] {
-    @inline def render(value: Option[T]) = optionToModifierRender(value)
-  }
+    @inline private class ArrayRenderAsClass[T: Render] extends Render[Array[T]] {
+      @inline def render(value: Array[T]) = iterableToModifierRender(value)
+    }
 
-  implicit object UndefinedModifier extends Render[js.UndefOr[VDomModifier]] {
-    @inline def render(value: js.UndefOr[VDomModifier]): VDomModifier = value.getOrElse(VDomModifier.empty)
-  }
+    implicit object SeqModifier extends Render[Seq[VDomModifier]] {
+      @inline def render(value: Seq[VDomModifier]): VDomModifier = CompositeModifier(value)
+    }
 
-  @inline implicit def UndefinedModifierAs[T : Render]: Render[js.UndefOr[T]] = new UndefinedRenderAsClass[T]
-  @inline private class UndefinedRenderAsClass[T : Render] extends Render[js.UndefOr[T]] {
-    @inline def render(value: js.UndefOr[T]) = undefinedToModifierRender(value)
-  }
+    @inline implicit def SeqModifierAs[T: Render]: Render[Seq[T]] = new SeqRenderAsClass[T]
 
-  implicit object VDomModifierRender extends Render[VDomModifier] {
-    @inline def render(value: VDomModifier): VDomModifier = value
-  }
+    @inline private class SeqRenderAsClass[T: Render] extends Render[Seq[T]] {
+      @inline def render(value: Seq[T]) = iterableToModifierRender(value)
+    }
 
-  implicit object StringRender extends Render[String] {
-    @inline def render(value: String): VDomModifier = StringVNode(value)
-  }
+    implicit object OptionModifier extends Render[Option[VDomModifier]] {
+      @inline def render(value: Option[VDomModifier]): VDomModifier = value.getOrElse(VDomModifier.empty)
+    }
 
-  implicit object IntRender extends Render[Int] {
-    @inline def render(value: Int): VDomModifier = StringVNode(value.toString)
-  }
+    @inline implicit def OptionModifierAs[T: Render]: Render[Option[T]] = new OptionRenderAsClass[T]
 
-  implicit object DoubleRender extends Render[Double] {
-    @inline def render(value: Double): VDomModifier = StringVNode(value.toString)
-  }
+    @inline private class OptionRenderAsClass[T: Render] extends Render[Option[T]] {
+      @inline def render(value: Option[T]) = optionToModifierRender(value)
+    }
 
-  implicit object LongRender extends Render[Long] {
-    @inline def render(value: Long): VDomModifier = StringVNode(value.toString)
-  }
+    implicit object UndefinedModifier extends Render[js.UndefOr[VDomModifier]] {
+      @inline def render(value: js.UndefOr[VDomModifier]): VDomModifier = value.getOrElse(VDomModifier.empty)
+    }
 
-  implicit object BooleanRender extends Render[Boolean] {
-    @inline def render(value: Boolean): VDomModifier = StringVNode(value.toString)
-  }
+    @inline implicit def UndefinedModifierAs[T: Render]: Render[js.UndefOr[T]] = new UndefinedRenderAsClass[T]
 
-  @inline implicit def SyncEffectRender[F[_] : RunSyncEffect]: Render[F[VDomModifier]] = new SyncEffectRenderClass[F]
-  @inline private class SyncEffectRenderClass[F[_] : RunSyncEffect] extends Render[F[VDomModifier]] {
-    @inline def render(effect: F[VDomModifier]) = syncToModifier(effect)
-  }
+    @inline private class UndefinedRenderAsClass[T: Render] extends Render[js.UndefOr[T]] {
+      @inline def render(value: js.UndefOr[T]) = undefinedToModifierRender(value)
+    }
 
-  @inline implicit def SyncEffectRenderAs[F[_] : RunSyncEffect, T : Render]: Render[F[T]] = new SyncEffectRenderAsClass[F, T]
-  @inline private class SyncEffectRenderAsClass[F[_] : RunSyncEffect, T : Render] extends Render[F[T]] {
-    @inline def render(effect: F[T]) = syncToModifierRender(effect)
-  }
+    implicit object VDomModifierRender extends Render[VDomModifier] {
+      @inline def render(value: VDomModifier): VDomModifier = value
+    }
 
-  implicit def EffectRender[F[_] : Effect]: Render[F[VDomModifier]] = new EffectRenderClass[F]
-  @inline private class EffectRenderClass[F[_] : Effect] extends Render[F[VDomModifier]] {
-    def render(effect: F[VDomModifier]) = asyncToModifier(effect)
-  }
+    implicit object StringRender extends Render[String] {
+      @inline def render(value: String): VDomModifier = StringVNode(value)
+    }
 
-  @inline implicit def EffectRenderAs[F[_] : Effect, T : Render]: Render[F[T]] = new EffectRenderAsClass[F, T]
-  @inline private class EffectRenderAsClass[F[_] : Effect, T : Render] extends Render[F[T]] {
-    @inline def render(effect: F[T]) = asyncToModifierRender(effect)
-  }
+    implicit object IntRender extends Render[Int] {
+      @inline def render(value: Int): VDomModifier = StringVNode(value.toString)
+    }
 
-  implicit def FutureRender(implicit ec: ExecutionContext): Render[Future[VDomModifier]] = new FutureRenderClass
-  @inline private class FutureRenderClass(implicit ec: ExecutionContext) extends Render[Future[VDomModifier]] {
-    @inline def render(future: Future[VDomModifier]) = futureToModifier(future)
-  }
+    implicit object DoubleRender extends Render[Double] {
+      @inline def render(value: Double): VDomModifier = StringVNode(value.toString)
+    }
 
-  @inline implicit def FutureRenderAs[T : Render](implicit ec: ExecutionContext): Render[Future[T]] = new FutureRenderAsClass[T]
-  @inline private class FutureRenderAsClass[T: Render](implicit ec: ExecutionContext) extends Render[Future[T]] {
-    @inline def render(future: Future[T]) = futureToModifierRender(future)
-  }
+    implicit object LongRender extends Render[Long] {
+      @inline def render(value: Long): VDomModifier = StringVNode(value.toString)
+    }
 
-  @inline implicit def SourceRender[F[_] : Source]: Render[F[VDomModifier]] = new SourceRenderClass[F]
-  @inline private class SourceRenderClass[F[_] : Source] extends Render[F[VDomModifier]] {
-    @inline def render(source: F[VDomModifier]) = sourceToModifier(source)
-  }
+    implicit object BooleanRender extends Render[Boolean] {
+      @inline def render(value: Boolean): VDomModifier = StringVNode(value.toString)
+    }
 
-  @inline implicit def SourceRenderAs[F[_] : Source, T : Render]: Render[F[T]] = new SourceRenderAsClass[F, T]
-  @inline private class SourceRenderAsClass[F[_]: Source, T: Render] extends Render[F[T]] {
-    @inline def render(source: F[T]) = sourceToModifierRender(source)
-  }
+    @inline implicit def SyncEffectRender[F[_] : RunSyncEffect]: Render[F[VDomModifier]] = new SyncEffectRenderClass[F]
 
-  @inline implicit def ChildCommandSourceRender[F[_] : Source]: Render[F[ChildCommand]] = new ChildCommandRenderClass[F]
-  @inline private class ChildCommandRenderClass[F[_] : Source] extends Render[F[ChildCommand]] {
-    @inline def render(source: F[ChildCommand]) = childCommandToModifier(source)
-  }
+    @inline private class SyncEffectRenderClass[F[_] : RunSyncEffect] extends Render[F[VDomModifier]] {
+      @inline def render(effect: F[VDomModifier]) = syncToModifier(effect)
+    }
 
-  @inline implicit def ChildCommandSeqSourceRender[F[_] : Source]: Render[F[Seq[ChildCommand]]] = new ChildCommandSeqRenderClass[F]
-  @inline private class ChildCommandSeqRenderClass[F[_] : Source] extends Render[F[Seq[ChildCommand]]] {
-    @inline def render(source: F[Seq[ChildCommand]]) = childCommandSeqToModifier(source)
-  }
+    @inline implicit def SyncEffectRenderAs[F[_] : RunSyncEffect, T: Render]: Render[F[T]] = new SyncEffectRenderAsClass[F, T]
 
-  @noinline private def iterableToModifierRender[T: Render](value: Iterable[T]): VDomModifier = CompositeModifier(value.map(VDomModifier(_)))
-  @noinline private def optionToModifierRender[T: Render](value: Option[T]): VDomModifier = value.fold(VDomModifier.empty)(VDomModifier(_))
-  @noinline private def undefinedToModifierRender[T: Render](value: js.UndefOr[T]): VDomModifier = value.fold(VDomModifier.empty)(VDomModifier(_))
-  @noinline private def syncToModifierRender[F[_] : RunSyncEffect, T: Render](effect: F[T]): VDomModifier = SyncEffectModifier(() => VDomModifier(RunSyncEffect[F].unsafeRun(effect)))
-  @noinline private def syncToModifier[F[_] : RunSyncEffect](effect: F[VDomModifier]): VDomModifier = SyncEffectModifier(() => RunSyncEffect[F].unsafeRun(effect))
-  @noinline private def asyncToModifier[F[_] : Effect](effect: F[VDomModifier]): VDomModifier = StreamModifier(Observable.fromAsync(effect).subscribe(_))
-  @noinline private def asyncToModifierRender[F[_] : Effect, T: Render](effect: F[T]): VDomModifier = StreamModifier(Observable.fromAsync(effect).map(VDomModifier(_)).subscribe(_))
-  @noinline private def sourceToModifier[F[_] : Source](source: F[VDomModifier]): VDomModifier = StreamModifier(Source[F].subscribe(source))
-  @noinline private def sourceToModifierRender[F[_] : Source, T: Render](source: F[T]): VDomModifier = StreamModifier(sink => Source[F].subscribe(source)(Observer.contramap[Observer, VDomModifier, T](sink)(VDomModifier(_))))
-  @noinline private def childCommandSeqToModifier[F[_] : Source](source: F[Seq[ChildCommand]]): VDomModifier = ChildCommandsModifier(Observable.lift(source))
-  @noinline private def childCommandToModifier[F[_] : Source](source: F[ChildCommand]): VDomModifier = ChildCommandsModifier(Observable.map(source)(Seq(_)))
-  @noinline private def futureToModifierRender[T: Render](future: Future[T])(implicit ec: ExecutionContext): VDomModifier = future.value match {
-    case Some(Success(value)) => VDomModifier(value)
-    case _ => StreamModifier(Observable.fromFuture(future).map(VDomModifier(_)).subscribe(_))
-  }
-  @noinline private def futureToModifier(future: Future[VDomModifier])(implicit ec: ExecutionContext): VDomModifier = future.value match {
-    case Some(Success(value)) => value
-    case _ => StreamModifier(Observable.fromFuture(future).subscribe(_))
+    @inline private class SyncEffectRenderAsClass[F[_] : RunSyncEffect, T: Render] extends Render[F[T]] {
+      @inline def render(effect: F[T]) = syncToModifierRender(effect)
+    }
+
+    implicit def EffectRender[F[_] : Effect]: Render[F[VDomModifier]] = new EffectRenderClass[F]
+
+    @inline private class EffectRenderClass[F[_] : Effect] extends Render[F[VDomModifier]] {
+      def render(effect: F[VDomModifier]) = asyncToModifier(effect)
+    }
+
+    @inline implicit def EffectRenderAs[F[_] : Effect, T: Render]: Render[F[T]] = new EffectRenderAsClass[F, T]
+
+    @inline private class EffectRenderAsClass[F[_] : Effect, T: Render] extends Render[F[T]] {
+      @inline def render(effect: F[T]) = asyncToModifierRender(effect)
+    }
+
+    implicit def FutureRender(implicit ec: ExecutionContext): Render[Future[VDomModifier]] = new FutureRenderClass
+
+    @inline private class FutureRenderClass(implicit ec: ExecutionContext) extends Render[Future[VDomModifier]] {
+      @inline def render(future: Future[VDomModifier]) = futureToModifier(future)
+    }
+
+    @inline implicit def FutureRenderAs[T: Render](implicit ec: ExecutionContext): Render[Future[T]] = new FutureRenderAsClass[T]
+
+    @inline private class FutureRenderAsClass[T: Render](implicit ec: ExecutionContext) extends Render[Future[T]] {
+      @inline def render(future: Future[T]) = futureToModifierRender(future)
+    }
+
+    @inline implicit def SourceRender[F[_] : Source]: Render[F[VDomModifier]] = new SourceRenderClass[F]
+
+    @inline private class SourceRenderClass[F[_] : Source] extends Render[F[VDomModifier]] {
+      @inline def render(source: F[VDomModifier]) = sourceToModifier(source)
+    }
+
+    @inline implicit def SourceRenderAs[F[_] : Source, T: Render]: Render[F[T]] = new SourceRenderAsClass[F, T]
+
+    @inline private class SourceRenderAsClass[F[_] : Source, T: Render] extends Render[F[T]] {
+      @inline def render(source: F[T]) = sourceToModifierRender(source)
+    }
+
+    @inline implicit def ChildCommandSourceRender[F[_] : Source]: Render[F[ChildCommand]] = new ChildCommandRenderClass[F]
+
+    @inline private class ChildCommandRenderClass[F[_] : Source] extends Render[F[ChildCommand]] {
+      @inline def render(source: F[ChildCommand]) = childCommandToModifier(source)
+    }
+
+    @inline implicit def ChildCommandSeqSourceRender[F[_] : Source]: Render[F[Seq[ChildCommand]]] = new ChildCommandSeqRenderClass[F]
+
+    @inline private class ChildCommandSeqRenderClass[F[_] : Source] extends Render[F[Seq[ChildCommand]]] {
+      @inline def render(source: F[Seq[ChildCommand]]) = childCommandSeqToModifier(source)
+    }
+
+    @noinline private def iterableToModifierRender[T: Render](value: Iterable[T]): VDomModifier = CompositeModifier(value.map(VDomModifier(_)))
+
+    @noinline private def optionToModifierRender[T: Render](value: Option[T]): VDomModifier = value.fold(VDomModifier.empty)(VDomModifier(_))
+
+    @noinline private def undefinedToModifierRender[T: Render](value: js.UndefOr[T]): VDomModifier = value.fold(VDomModifier.empty)(VDomModifier(_))
+
+    @noinline private def syncToModifierRender[F[_] : RunSyncEffect, T: Render](effect: F[T]): VDomModifier = SyncEffectModifier(() => VDomModifier(RunSyncEffect[F].unsafeRun(effect)))
+
+    @noinline private def syncToModifier[F[_] : RunSyncEffect](effect: F[VDomModifier]): VDomModifier = SyncEffectModifier(() => RunSyncEffect[F].unsafeRun(effect))
+
+    @noinline private def asyncToModifier[F[_] : Effect](effect: F[VDomModifier]): VDomModifier = StreamModifier(Observable.fromAsync(effect).subscribe(_))
+
+    @noinline private def asyncToModifierRender[F[_] : Effect, T: Render](effect: F[T]): VDomModifier = StreamModifier(Observable.fromAsync(effect).map(VDomModifier(_)).subscribe(_))
+
+    @noinline private def sourceToModifier[F[_] : Source](source: F[VDomModifier]): VDomModifier = StreamModifier(Source[F].subscribe(source))
+
+    @noinline private def sourceToModifierRender[F[_] : Source, T: Render](source: F[T]): VDomModifier = StreamModifier(sink => Source[F].subscribe(source)(Observer.contramap[Observer, VDomModifier, T](sink)(VDomModifier(_))))
+
+    @noinline private def childCommandSeqToModifier[F[_] : Source](source: F[Seq[ChildCommand]]): VDomModifier = ChildCommandsModifier(Observable.lift(source))
+
+    @noinline private def childCommandToModifier[F[_] : Source](source: F[ChildCommand]): VDomModifier = ChildCommandsModifier(Observable.map(source)(Seq(_)))
+
+    @noinline private def futureToModifierRender[T: Render](future: Future[T])(implicit ec: ExecutionContext): VDomModifier = future.value match {
+      case Some(Success(value)) => VDomModifier(value)
+      case _ => StreamModifier(Observable.fromFuture(future).map(VDomModifier(_)).subscribe(_))
+    }
+
+    @noinline private def futureToModifier(future: Future[VDomModifier])(implicit ec: ExecutionContext): VDomModifier = future.value match {
+      case Some(Success(value)) => value
+      case _ => StreamModifier(Observable.fromFuture(future).subscribe(_))
+    }
   }
 }

--- a/outwatch/src/main/scala/outwatch/VDomModifier.scala
+++ b/outwatch/src/main/scala/outwatch/VDomModifier.scala
@@ -10,8 +10,8 @@ import snabbdom.{DataObject, VNodeProxy}
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters._
 
-class CVDomModifier(implicit cereal: Cereal) {
-  import cereal._
+class CVDomModifier(implicit env: Env) {
+  import env._
 
   sealed trait VDomModifier
 

--- a/outwatch/src/main/scala/outwatch/VDomModifier.scala
+++ b/outwatch/src/main/scala/outwatch/VDomModifier.scala
@@ -4,147 +4,151 @@ import cats.Monoid
 import org.scalajs.dom._
 import outwatch.helpers.ModifierBooleanOps
 import outwatch.helpers.NativeHelpers._
-import colibri.{Observable, Observer, Cancelable, SubscriptionOwner}
+import hummingbird._
 import snabbdom.{DataObject, VNodeProxy}
 
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters._
 
-sealed trait VDomModifier
+class CVDomModifier(implicit cereal: Cereal) {
+  import cereal._
 
-object VDomModifier {
-  @inline def empty: VDomModifier = EmptyModifier
+  sealed trait VDomModifier
 
-  @inline def apply(): VDomModifier = empty
+  object VDomModifier {
+    @inline def empty: VDomModifier = EmptyModifier
 
-  @inline def apply[T : Render](t: T): VDomModifier = Render[T].render(t)
+    @inline def apply(): VDomModifier = empty
 
-  @inline def apply(modifier: VDomModifier, modifier2: VDomModifier): VDomModifier =
-    CompositeModifier(js.Array(modifier, modifier2))
+    @inline def apply[T : Render](t: T): VDomModifier = Render[T].render(t)
 
-  @inline def apply(modifier: VDomModifier, modifier2: VDomModifier, modifier3: VDomModifier): VDomModifier =
-    CompositeModifier(js.Array(modifier, modifier2, modifier3))
+    @inline def apply(modifier: VDomModifier, modifier2: VDomModifier): VDomModifier =
+      CompositeModifier(js.Array(modifier, modifier2))
 
-  @inline def apply(modifier: VDomModifier, modifier2: VDomModifier, modifier3: VDomModifier, modifier4: VDomModifier): VDomModifier =
-    CompositeModifier(js.Array(modifier, modifier2, modifier3, modifier4))
+    @inline def apply(modifier: VDomModifier, modifier2: VDomModifier, modifier3: VDomModifier): VDomModifier =
+      CompositeModifier(js.Array(modifier, modifier2, modifier3))
 
-  @inline def apply(modifier: VDomModifier, modifier2: VDomModifier, modifier3: VDomModifier, modifier4: VDomModifier, modifier5: VDomModifier): VDomModifier =
-    CompositeModifier(js.Array(modifier, modifier2, modifier3, modifier4, modifier5))
+    @inline def apply(modifier: VDomModifier, modifier2: VDomModifier, modifier3: VDomModifier, modifier4: VDomModifier): VDomModifier =
+      CompositeModifier(js.Array(modifier, modifier2, modifier3, modifier4))
 
-  @inline def apply(modifier: VDomModifier, modifier2: VDomModifier, modifier3: VDomModifier, modifier4: VDomModifier, modifier5: VDomModifier, modifier6: VDomModifier): VDomModifier =
-    CompositeModifier(js.Array(modifier, modifier2, modifier3, modifier4, modifier5, modifier6))
+    @inline def apply(modifier: VDomModifier, modifier2: VDomModifier, modifier3: VDomModifier, modifier4: VDomModifier, modifier5: VDomModifier): VDomModifier =
+      CompositeModifier(js.Array(modifier, modifier2, modifier3, modifier4, modifier5))
 
-  @inline def apply(modifier: VDomModifier, modifier2: VDomModifier, modifier3: VDomModifier, modifier4: VDomModifier, modifier5: VDomModifier, modifier6: VDomModifier, modifier7: VDomModifier, modifiers: VDomModifier*): VDomModifier =
-    CompositeModifier(js.Array(modifier, modifier2, modifier3, modifier4, modifier5, modifier6, modifier7, CompositeModifier(modifiers)))
+    @inline def apply(modifier: VDomModifier, modifier2: VDomModifier, modifier3: VDomModifier, modifier4: VDomModifier, modifier5: VDomModifier, modifier6: VDomModifier): VDomModifier =
+      CompositeModifier(js.Array(modifier, modifier2, modifier3, modifier4, modifier5, modifier6))
 
-  @inline def delay[T : Render](modifier: => T): VDomModifier = SyncEffectModifier(() => VDomModifier(modifier))
+    @inline def apply(modifier: VDomModifier, modifier2: VDomModifier, modifier3: VDomModifier, modifier4: VDomModifier, modifier5: VDomModifier, modifier6: VDomModifier, modifier7: VDomModifier, modifiers: VDomModifier*): VDomModifier =
+      CompositeModifier(js.Array(modifier, modifier2, modifier3, modifier4, modifier5, modifier6, modifier7, CompositeModifier(modifiers)))
 
-  @inline def ifTrue(condition: Boolean): ModifierBooleanOps = new ModifierBooleanOps(condition)
-  @inline def ifNot(condition: Boolean): ModifierBooleanOps = new ModifierBooleanOps(!condition)
+    @inline def delay[T : Render](modifier: => T): VDomModifier = SyncEffectModifier(() => VDomModifier(modifier))
 
-  implicit object monoid extends Monoid[VDomModifier] {
-    @inline def empty: VDomModifier = VDomModifier.empty
-    @inline def combine(x: VDomModifier, y: VDomModifier): VDomModifier = VDomModifier(x, y)
+    @inline def ifTrue(condition: Boolean): ModifierBooleanOps = new ModifierBooleanOps(condition)
+    @inline def ifNot(condition: Boolean): ModifierBooleanOps = new ModifierBooleanOps(!condition)
+
+    implicit object monoid extends Monoid[VDomModifier] {
+      @inline def empty: VDomModifier = VDomModifier.empty
+      @inline def combine(x: VDomModifier, y: VDomModifier): VDomModifier = VDomModifier(x, y)
+    }
+
+    implicit object subscriptionOwner extends SubscriptionOwner[VDomModifier] {
+      @inline def own(owner: VDomModifier)(subscription: () => Cancelable): VDomModifier = VDomModifier(managedFunction(subscription), owner)
+    }
+
+    @inline implicit def renderToVDomModifier[T : Render](value: T): VDomModifier = Render[T].render(value)
   }
 
-  implicit object subscriptionOwner extends SubscriptionOwner[VDomModifier] {
-    @inline def own(owner: VDomModifier)(subscription: () => Cancelable): VDomModifier = VDomModifier(managedFunction(subscription), owner)
+  sealed trait StaticVDomModifier extends VDomModifier
+
+  final case class VNodeProxyNode(proxy: VNodeProxy) extends StaticVDomModifier
+
+  final case class Key(value: Key.Value) extends StaticVDomModifier
+  object Key {
+    type Value = DataObject.KeyValue
   }
 
-  @inline implicit def renderToVDomModifier[T : Render](value: T): VDomModifier = Render[T].render(value)
-}
+  final case class Emitter(eventType: String, trigger: js.Function1[Event, Unit]) extends StaticVDomModifier
 
-sealed trait StaticVDomModifier extends VDomModifier
-
-final case class VNodeProxyNode(proxy: VNodeProxy) extends StaticVDomModifier
-
-final case class Key(value: Key.Value) extends StaticVDomModifier
-object Key {
-  type Value = DataObject.KeyValue
-}
-
-final case class Emitter(eventType: String, trigger: js.Function1[Event, Unit]) extends StaticVDomModifier
-
-sealed trait Attr extends StaticVDomModifier
-object Attr {
-  type Value = DataObject.AttrValue
-}
-final case class BasicAttr(title: String, value: Attr.Value) extends Attr
-final case class AccumAttr(title: String, value: Attr.Value, accum: (Attr.Value, Attr.Value)=> Attr.Value) extends Attr
-
-final case class Prop(title: String, value: Prop.Value) extends StaticVDomModifier
-object Prop {
-  type Value = DataObject.PropValue
-}
-
-sealed trait Style extends StaticVDomModifier
-final case class AccumStyle(title: String, value: String, accum: (String, String) => String) extends Style
-final case class BasicStyle(title: String, value: String) extends Style
-final case class DelayedStyle(title: String, value: String) extends Style
-final case class RemoveStyle(title: String, value: String) extends Style
-final case class DestroyStyle(title: String, value: String) extends Style
-
-sealed trait SnabbdomHook extends StaticVDomModifier
-final case class InitHook(trigger: js.Function1[VNodeProxy, Unit]) extends SnabbdomHook
-final case class InsertHook(trigger: js.Function1[VNodeProxy, Unit]) extends SnabbdomHook
-final case class PrePatchHook(trigger: js.Function2[VNodeProxy, VNodeProxy, Unit]) extends SnabbdomHook
-final case class UpdateHook(trigger: js.Function2[VNodeProxy, VNodeProxy, Unit]) extends SnabbdomHook
-final case class PostPatchHook(trigger: js.Function2[VNodeProxy, VNodeProxy, Unit]) extends SnabbdomHook
-final case class DestroyHook(trigger: js.Function1[VNodeProxy, Unit]) extends SnabbdomHook
-
-sealed trait DomHook extends SnabbdomHook
-final case class DomMountHook(trigger: js.Function1[VNodeProxy, Unit]) extends DomHook
-final case class DomUnmountHook(trigger: js.Function1[VNodeProxy, Unit]) extends DomHook
-final case class DomUpdateHook(trigger: js.Function2[VNodeProxy, VNodeProxy, Unit]) extends DomHook
-final case class DomPreUpdateHook(trigger: js.Function2[VNodeProxy, VNodeProxy, Unit]) extends DomHook
-
-final case class NextVDomModifier(modifier: StaticVDomModifier) extends StaticVDomModifier
-
-case object EmptyModifier extends VDomModifier
-final case class CompositeModifier(modifiers: Iterable[VDomModifier]) extends VDomModifier
-final case class StreamModifier(subscription: Observer[VDomModifier] => Cancelable) extends VDomModifier
-final case class ChildCommandsModifier(commands: Observable[Seq[ChildCommand]]) extends VDomModifier
-final case class CancelableModifier(subscription: () => Cancelable) extends VDomModifier
-final case class SyncEffectModifier(unsafeRun: () => VDomModifier) extends VDomModifier
-final case class StringVNode(text: String) extends VDomModifier
-
-sealed trait VNode extends VDomModifier {
-  def apply(args: VDomModifier*): VNode
-  def append(args: VDomModifier*): VNode
-  def prepend(args: VDomModifier*): VNode
-}
-object VNode {
-  implicit object subscriptionOwner extends SubscriptionOwner[VNode] {
-    @inline def own(owner: VNode)(subscription: () => Cancelable): VNode = owner.append(managedFunction(subscription))
+  sealed trait Attr extends StaticVDomModifier
+  object Attr {
+    type Value = DataObject.AttrValue
   }
-}
-sealed trait BasicVNode extends VNode {
-  def nodeType: String
-  def modifiers: js.Array[VDomModifier]
-  def apply(args: VDomModifier*): BasicVNode
-  def append(args: VDomModifier*): BasicVNode
-  def prepend(args: VDomModifier*): BasicVNode
-  def thunk(key: Key.Value)(arguments: Any*)(renderFn: => VDomModifier): ThunkVNode = ThunkVNode(this, key, arguments.toJSArray, () => renderFn)
-  def thunkConditional(key: Key.Value)(shouldRender: Boolean)(renderFn: => VDomModifier): ConditionalVNode = ConditionalVNode(this, key, shouldRender, () => renderFn)
-  @inline def thunkStatic(key: Key.Value)(renderFn: => VDomModifier): ConditionalVNode = thunkConditional(key)(false)(renderFn)
-}
-@inline final case class ThunkVNode(baseNode: BasicVNode, key: Key.Value, arguments: js.Array[Any], renderFn: () => VDomModifier) extends VNode {
-  @inline def apply(args: VDomModifier*): ThunkVNode = append(args: _*)
-  def append(args: VDomModifier*): ThunkVNode = copy(baseNode = baseNode(args: _*))
-  def prepend(args: VDomModifier*): ThunkVNode = copy(baseNode = baseNode.prepend(args :_*))
-}
-@inline final case class ConditionalVNode(baseNode: BasicVNode, key: Key.Value, shouldRender: Boolean, renderFn: () => VDomModifier) extends VNode {
-  @inline def apply(args: VDomModifier*): ConditionalVNode = append(args: _*)
-  def append(args: VDomModifier*): ConditionalVNode = copy(baseNode = baseNode(args: _*))
-  def prepend(args: VDomModifier*): ConditionalVNode = copy(baseNode = baseNode.prepend(args: _*))
-}
-@inline final case class HtmlVNode(nodeType: String, modifiers: js.Array[VDomModifier]) extends BasicVNode {
-  @inline def apply(args: VDomModifier*): HtmlVNode = append(args: _*)
-  def append(args: VDomModifier*): HtmlVNode = copy(modifiers = appendSeq(modifiers, args))
-  def prepend(args: VDomModifier*): HtmlVNode = copy(modifiers = prependSeq(modifiers, args))
-}
-@inline final case class SvgVNode(nodeType: String, modifiers: js.Array[VDomModifier]) extends BasicVNode {
-  @inline def apply(args: VDomModifier*): SvgVNode = append(args: _*)
-  def append(args: VDomModifier*): SvgVNode = copy(modifiers = appendSeq(modifiers, args))
-  def prepend(args: VDomModifier*): SvgVNode = copy(modifiers = prependSeq(modifiers, args))
+  final case class BasicAttr(title: String, value: Attr.Value) extends Attr
+  final case class AccumAttr(title: String, value: Attr.Value, accum: (Attr.Value, Attr.Value)=> Attr.Value) extends Attr
+
+  final case class Prop(title: String, value: Prop.Value) extends StaticVDomModifier
+  object Prop {
+    type Value = DataObject.PropValue
+  }
+
+  sealed trait Style extends StaticVDomModifier
+  final case class AccumStyle(title: String, value: String, accum: (String, String) => String) extends Style
+  final case class BasicStyle(title: String, value: String) extends Style
+  final case class DelayedStyle(title: String, value: String) extends Style
+  final case class RemoveStyle(title: String, value: String) extends Style
+  final case class DestroyStyle(title: String, value: String) extends Style
+
+  sealed trait SnabbdomHook extends StaticVDomModifier
+  final case class InitHook(trigger: js.Function1[VNodeProxy, Unit]) extends SnabbdomHook
+  final case class InsertHook(trigger: js.Function1[VNodeProxy, Unit]) extends SnabbdomHook
+  final case class PrePatchHook(trigger: js.Function2[VNodeProxy, VNodeProxy, Unit]) extends SnabbdomHook
+  final case class UpdateHook(trigger: js.Function2[VNodeProxy, VNodeProxy, Unit]) extends SnabbdomHook
+  final case class PostPatchHook(trigger: js.Function2[VNodeProxy, VNodeProxy, Unit]) extends SnabbdomHook
+  final case class DestroyHook(trigger: js.Function1[VNodeProxy, Unit]) extends SnabbdomHook
+
+  sealed trait DomHook extends SnabbdomHook
+  final case class DomMountHook(trigger: js.Function1[VNodeProxy, Unit]) extends DomHook
+  final case class DomUnmountHook(trigger: js.Function1[VNodeProxy, Unit]) extends DomHook
+  final case class DomUpdateHook(trigger: js.Function2[VNodeProxy, VNodeProxy, Unit]) extends DomHook
+  final case class DomPreUpdateHook(trigger: js.Function2[VNodeProxy, VNodeProxy, Unit]) extends DomHook
+
+  final case class NextVDomModifier(modifier: StaticVDomModifier) extends StaticVDomModifier
+
+  case object EmptyModifier extends VDomModifier
+  final case class CompositeModifier(modifiers: Iterable[VDomModifier]) extends VDomModifier
+  final case class StreamModifier(subscription: Rx[VDomModifier] => Cancelable) extends VDomModifier
+  final case class ChildCommandsModifier(commands: Tx[Seq[ChildCommand]]) extends VDomModifier
+  final case class CancelableModifier(subscription: () => Cancelable) extends VDomModifier
+  final case class SyncEffectModifier(unsafeRun: () => VDomModifier) extends VDomModifier
+  final case class StringVNode(text: String) extends VDomModifier
+
+  sealed trait VNode extends VDomModifier {
+    def apply(args: VDomModifier*): VNode
+    def append(args: VDomModifier*): VNode
+    def prepend(args: VDomModifier*): VNode
+  }
+  object VNode {
+    implicit object subscriptionOwner extends SubscriptionOwner[VNode] {
+      @inline def own(owner: VNode)(subscription: () => Cancelable): VNode = owner.append(managedFunction(subscription))
+    }
+  }
+  sealed trait BasicVNode extends VNode {
+    def nodeType: String
+    def modifiers: js.Array[VDomModifier]
+    def apply(args: VDomModifier*): BasicVNode
+    def append(args: VDomModifier*): BasicVNode
+    def prepend(args: VDomModifier*): BasicVNode
+    def thunk(key: Key.Value)(arguments: Any*)(renderFn: => VDomModifier): ThunkVNode = ThunkVNode(this, key, arguments.toJSArray, () => renderFn)
+    def thunkConditional(key: Key.Value)(shouldRender: Boolean)(renderFn: => VDomModifier): ConditionalVNode = ConditionalVNode(this, key, shouldRender, () => renderFn)
+    @inline def thunkStatic(key: Key.Value)(renderFn: => VDomModifier): ConditionalVNode = thunkConditional(key)(false)(renderFn)
+  }
+  @inline final case class ThunkVNode(baseNode: BasicVNode, key: Key.Value, arguments: js.Array[Any], renderFn: () => VDomModifier) extends VNode {
+    @inline def apply(args: VDomModifier*): ThunkVNode = append(args: _*)
+    def append(args: VDomModifier*): ThunkVNode = copy(baseNode = baseNode(args: _*))
+    def prepend(args: VDomModifier*): ThunkVNode = copy(baseNode = baseNode.prepend(args :_*))
+  }
+  @inline final case class ConditionalVNode(baseNode: BasicVNode, key: Key.Value, shouldRender: Boolean, renderFn: () => VDomModifier) extends VNode {
+    @inline def apply(args: VDomModifier*): ConditionalVNode = append(args: _*)
+    def append(args: VDomModifier*): ConditionalVNode = copy(baseNode = baseNode(args: _*))
+    def prepend(args: VDomModifier*): ConditionalVNode = copy(baseNode = baseNode.prepend(args: _*))
+  }
+  @inline final case class HtmlVNode(nodeType: String, modifiers: js.Array[VDomModifier]) extends BasicVNode {
+    @inline def apply(args: VDomModifier*): HtmlVNode = append(args: _*)
+    def append(args: VDomModifier*): HtmlVNode = copy(modifiers = appendSeq(modifiers, args))
+    def prepend(args: VDomModifier*): HtmlVNode = copy(modifiers = prependSeq(modifiers, args))
+  }
+  @inline final case class SvgVNode(nodeType: String, modifiers: js.Array[VDomModifier]) extends BasicVNode {
+    @inline def apply(args: VDomModifier*): SvgVNode = append(args: _*)
+    def append(args: VDomModifier*): SvgVNode = copy(modifiers = appendSeq(modifiers, args))
+    def prepend(args: VDomModifier*): SvgVNode = copy(modifiers = prependSeq(modifiers, args))
+  }
 }

--- a/outwatch/src/main/scala/outwatch/package.scala
+++ b/outwatch/src/main/scala/outwatch/package.scala
@@ -2,7 +2,7 @@ import com.raquo.domtypes.generic.keys
 import outwatch.helpers.BasicStyleBuilder
 
 package object outwatch extends ManagedSubscriptions {
-  type EmitterBuilder[+O, +R] = EmitterBuilderExecution[O, R, EmitterBuilder.Execution]
+  // type EmitterBuilder[+O, +R] = EmitterBuilderExecution[O, R, EmitterBuilder.Execution]
 
   //TODO: invent typeclass CanBuildStyle[F[_]]
   @inline implicit def StyleIsBuilder[T](style: keys.Style[T]): BasicStyleBuilder[T] = new BasicStyleBuilder[T](style.name)


### PR DESCRIPTION
This Pull Request aims to introduce a generalized abstraction over streams to outwatch via use of the hummingbird library. While this PR is still a work in progress, it could in theory make outwatch compatible with libraries such as zio and fs2 without the need to introduce their specific features into outwatch itself.  

The concept works as if the entire library was wrapped into a trait that defines two abstract type parameters, `Rx[-T]` and `Tx[+T]`. These take the role of the `Observer` and the `Observable` respectively. The usual set of streaming functions is made available for these types via syntax imports. When working with a specific streaming library, the trait is extended and the abstract types are set to whichever streaming types are supported, i.e. `fs2.Stream` or `zio.ZStream` and so on.  
While this example is nice to visualize the concept, in reality it is a bit more complicated since the concept would require us to write all of the libraries code into a singe file. Instead this PR creates a class called `Env` which provides the necessary environment everything is wrapped into it individually.  

**While I am still not done integrating this, I wanted to make this PR to get some feedback on the general idea.**  

Right now this requires the [hummingbird library](https://github.com/busti/hummingbird) to be checked out into the parent folder of this repo, which makes it easier to develop on both libraries at once as opposed to using jitpack.