### PR TITLE
Mdoc 2.3.1, remove no longer necessary hacks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -206,16 +206,6 @@ lazy val docs = project
       "REPOURL" -> "https://github.com/OutWatch/outwatch/blob/master",
       "js-mount-node" -> "docPreview"
     ),
-    libraryDependencies += "org.scala-js" %% "scalajs-linker" % scalaJSVersion,
-    libraryDependencies += {
-      scalaBinaryVersion.value match {
-        // keep these pinned to mdoc.js Scala versions
-        // scala-steward:off
-        case "2.12" => "org.scala-js" %% "scalajs-compiler" % scalaJSVersion cross CrossVersion.constant("2.12.15")
-        case "2.13" => "org.scala-js" %% "scalajs-compiler" % scalaJSVersion cross CrossVersion.constant("2.13.6")
-        // scala-steward:on
-      }
-    }
   )
 
 lazy val root = project

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.20.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.2")
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.24" )
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.1")
 
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 


### PR DESCRIPTION
Howdy! 

We've just released 2.3.1 which hopefully addresses the issues seen in #573
Locally I've been able to run `docs/docusaurusCreateSite`, whereas it was crashing before