### PR TITLE
optimization: ignore empty subscriptions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ inThisBuild(Seq(
 ))
 
 val jsdomVersion = "13.2.0"
-val colibriVersion = "0.4.2"
+val colibriVersion = "0.4.4"
 
 lazy val commonSettings = Seq(
   addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.2" cross CrossVersion.full),

--- a/outwatch/src/main/scala/outwatch/helpers/MutableNestedArray.scala
+++ b/outwatch/src/main/scala/outwatch/helpers/MutableNestedArray.scala
@@ -16,4 +16,9 @@ private[outwatch] class MutableNestedArray[T] {
   @inline def push(value: T | MutableNestedArray[T]): Unit = { array.push(value); () }
   @inline def clear(): Unit = array.clear()
   @inline def isEmpty: Boolean = array.isEmpty
+  @inline def calculateLength(): Int = {
+    var counter = 0
+    foreach(_ => counter += 1)
+    counter
+  }
 }


### PR DESCRIPTION
Currently, we setup mount and unmount hooks for every observable we encounter.
But some observables are empty or return just a few values or return a value from unsafely running a SyncIO or IO.
Colibri does not have a direct concept of completion to listen to, but we can check whether `subscribe` returns a Cancelable that is empty - no values coming in anymore and nothing to cancel.

This PR checks for empty subscriptions and ignores them - thereby having less overhead: no mount/unmount hooks, no preparation for patching the dom node.

Based on https://github.com/cornerman/colibri/pull/182
