### PR TITLE
Async patching and batching

### DIFF
--- a/outwatch/src/main/scala/outwatch/helpers/MutableNestedArray.scala
+++ b/outwatch/src/main/scala/outwatch/helpers/MutableNestedArray.scala
@@ -13,6 +13,12 @@ private[outwatch] final class MutableNestedArray[T] {
     case t: T@unchecked => f(t)
   })
 
+  def forall(condition: T => Boolean): Boolean = !exists(t => !condition(t))
+  def exists(condition: T => Boolean): Boolean = {
+    foreach { t => if (condition(t)) return true }
+    return false
+  }
+
   @inline def push(value: T | MutableNestedArray[T]): Unit = { array.push(value); () }
   @inline def clear(): Unit = array.clear()
   @inline def isEmpty: Boolean = array.isEmpty

--- a/outwatch/src/main/scala/outwatch/helpers/MutableNestedArray.scala
+++ b/outwatch/src/main/scala/outwatch/helpers/MutableNestedArray.scala
@@ -22,9 +22,13 @@ private[outwatch] final class MutableNestedArray[T] {
   @inline def push(value: T | MutableNestedArray[T]): Unit = { array.push(value); () }
   @inline def clear(): Unit = array.clear()
   @inline def isEmpty: Boolean = array.isEmpty
-  @inline def calculateLength(): Int = {
-    var counter = 0
-    foreach(_ => counter += 1)
-    counter
+
+  def toFlatArray: js.Array[T] = {
+    val flatArray = new js.Array[T]
+    foreach { t =>
+      flatArray.push(t)
+      ()
+    }
+    flatArray
   }
 }

--- a/outwatch/src/main/scala/outwatch/helpers/NativeHelpers.scala
+++ b/outwatch/src/main/scala/outwatch/helpers/NativeHelpers.scala
@@ -41,16 +41,4 @@ private[outwatch] object NativeHelpers {
       source.foreach(arr.push(_))
       arr
   }
-
-  // See: https://www.scala-js.org/doc/interoperability/global-scope.html#dynamically-lookup-a-global-variable-given-its-name
-  lazy val globalObject: js.Dynamic = {
-    import js.Dynamic.{global => g}
-    if (js.typeOf(g.global) != "undefined" && (g.global.Object eq g.Object)) {
-      // Node.js environment detected
-      g.global
-    } else {
-      // In all other well-known environment, we can use the global `this`
-      js.special.fileLevelThis.asInstanceOf[js.Dynamic]
-    }
-  }
 }

--- a/outwatch/src/main/scala/outwatch/interpreter/SnabbdomOps.scala
+++ b/outwatch/src/main/scala/outwatch/interpreter/SnabbdomOps.scala
@@ -97,7 +97,7 @@ private[outwatch] object SnabbdomOps {
 
     val nativeModifiers = NativeModifiers.from(node.modifiers, config, observer)
 
-    if (nativeModifiers.subscribables.isEmpty) {
+    if (nativeModifiers.subscribables.forall(_.isEmpty())) {
       // if no dynamic/subscribable content, then just create a simple proxy
       createProxy(SeparatedModifiers.from(nativeModifiers.modifiers), node.nodeType, vNodeId, vNodeNS)
     } else if (nativeModifiers.hasStream) {

--- a/tests/src/test/scala/outwatch/DomEventSpec.scala
+++ b/tests/src/test/scala/outwatch/DomEventSpec.scala
@@ -33,7 +33,7 @@ class DomEventSpec extends JSDomAsyncSpec {
                   cancelable = false
                 })
               }
-          _ <- IO(document.getElementById("click").dispatchEvent(event))
+          _ <- IO(document.getElementById("click").dispatchEvent(event)) *> IO.cede
           d <- IO(document.getElementById("btn").getAttribute("disabled"))
           _ <- IO(d shouldBe "")
     } yield succeed
@@ -52,67 +52,63 @@ class DomEventSpec extends JSDomAsyncSpec {
     for {
       vtree <- vtree
       _ <- Outwatch.renderInto[IO]("#app", vtree)
-    } yield {
-      document.getElementById("child").innerHTML shouldBe ""
+      _ = document.getElementById("child").innerHTML shouldBe ""
 
-      val event = new Event("click", new EventInit {
+      event = new Event("click", new EventInit {
         bubbles = true
         cancelable = false
       })
-      document.getElementById("click").dispatchEvent(event)
+      _ <- IO(document.getElementById("click").dispatchEvent(event)) *> IO.cede
 
-      document.getElementById("child").innerHTML shouldBe message
+      _ = document.getElementById("child").innerHTML shouldBe message
 
       //dispatch another event
-      document.getElementById("click").dispatchEvent(event)
+      _ <- IO(document.getElementById("click").dispatchEvent(event)) *> IO.cede
 
-      document.getElementById("child").innerHTML shouldBe message
+      _ = document.getElementById("child").innerHTML shouldBe message
 
-    }
+    } yield succeed
   }
 
   it should "be converted to a generic stream emitter correctly" in {
 
-    IO(Subject.replayLatest[String]()).flatMap { messages =>
+    val messages = Subject.replayLatest[String]()
 
-      val vtree = IO(Subject.replayLatest[String]()).map { stream =>
-        div(idAttr := "click", onClick.asLatest(messages) --> stream,
-          span(idAttr := "child", stream)
-        )
-      }
-
-      for {
-        vtree <- vtree
-        _ <- Outwatch.renderInto[IO]("#app", vtree)
-      } yield {
-
-        document.getElementById("child").innerHTML shouldBe ""
-
-        val firstMessage = "First"
-        messages.unsafeOnNext(firstMessage)
-
-        val event = new Event("click", new EventInit {
-          bubbles = true
-          cancelable = false
-        })
-        document.getElementById("click").dispatchEvent(event)
-
-        document.getElementById("child").innerHTML shouldBe firstMessage
-
-        //dispatch another event
-        document.getElementById("click").dispatchEvent(event)
-
-        document.getElementById("child").innerHTML shouldBe firstMessage
-
-        val secondMessage = "Second"
-        messages.unsafeOnNext(secondMessage)
-
-        document.getElementById("click").dispatchEvent(event)
-
-        document.getElementById("child").innerHTML shouldBe secondMessage
-      }
-
+    val vtree = IO(Subject.replayLatest[String]()).map { stream =>
+      div(idAttr := "click", onClick.asLatest(messages) --> stream,
+        span(idAttr := "child", stream)
+      )
     }
+
+    for {
+      vtree <- vtree
+      _ <- Outwatch.renderInto[IO]("#app", vtree)
+
+      _ = document.getElementById("child").innerHTML shouldBe ""
+
+      firstMessage = "First"
+      _ <- messages.onNextIO(firstMessage) *> IO.cede
+
+      event = new Event("click", new EventInit {
+        bubbles = true
+        cancelable = false
+      })
+      _ <- IO(document.getElementById("click").dispatchEvent(event)) *> IO.cede
+
+      _ = document.getElementById("child").innerHTML shouldBe firstMessage
+
+      //dispatch another event
+      _ <- IO(document.getElementById("click").dispatchEvent(event)) *> IO.cede
+
+      _ = document.getElementById("child").innerHTML shouldBe firstMessage
+
+      secondMessage = "Second"
+      _ <- messages.onNextIO(secondMessage) *> IO.cede
+
+      _ <- IO(document.getElementById("click").dispatchEvent(event)) *> IO.cede
+
+      _ = document.getElementById("child").innerHTML shouldBe secondMessage
+    } yield succeed
   }
 
   it should "be able to set the value of a text field" in {
@@ -121,116 +117,121 @@ class DomEventSpec extends JSDomAsyncSpec {
 
     val vtree = input(idAttr := "input", attributes.value <-- values)
 
-    Outwatch.renderInto[IO]("#app", vtree).map {_ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", vtree)
 
-      val patched = document.getElementById("input").asInstanceOf[html.Input]
+      patched = document.getElementById("input").asInstanceOf[html.Input]
 
-      patched.value shouldBe ""
+      _ = patched.value shouldBe ""
 
-      val value1 = "Hello"
-      values.unsafeOnNext(value1)
+      value1 = "Hello"
+      _ <- values.onNextIO(value1) *> IO.cede
 
-      patched.value shouldBe value1
+      _ = patched.value shouldBe value1
 
-      val value2 = "World"
-      values.unsafeOnNext(value2)
+      value2 = "World"
+      _ <- values.onNextIO(value2) *> IO.cede
 
-      patched.value shouldBe value2
+      _ = patched.value shouldBe value2
 
-      values.unsafeOnNext("")
+      _ <- values.onNextIO("") *> IO.cede
 
-      patched.value shouldBe ""
+      _ = patched.value shouldBe ""
 
-    }
+    } yield succeed
   }
 
   it should "preserve user input after setting defaultValue" in {
     val defaultValues = Subject.publish[String]()
 
     val vtree = input(idAttr := "input", attributes.defaultValue <-- defaultValues)
-    Outwatch.renderInto[IO]("#app", vtree).map { _ =>
 
-      val patched = document.getElementById("input").asInstanceOf[html.Input]
-      patched.value shouldBe ""
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", vtree)
 
-      val value1 = "Hello"
-      defaultValues.unsafeOnNext(value1)
-      patched.value shouldBe value1
+      patched = document.getElementById("input").asInstanceOf[html.Input]
+      _ = patched.value shouldBe ""
 
-      val userInput = "user input"
-      patched.value = userInput
+      value1 = "Hello"
+      _ <- defaultValues.onNextIO(value1) *> IO.cede
+      _ = patched.value shouldBe value1
 
-      defaultValues.unsafeOnNext("GoodByte")
-      patched.value shouldBe userInput
+      userInput = "user input"
+      _ = patched.value = userInput
 
-    }
+      _ <- defaultValues.onNextIO("GoodByte") *> IO.cede
+      _ = patched.value shouldBe userInput
+
+    } yield succeed
   }
 
   it should "set input value to the same value after user change" in {
     val values = Subject.publish[String]()
 
     val vtree = input(idAttr := "input", attributes.value <-- values)
-    Outwatch.renderInto[IO]("#app", vtree).map { _ =>
 
-      val patched = document.getElementById("input").asInstanceOf[html.Input]
-      patched.value shouldBe ""
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", vtree)
 
-      val value1 = "Hello"
-      values.unsafeOnNext(value1)
-      patched.value shouldBe value1
+      patched = document.getElementById("input").asInstanceOf[html.Input]
+      _ = patched.value shouldBe ""
 
-      patched.value = "user input"
+      value1 = "Hello"
+      _ <- values.onNextIO(value1) *> IO.cede
+      _ = patched.value shouldBe value1
 
-      values.unsafeOnNext("Hello")
-      patched.value shouldBe value1
+      _ = patched.value = "user input"
 
-    }
+      _ <- values.onNextIO("Hello") *> IO.cede
+      _ = patched.value shouldBe value1
+
+    } yield succeed
   }
 
   it should "be bindable to a list of children" in {
 
     val state = Subject.publish[Seq[VNode]]()
 
-
     val vtree = div(
       ul(idAttr := "list", state)
     )
 
-    Outwatch.renderInto[IO]("#app", vtree).map { _ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", vtree)
 
-      val list = document.getElementById("list")
+      list = document.getElementById("list")
 
-      list.childElementCount shouldBe 0
+      _ = list.childElementCount shouldBe 0
 
-      val first = "Test"
+      first = "Test"
 
-      state.unsafeOnNext(Seq(span(first)))
+      _ <- state.onNextIO(Seq(span(first))) *> IO.cede
 
-      list.childElementCount shouldBe 1
-      list.innerHTML.contains(first) shouldBe true
+      _ = list.childElementCount shouldBe 1
+      _ = list.innerHTML.contains(first) shouldBe true
 
-      val second = "Hello"
-      state.unsafeOnNext(Seq(span(first), span(second)))
+      second = "Hello"
+      _ <- state.onNextIO(Seq(span(first), span(second))) *> IO.cede
 
-      list.childElementCount shouldBe 2
-      list.innerHTML.contains(first) shouldBe true
-      list.innerHTML.contains(second) shouldBe true
+      _ = list.childElementCount shouldBe 2
+      _ = list.innerHTML.contains(first) shouldBe true
+      _ = list.innerHTML.contains(second) shouldBe true
 
-      val third = "World"
+      third = "World"
 
-      state.unsafeOnNext(Seq(span(first), span(second), span(third)))
+      _ <- state.onNextIO(Seq(span(first), span(second), span(third))) *> IO.cede
 
-      list.childElementCount shouldBe 3
-      list.innerHTML.contains(first) shouldBe true
-      list.innerHTML.contains(second) shouldBe true
-      list.innerHTML.contains(third) shouldBe true
+      _ = list.childElementCount shouldBe 3
+      _ = list.innerHTML.contains(first) shouldBe true
+      _ = list.innerHTML.contains(second) shouldBe true
+      _ = list.innerHTML.contains(third) shouldBe true
 
-      state.unsafeOnNext(Seq(span(first), span(third)))
+      _ <- state.onNextIO(Seq(span(first), span(third))) *> IO.cede
 
-      list.childElementCount shouldBe 2
-      list.innerHTML.contains(first) shouldBe true
-      list.innerHTML.contains(third) shouldBe true
-    }
+      _ = list.childElementCount shouldBe 2
+      _ = list.innerHTML.contains(first) shouldBe true
+      _ = list.innerHTML.contains(third) shouldBe true
+    } yield succeed
   }
 
   it should "be able to handle two events of the same type" in {
@@ -250,16 +251,17 @@ class DomEventSpec extends JSDomAsyncSpec {
     for {
       node <- node
       _ <- Outwatch.renderInto[IO]("#app", node)
-    } yield {
-      val event = new Event("click", new EventInit {
+
+      event = new Event("click", new EventInit {
         bubbles = true
         cancelable = false
       })
-      document.getElementById("click").dispatchEvent(event)
 
-      document.getElementById("first").innerHTML shouldBe messages._1
-      document.getElementById("second").innerHTML shouldBe messages._2
-    }
+      _ <- IO(document.getElementById("click").dispatchEvent(event)) *> IO.cede
+
+      _ = document.getElementById("first").innerHTML shouldBe messages._1
+      _ = document.getElementById("second").innerHTML shouldBe messages._2
+    } yield succeed
   }
 
   it should "be able to be transformed by a function in place" in {
@@ -278,17 +280,17 @@ class DomEventSpec extends JSDomAsyncSpec {
     for {
       node <- node
       _ <- Outwatch.renderInto[IO]("#app", node)
-    } yield {
 
-      val event = new Event("click", new EventInit {
+      event = new Event("click", new EventInit {
         bubbles = true
         cancelable = false
       })
-      document.getElementById("click").dispatchEvent(event)
 
-      document.getElementById("num").innerHTML shouldBe number.toString
+      _ <- IO(document.getElementById("click").dispatchEvent(event)) *> IO.cede
 
-    }
+      _ = document.getElementById("num").innerHTML shouldBe number.toString
+
+    } yield succeed
   }
 
   it should ".transform should work as expected" in {
@@ -310,17 +312,17 @@ class DomEventSpec extends JSDomAsyncSpec {
     for {
       node <- node
       _ <- Outwatch.renderInto[IO]("#app", node)
-    } yield {
 
-      val event = new Event("click", new EventInit {
+      event = new Event("click", new EventInit {
         bubbles = true
         cancelable = false
       })
-      document.getElementById("click").dispatchEvent(event)
 
-      document.getElementById("num").innerHTML shouldBe "<span>1</span><span>2</span>"
+      _ <- IO(document.getElementById("click").dispatchEvent(event)) *> IO.cede
 
-    }
+      _ = document.getElementById("num").innerHTML shouldBe "<span>1</span><span>2</span>"
+
+    } yield succeed
   }
 
   it should "be able to be transformed from strings" in {
@@ -337,17 +339,16 @@ class DomEventSpec extends JSDomAsyncSpec {
     for {
       node <- node
       _ <- Outwatch.renderInto[IO]("#app", node)
-    } yield {
 
-      val inputEvt = new Event("input", new EventInit {
+      inputEvt = new Event("input", new EventInit {
         bubbles = false
         cancelable = true
       })
-      document.getElementById("input").dispatchEvent(inputEvt)
+      _ <- IO(document.getElementById("input").dispatchEvent(inputEvt)) *> IO.cede
 
-      document.getElementById("num").innerHTML shouldBe number.toString
+      _ = document.getElementById("num").innerHTML shouldBe number.toString
 
-    }
+    } yield succeed
   }
 
   it should "handler can trigger side-effecting functions" in {
@@ -369,27 +370,28 @@ class DomEventSpec extends JSDomAsyncSpec {
       )
     }
 
-    Outwatch.renderInto[IO]("#app", node).map {_ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      val inputEvt = new Event("click", new EventInit {
+      inputEvt = new Event("click", new EventInit {
         bubbles = false
         cancelable = true
       })
-      document.getElementById("button").dispatchEvent(inputEvt)
-      stream.unsafeOnNext("woop")
-      triggeredEventFunction shouldBe 1
-      triggeredIntFunction shouldBe 1
-      triggeredFunction shouldBe 1
-      triggeredFunction2 shouldBe 1
+      _ <- IO(document.getElementById("button").dispatchEvent(inputEvt)) *> IO.cede
+      _ <- stream.onNextIO("woop") *> IO.cede
+      _ = triggeredEventFunction shouldBe 1
+      _ = triggeredIntFunction shouldBe 1
+      _ = triggeredFunction shouldBe 1
+      _ = triggeredFunction2 shouldBe 1
 
-      document.getElementById("button").dispatchEvent(inputEvt)
-      stream.unsafeOnNext("waap")
-      triggeredEventFunction shouldBe 2
-      triggeredIntFunction shouldBe 2
-      triggeredFunction shouldBe 2
-      triggeredFunction2 shouldBe 2
+      _ <- IO(document.getElementById("button").dispatchEvent(inputEvt)) *> IO.cede
+      _ <- stream.onNextIO("waap") *> IO.cede
+      _ = triggeredEventFunction shouldBe 2
+      _ = triggeredIntFunction shouldBe 2
+      _ = triggeredFunction shouldBe 2
+      _ = triggeredFunction2 shouldBe 2
 
-    }
+    } yield succeed
   }
 
   it should "correctly be transformed from latest in observable" in {
@@ -412,33 +414,32 @@ class DomEventSpec extends JSDomAsyncSpec {
     for {
       node <- node
       _ <- Outwatch.renderInto[IO]("#app", node)
-    } yield {
 
-      val inputElement = document.getElementById("input").asInstanceOf[html.Input]
-      val submitButton = document.getElementById("submit")
+      inputElement = document.getElementById("input").asInstanceOf[html.Input]
+      submitButton = document.getElementById("submit")
 
-      val inputEvt = new Event("input", new EventInit {
+      inputEvt = new Event("input", new EventInit {
         bubbles = false
         cancelable = true
       })
-      val clickEvt = new Event("click", new EventInit {
+      clickEvt = new Event("click", new EventInit {
         bubbles = true
         cancelable = true
       })
-      inputElement.value = "item 1"
-      inputElement.dispatchEvent(inputEvt)
+      _ = inputElement.value = "item 1"
+      _ <- IO(inputElement.dispatchEvent(inputEvt)) *> IO.cede
 
-      inputElement.value = "item 2"
-      inputElement.dispatchEvent(inputEvt)
+      _ = inputElement.value = "item 2"
+      _ <- IO(inputElement.dispatchEvent(inputEvt)) *> IO.cede
 
-      inputElement.value = "item 3"
-      inputElement.dispatchEvent(inputEvt)
+      _ = inputElement.value = "item 3"
+      _ <- IO(inputElement.dispatchEvent(inputEvt)) *> IO.cede
 
-      submitButton.dispatchEvent(clickEvt)
+      _ <- IO(submitButton.dispatchEvent(clickEvt)) *> IO.cede
 
-      document.getElementById("items").childNodes.length shouldBe 1
+      _ = document.getElementById("items").childNodes.length shouldBe 1
 
-    }
+    } yield succeed
   }
 
   "Boolean Props" should "be handled corectly" in {
@@ -454,27 +455,26 @@ class DomEventSpec extends JSDomAsyncSpec {
     for {
       node <- node
       _ <- Outwatch.renderInto[IO]("#app", node)
-    } yield {
 
-      val checkbox = document.getElementById("checkbox").asInstanceOf[html.Input]
-      val onButton = document.getElementById("on_button")
-      val offButton = document.getElementById("off_button")
+      checkbox = document.getElementById("checkbox").asInstanceOf[html.Input]
+      onButton = document.getElementById("on_button")
+      offButton = document.getElementById("off_button")
 
-      checkbox.checked shouldBe false
+      _ = checkbox.checked shouldBe false
 
-      val clickEvt = new Event("click", new EventInit {
+      clickEvt = new Event("click", new EventInit {
         bubbles = true
         cancelable = true
       })
-      onButton.dispatchEvent(clickEvt)
+      _ <- IO(onButton.dispatchEvent(clickEvt)) *> IO.cede
 
-      checkbox.checked shouldBe true
+      _ = checkbox.checked shouldBe true
 
-      offButton.dispatchEvent(clickEvt)
+      _ <- IO(offButton.dispatchEvent(clickEvt)) *> IO.cede
 
-      checkbox.checked shouldBe false
+      _ = checkbox.checked shouldBe false
 
-    }
+    } yield succeed
   }
 
   "DomWindowEvents and DomDocumentEvents" should "trigger correctly" in {
@@ -503,9 +503,7 @@ class DomEventSpec extends JSDomAsyncSpec {
 
   "EmitterOps" should "correctly work on events" in {
 
-    val node = IO(Subject.replayLatest[String]()).flatMap { _ =>
-
-      for {
+    val node = for {
         stringStream <- IO(Subject.replayLatest[String]())
         doubleStream <- IO(Subject.replayLatest[Double]())
         boolStream <- IO(Subject.replayLatest[Boolean]())
@@ -534,7 +532,6 @@ class DomEventSpec extends JSDomAsyncSpec {
           ul(idAttr := "items")
         )
       } yield elem
-    }
 
     for {
       node <- node
@@ -587,17 +584,17 @@ class DomEventSpec extends JSDomAsyncSpec {
 
     LocalStorage.handler[IO]("hans").map { handler =>
 
-    handler.unsafeForeach { o => option = Some(o) }
+      handler.unsafeForeach { o => option = Some(o) }
 
-    option shouldBe Some(None)
+      option shouldBe Some(None)
 
-    handler.unsafeOnNext(Some("gisela"))
-    option shouldBe Some(Some("gisela"))
+      handler.unsafeOnNext(Some("gisela"))
+      option shouldBe Some(Some("gisela"))
 
-    handler.unsafeOnNext(None)
-    option shouldBe Some(None)
+      handler.unsafeOnNext(None)
+      option shouldBe Some(None)
 
-  }
+    }
   }
 
   it should "have handlerWithEventsOnly with proper events" in {
@@ -656,7 +653,7 @@ class DomEventSpec extends JSDomAsyncSpec {
       onClick.preventDefault.map(_ => 3).discard
     )
 
-    val test = for {
+    for {
       _ <- Outwatch.renderInto[IO]("#app", node)
       _ <- IO {
             val event = new Event("click", new EventInit {
@@ -668,9 +665,6 @@ class DomEventSpec extends JSDomAsyncSpec {
     } yield {
       succeed
     }
-
-    test
-
   }
 
   it should "stopPropagation" in {
@@ -685,17 +679,18 @@ class DomEventSpec extends JSDomAsyncSpec {
       )
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      val event = new Event("click", new EventInit {
+      event = new Event("click", new EventInit {
         bubbles = true
         cancelable = false
       })
-      document.getElementById("click").dispatchEvent(event)
+      send <- IO(document.getElementById("click").dispatchEvent(event)) *> IO.cede
 
-      triggeredFirst shouldBe true
-      triggeredSecond shouldBe false
-    }
+      _ = triggeredFirst shouldBe true
+      _ = triggeredSecond shouldBe false
+    } yield succeed
   }
 
   "Global dom events" should "return an observable" in {

--- a/tests/src/test/scala/outwatch/LifecycleHookSpec.scala
+++ b/tests/src/test/scala/outwatch/LifecycleHookSpec.scala
@@ -22,9 +22,10 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
 
     switch shouldBe false
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      switch shouldBe true
-    }
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ = switch shouldBe true
+    } yield succeed
   }
 
   it should "be called correctly on merged nodes" in {
@@ -42,10 +43,11 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
     switch shouldBe false
     switch2 shouldBe false
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      switch shouldBe true
-      switch2 shouldBe true
-    }
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ = switch shouldBe true
+      _ = switch2 shouldBe true
+    } yield succeed
   }
 
 
@@ -61,13 +63,14 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
 
     switch shouldBe false
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      switch shouldBe false
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ = switch shouldBe false
 
-      innerHandler.unsafeOnNext(div("Hasdasd"))
+      _ <- innerHandler.onNextIO(div("Hasdasd")) *> IO.cede
 
-      switch shouldBe true
-    }
+      _ = switch shouldBe true
+    } yield succeed
   }
 
   it should "be called correctly on merged nodes" in {
@@ -87,15 +90,16 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
     switch shouldBe false
     switch2 shouldBe false
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      switch shouldBe false
-      switch2 shouldBe false
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ = switch shouldBe false
+      _ = switch2 shouldBe false
 
-      innerHandler.unsafeOnNext(div("Hasdasd"))
+      _ <- innerHandler.onNextIO(div("Hasdasd")) *> IO.cede
 
-      switch shouldBe true
-      switch2 shouldBe true
-    }
+      _ = switch shouldBe true
+      _ = switch2 shouldBe true
+    } yield succeed
   }
 
   "Update hooks" should "be called correctly on merged nodes" in {
@@ -111,15 +115,16 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
     val message = Subject.publish[String]()
     val node = div(message, dsl.key := "unique", onSnabbdomUpdate --> observer1)(onSnabbdomUpdate --> observer2)
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      switch1 shouldBe false
-      switch2 shouldBe false
+      _ = switch1 shouldBe false
+      _ = switch2 shouldBe false
 
-      message.unsafeOnNext("wursi")
-      switch1 shouldBe true
-      switch2 shouldBe true
-    }
+      _ <- message.onNextIO("wursi") *> IO.cede
+      _ = switch1 shouldBe true
+      _ = switch2 shouldBe true
+    } yield succeed
   }
 
 
@@ -135,13 +140,14 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
 
     switch shouldBe false
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      switch shouldBe false
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ = switch shouldBe false
 
-      innerHandler.unsafeOnNext(span(onSnabbdomUpdate --> observer, "Hey"))
+      _ <- innerHandler.onNextIO(span(onSnabbdomUpdate --> observer, "Hey")) *> IO.cede
 
-      switch shouldBe true
-    }
+      _ = switch shouldBe true
+    } yield succeed
   }
 
   "Prepatch hooks" should "be called" in {
@@ -157,13 +163,14 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
 
     switch shouldBe false
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      switch shouldBe false
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ = switch shouldBe false
 
-      handler.unsafeOnNext(prepatchNode)
+      _ <- handler.onNextIO(prepatchNode) *> IO.cede
 
-      switch shouldBe true
-    }
+      _ = switch shouldBe true
+    } yield succeed
   }
 
   it should "be called correctly on merged nodes" in {
@@ -179,15 +186,16 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
     val message = Subject.publish[String]()
     val node = div(message, dsl.key := "unique", onSnabbdomPrePatch --> observer1)(onSnabbdomPrePatch --> observer2)
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      switch1 shouldBe false
-      switch2 shouldBe false
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ = switch1 shouldBe false
+      _ = switch2 shouldBe false
 
-      message.unsafeOnNext("wursi")
+      _ <- message.onNextIO("wursi") *> IO.cede
 
-      switch1 shouldBe true
-      switch2 shouldBe true
-    }
+      _ = switch1 shouldBe true
+      _ = switch2 shouldBe true
+    } yield succeed
   }
 
   "Postpatch hooks" should "be called" in {
@@ -202,13 +210,14 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
 
     switch shouldBe false
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      switch shouldBe false
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ = switch shouldBe false
 
-      message.unsafeOnNext("hallo")
+      _ <- message.onNextIO("hallo") *> IO.cede
 
-      switch shouldBe true
-    }
+      _ = switch shouldBe true
+    } yield succeed
   }
 
 
@@ -224,15 +233,16 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
     val message = Subject.publish[String]()
     val node = div(message, dsl.key := "unique", onSnabbdomPostPatch --> observer1)(onSnabbdomPostPatch --> observer2)
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      switch1 shouldBe false
-      switch2 shouldBe false
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ = switch1 shouldBe false
+      _ = switch2 shouldBe false
 
-      message.unsafeOnNext("wursi")
+      _ <- message.onNextIO("wursi") *> IO.cede
 
-      switch1 shouldBe true
-      switch2 shouldBe true
-    }
+      _ = switch1 shouldBe true
+      _ = switch2 shouldBe true
+    } yield succeed
   }
 
 
@@ -268,13 +278,14 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
 
     hooks shouldBe empty
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      hooks.toList shouldBe List("insert")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ = hooks.toList shouldBe List("insert")
 
-      message.unsafeOnNext("next")
+      _ <- message.onNextIO("next") *> IO.cede
 
-      hooks.toList shouldBe List("insert", "prepatch", "update", "postpatch")
-    }
+      _ = hooks.toList shouldBe List("insert", "prepatch", "update", "postpatch")
+    } yield succeed
   }
 
   "Empty single children receiver" should "not trigger node update on render" in {
@@ -294,9 +305,10 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
 
     hooks shouldBe empty
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      hooks.toList shouldBe  List("insert")
-    }
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ = hooks.toList shouldBe  List("insert")
+    } yield succeed
   }
 
   "Static child nodes" should "not be destroyed and inserted when child stream emits" in {
@@ -318,11 +330,12 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
 
     hooks shouldBe empty
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      message.unsafeOnNext("next")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ <- message.onNextIO("next") *> IO.cede
 
-      hooks.contains("destroy") shouldBe false
-    }
+      _ = hooks.contains("destroy") shouldBe false
+    } yield succeed
   }
 
   it should "be only inserted once when children stream emits" in {
@@ -344,13 +357,14 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
 
     hooks shouldBe empty
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      messageList.unsafeOnNext(Seq("one"))
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ <- messageList.onNextIO(Seq("one")) *> IO.cede
 
-      messageList.unsafeOnNext(Seq("one", "two"))
+      _ <- messageList.onNextIO(Seq("one", "two")) *> IO.cede
 
-      hooks.count(_ == "insert") shouldBe 1
-    }
+      _ = hooks.count(_ == "insert") shouldBe 1
+    } yield succeed
   }
 
 
@@ -369,18 +383,19 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
       span(VModifier.managedDelay(sub.unsafeSubscribe(observer)))
     )))
 
-    sub.unsafeOnNext("pre")
-    latest shouldBe ""
+    for {
+      _ <- sub.onNextIO("pre") *> IO.cede
+      _ = latest shouldBe ""
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      sub.unsafeOnNext("first")
-      latest shouldBe "first"
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ <- sub.onNextIO("first") *> IO.cede
+      _ = latest shouldBe "first"
 
-      nodes.unsafeOnNext(div()) // this triggers child destroy and subscription cancelation
+      _ <- nodes.onNextIO(div()) *> IO.cede // this triggers child destroy and subscription cancelation
 
-      sub.unsafeOnNext("second")
-      latest shouldBe "first"
-    }
+      _ <- sub.onNextIO("second") *> IO.cede
+      _ = latest shouldBe "first"
+    } yield succeed
   }
 
   it should "subscribe on insert and unsubscribe on destroy 2" in {
@@ -398,18 +413,18 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
       span(VModifier.managedSubscribe(sub.to(observer)))
     )))
 
-    sub.unsafeOnNext("pre")
-    latest shouldBe ""
+    for {
+      _ <- sub.onNextIO("pre") *> IO.cede
+      _ = latest shouldBe ""
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ <- sub.onNextIO("first") *> IO.cede
+      _ = latest shouldBe "first"
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      sub.unsafeOnNext("first")
-      latest shouldBe "first"
+      _ <- nodes.onNextIO(div()) *> IO.cede // this triggers child destroy and subscription cancelation
 
-      nodes.unsafeOnNext(div()) // this triggers child destroy and subscription cancelation
-
-      sub.unsafeOnNext("second")
-      latest shouldBe "first"
-    }
+      _ <- sub.onNextIO("second") *> IO.cede
+      _ = latest shouldBe "first"
+    } yield succeed
   }
 
   it should "work with EmitterBuilder.fromSource(observable)" in {
@@ -427,119 +442,125 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
       span(EmitterBuilder.fromSource(sub) --> observer)
     )))
 
-    sub.unsafeOnNext("pre")
-    latest shouldBe ""
+    for {
+      _ <- sub.onNextIO("pre") *> IO.cede
+      _ = latest shouldBe ""
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ <- sub.onNextIO("first") *> IO.cede
+      _ = latest shouldBe "first"
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      sub.unsafeOnNext("first")
-      latest shouldBe "first"
+      _ <- nodes.onNextIO(div()) *> IO.cede // this triggers child destroy and subscription cancelation
 
-      nodes.unsafeOnNext(div()) // this triggers child destroy and subscription cancelation
-
-      sub.unsafeOnNext("second")
-      latest shouldBe "first"
-    }
+      _ <- sub.onNextIO("second") *> IO.cede
+      _ = latest shouldBe "first"
+    } yield succeed
   }
 
   "DomHook" should "be called on static nodes" in {
+
+    var domHooks = List.empty[String]
 
     val modHandler = Subject.publish[VModifier]()
 
     val node = div(modHandler)
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      var domHooks = List.empty[String]
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      modHandler.unsafeOnNext(div(onDomMount doAction { domHooks :+= "mount" }, p(onDomUnmount doAction { domHooks :+= "unmount" })))
-      domHooks shouldBe List("mount")
+      _ <- modHandler.onNextIO(div(onDomMount doAction { domHooks :+= "mount" }, p(onDomUnmount doAction { domHooks :+= "unmount" }))) *> IO.cede
+      _ = domHooks shouldBe List("mount")
 
-      val innerHandler = Subject.publish[String]()
-      modHandler.unsafeOnNext(div("meh", p(onDomMount doAction { domHooks :+= "mount2" }), onDomPreUpdate doAction { domHooks :+= "preupdate2" }, onDomUpdate doAction { domHooks :+= "update2" }, onDomUnmount doAction { domHooks :+= "unmount2" }, innerHandler, Observable("distract-sync")))
-      domHooks shouldBe List("mount", "unmount", "mount2")
+      innerHandler = Subject.publish[String]()
+      _ <- modHandler.onNextIO(div("meh", p(onDomMount doAction { domHooks :+= "mount2" }), onDomPreUpdate doAction { domHooks :+= "preupdate2" }, onDomUpdate doAction { domHooks :+= "update2" }, onDomUnmount doAction { domHooks :+= "unmount2" }, innerHandler, Observable("distract-sync"))) *> IO.cede
+      _ = domHooks shouldBe List("mount", "unmount", "mount2")
 
-      innerHandler.unsafeOnNext("distract")
-      domHooks shouldBe List("mount", "unmount", "mount2", "preupdate2", "update2")
+      _ <- innerHandler.onNextIO("distract") *> IO.cede
+      _ = domHooks shouldBe List("mount", "unmount", "mount2", "preupdate2", "update2")
 
-      modHandler.unsafeOnNext(span("muh", onDomMount doAction { domHooks :+= "mount3" }, onDomPreUpdate doAction { domHooks :+= "preupdate3" }, onDomUpdate doAction { domHooks :+= "update3" }, onDomUnmount doAction { domHooks :+= "unmount3" }))
-      domHooks shouldBe List("mount", "unmount", "mount2", "preupdate2", "update2", "unmount2", "mount3")
+      _ <- modHandler.onNextIO(span("muh", onDomMount doAction { domHooks :+= "mount3" }, onDomPreUpdate doAction { domHooks :+= "preupdate3" }, onDomUpdate doAction { domHooks :+= "update3" }, onDomUnmount doAction { domHooks :+= "unmount3" })) *> IO.cede
+      _ = domHooks shouldBe List("mount", "unmount", "mount2", "preupdate2", "update2", "unmount2", "mount3")
 
-      modHandler.unsafeOnNext(VModifier.empty)
-      domHooks shouldBe List("mount", "unmount", "mount2", "preupdate2", "update2", "unmount2", "mount3", "unmount3")
-    }
+      _ <- modHandler.onNextIO(VModifier.empty) *> IO.cede
+      _ = domHooks shouldBe List("mount", "unmount", "mount2", "preupdate2", "update2", "unmount2", "mount3", "unmount3")
+    } yield succeed
   }
 
   it should "be called on nested streaming" in {
+
+    var domHooks = List.empty[String]
 
     val modHandler = Subject.publish[VModifier]()
     val innerHandler = Subject.publish[VModifier]()
     val node = div(modHandler)
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      var domHooks = List.empty[String]
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      modHandler.unsafeOnNext(VModifier(innerHandler))
-      domHooks shouldBe List()
+      _ <- modHandler.onNextIO(VModifier(innerHandler)) *> IO.cede
+      _ = domHooks shouldBe List()
 
-      innerHandler.unsafeOnNext("inner")
-      domHooks shouldBe List()
+      _ <- innerHandler.onNextIO("inner") *> IO.cede
+      _ = domHooks shouldBe List()
 
-      innerHandler.unsafeOnNext(onDomMount doAction { domHooks :+= "inner-mount" })
-      domHooks shouldBe List("inner-mount")
+      _ <- innerHandler.onNextIO(onDomMount doAction { domHooks :+= "inner-mount" }) *> IO.cede
+      _ = domHooks shouldBe List("inner-mount")
 
-      innerHandler.unsafeOnNext(onDomUnmount doAction { domHooks :+= "inner-unmount" })
-      domHooks shouldBe List("inner-mount")
+      _ <- innerHandler.onNextIO(onDomUnmount doAction { domHooks :+= "inner-unmount" }) *> IO.cede
+      _ = domHooks shouldBe List("inner-mount")
 
-      innerHandler.unsafeOnNext(onDomUnmount doAction { domHooks :+= "inner-unmount2" })
-      domHooks shouldBe List("inner-mount", "inner-unmount")
+      _ <- innerHandler.onNextIO(onDomUnmount doAction { domHooks :+= "inner-unmount2" }) *> IO.cede
+      _ = domHooks shouldBe List("inner-mount", "inner-unmount")
 
-      modHandler.unsafeOnNext(VModifier.empty)
-      domHooks shouldBe List("inner-mount", "inner-unmount", "inner-unmount2")
-    }
+      _ <- modHandler.onNextIO(VModifier.empty) *> IO.cede
+      _ = domHooks shouldBe List("inner-mount", "inner-unmount", "inner-unmount2")
+    } yield succeed
   }
 
   it should "be called on streaming in and streaming out" in {
+
+    var domHooks = List.empty[String]
 
     val modHandler = Subject.publish[VModifier]()
     val otherHandler = Subject.publish[VModifier]()
     val innerHandler = Subject.publish[VModifier]()
     val node = div(modHandler, otherHandler)
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      var domHooks = List.empty[String]
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      modHandler.unsafeOnNext(VModifier(onDomMount doAction { domHooks :+= "mount" }, onDomPreUpdate doAction { domHooks :+= "preupdate" }, onDomUpdate doAction { domHooks :+= "update" }, onDomUnmount doAction { domHooks :+= "unmount" }, innerHandler))
-      domHooks shouldBe List("mount")
+      _ <- modHandler.onNextIO(VModifier(onDomMount doAction { domHooks :+= "mount" }, onDomPreUpdate doAction { domHooks :+= "preupdate" }, onDomUpdate doAction { domHooks :+= "update" }, onDomUnmount doAction { domHooks :+= "unmount" }, innerHandler)) *> IO.cede
+      _ = domHooks shouldBe List("mount")
 
-      otherHandler.unsafeOnNext("other")
-      domHooks shouldBe List("mount", "preupdate", "update")
+      _ <- otherHandler.onNextIO("other") *> IO.cede
+      _ = domHooks shouldBe List("mount", "preupdate", "update")
 
-      innerHandler.unsafeOnNext("inner")
-      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update")
+      _ <- innerHandler.onNextIO("inner") *> IO.cede
+      _ = domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update")
 
-      innerHandler.unsafeOnNext(VModifier(onDomMount doAction { domHooks :+= "inner-mount" }, onDomPreUpdate doAction { domHooks :+= "inner-preupdate" }, onDomUpdate doAction { domHooks :+= "inner-update" }, onDomUnmount doAction { domHooks :+= "inner-unmount" }, Observable("distract")))
-      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update")
+      _ <- innerHandler.onNextIO(VModifier(onDomMount doAction { domHooks :+= "inner-mount" }, onDomPreUpdate doAction { domHooks :+= "inner-preupdate" }, onDomUpdate doAction { domHooks :+= "inner-update" }, onDomUnmount doAction { domHooks :+= "inner-unmount" }, Observable("distract"))) *> IO.cede
+      _ = domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount")
 
-      otherHandler.unsafeOnNext(span("hi!"))
-      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update")
+      _ <- otherHandler.onNextIO(span("hi!")) *> IO.cede
+      _ = domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update")
 
-      innerHandler.unsafeOnNext(VModifier(onDomPreUpdate doAction { domHooks :+= "inner-preupdate2" }, onDomUpdate doAction { domHooks :+= "inner-update2" }))
-      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update")
+      _ <- innerHandler.onNextIO(VModifier(onDomPreUpdate doAction { domHooks :+= "inner-preupdate2" }, onDomUpdate doAction { domHooks :+= "inner-update2" })) *> IO.cede
+      _ = domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update")
 
-      innerHandler.unsafeOnNext(VModifier(Observable("inner")))
-      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update", "preupdate", "update", "preupdate", "update")
+      _ <- innerHandler.onNextIO(VModifier(Observable("inner"))) *> IO.cede
+      _ = domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update", "preupdate", "update")
 
-      innerHandler.unsafeOnNext(VModifier(onDomMount doAction { domHooks :+= "inner-mount2" }, onDomUnmount doAction { domHooks :+= "inner-unmount2" }, "something-else"))
-      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount2")
+      _ <- innerHandler.onNextIO(VModifier(onDomMount doAction { domHooks :+= "inner-mount2" }, onDomUnmount doAction { domHooks :+= "inner-unmount2" }, "something-else")) *> IO.cede
+      _ = domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update", "preupdate", "update", "preupdate", "update", "inner-mount2")
 
-      modHandler.unsafeOnNext(onDomMount doAction { domHooks :+= "mount2" })
-      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount2", "unmount", "inner-unmount2", "mount2")
+      _ <- modHandler.onNextIO(onDomMount doAction { domHooks :+= "mount2" }) *> IO.cede
+      _ = domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update", "preupdate", "update", "preupdate", "update", "inner-mount2", "unmount", "inner-unmount2", "mount2")
 
-      modHandler.unsafeOnNext(onDomUnmount doAction { domHooks :+= "unmount2" })
-      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount2", "unmount", "inner-unmount2", "mount2")
+      _ <- modHandler.onNextIO(onDomUnmount doAction { domHooks :+= "unmount2" }) *> IO.cede
+      _ = domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update", "preupdate", "update", "preupdate", "update", "inner-mount2", "unmount", "inner-unmount2", "mount2")
 
-      modHandler.unsafeOnNext(VModifier.empty)
-      domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount2", "unmount", "inner-unmount2", "mount2", "unmount2")
-    }
+      _ <- modHandler.onNextIO(VModifier.empty) *> IO.cede
+      _ = domHooks shouldBe List("mount", "preupdate", "update", "preupdate", "update", "preupdate", "update", "inner-mount", "preupdate", "inner-preupdate", "update", "inner-update", "preupdate", "inner-unmount", "update", "preupdate", "update", "preupdate", "update", "inner-mount2", "unmount", "inner-unmount2", "mount2", "unmount2")
+    } yield succeed
   }
 
   it should "be called for default and streaming out" in {
@@ -551,27 +572,28 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
     val otherHandler = Subject.publish[VModifier]()
     val node = div(otherHandler, modHandler.prepend(VModifier(onDomMount doAction { domHooks :+= "default-mount" }, onDomPreUpdate doAction { domHooks :+= "default-preupdate" }, onDomUpdate doAction { domHooks :+= "default-update" }, onDomUnmount doAction { domHooks :+= "default-unmount" }, innerHandler)))
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      domHooks shouldBe List("default-mount")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ = domHooks shouldBe List("default-mount")
 
-      innerHandler.unsafeOnNext(VModifier(onDomMount doAction { domHooks :+= "inner-mount" }, onDomPreUpdate doAction { domHooks :+= "inner-preupdate" }, onDomUpdate doAction { domHooks :+= "inner-update" }, onDomUnmount doAction { domHooks :+= "inner-unmount" }))
-      domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount")
+      _ <- innerHandler.onNextIO(VModifier(onDomMount doAction { domHooks :+= "inner-mount" }, onDomPreUpdate doAction { domHooks :+= "inner-preupdate" }, onDomUpdate doAction { domHooks :+= "inner-update" }, onDomUnmount doAction { domHooks :+= "inner-unmount" })) *> IO.cede
+      _ = domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount")
 
-      otherHandler.unsafeOnNext(span("hi!"))
-      domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update")
+      _ <- otherHandler.onNextIO(span("hi!")) *> IO.cede
+      _ = domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update")
 
-      modHandler.unsafeOnNext(VModifier(onDomMount doAction { domHooks :+= "mount" }, onDomUnmount doAction { domHooks :+= "unmount" }))
-      domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "default-unmount", "inner-unmount", "mount")
+      _ <- modHandler.onNextIO(VModifier(onDomMount doAction { domHooks :+= "mount" }, onDomUnmount doAction { domHooks :+= "unmount" })) *> IO.cede
+      _ = domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "default-unmount", "inner-unmount", "mount")
 
-      modHandler.unsafeOnNext(onDomMount doAction { domHooks :+= "mount2" })
-      domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "default-unmount", "inner-unmount", "mount", "unmount", "mount2")
+      _ <- modHandler.onNextIO(onDomMount doAction { domHooks :+= "mount2" }) *> IO.cede
+      _ = domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "default-unmount", "inner-unmount", "mount", "unmount", "mount2")
 
-      modHandler.unsafeOnNext(onDomUnmount doAction { domHooks :+= "unmount2" })
-      domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "default-unmount", "inner-unmount", "mount", "unmount", "mount2")
+      _ <- modHandler.onNextIO(onDomUnmount doAction { domHooks :+= "unmount2" }) *> IO.cede
+      _ = domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "default-unmount", "inner-unmount", "mount", "unmount", "mount2")
 
-      modHandler.unsafeOnNext(VModifier.empty)
-      domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "default-unmount", "inner-unmount", "mount", "unmount", "mount2", "unmount2")
-    }
+      _ <- modHandler.onNextIO(VModifier.empty) *> IO.cede
+      _ = domHooks shouldBe List("default-mount", "default-preupdate", "default-update", "inner-mount", "default-preupdate", "inner-preupdate", "default-update", "inner-update", "default-unmount", "inner-unmount", "mount", "unmount", "mount2", "unmount2")
+    } yield succeed
   }
 
   it should "have unmount before mount hook when streamed" in {
@@ -592,15 +614,16 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
       }
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      domHooks shouldBe List.empty
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ = domHooks shouldBe List.empty
 
-      countHandler.unsafeOnNext(1)
-      domHooks shouldBe List("mount1", "child-mount1")
+      _ <- countHandler.onNextIO(1) *> IO.cede
+      _ = domHooks shouldBe List("mount1", "child-mount1")
 
-      countHandler.unsafeOnNext(2)
-      domHooks shouldBe List("mount1", "child-mount1", "unmount1", "child-unmount1", "child-mount2", "mount2")
-    }
+      _ <- countHandler.onNextIO(2) *> IO.cede
+      _ = domHooks shouldBe List("mount1", "child-mount1", "unmount1", "child-unmount1", "child-mount2", "mount2")
+    } yield succeed
   }
 
   "Hooks" should "support emitter operations" in {
@@ -620,9 +643,10 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
       span(divTagName --> observer)
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      operations.toList shouldBe List("div", "insert")
-    }
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      _ = operations.toList shouldBe List("div", "insert")
+    } yield succeed
   }
 
   "Lifecycle and subscription" should "with a snabbdom key" in {
@@ -663,100 +687,101 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
       }
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      val element = document.getElementById("strings")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      element = document.getElementById("strings")
 
-      element.innerHTML shouldBe ""
-      onSnabbdomInsertCount shouldBe 0
-      onSnabbdomPrePatchCount shouldBe 0
-      onSnabbdomPostPatchCount shouldBe 0
-      onSnabbdomUpdateCount shouldBe 0
-      onSnabbdomDestroyCount shouldBe 0
-      onDomMountList shouldBe Nil
-      onDomUnmountList shouldBe Nil
-      onDomUpdateList shouldBe Nil
+      _ = element.innerHTML shouldBe ""
+      _ = onSnabbdomInsertCount shouldBe 0
+      _ = onSnabbdomPrePatchCount shouldBe 0
+      _ = onSnabbdomPostPatchCount shouldBe 0
+      _ = onSnabbdomUpdateCount shouldBe 0
+      _ = onSnabbdomDestroyCount shouldBe 0
+      _ = onDomMountList shouldBe Nil
+      _ = onDomUnmountList shouldBe Nil
+      _ = onDomUpdateList shouldBe Nil
 
-      handler.unsafeOnNext(("key", "heinz"))
-      element.innerHTML shouldBe "<div>heinz</div>"
-      onSnabbdomInsertCount shouldBe 1
-      onSnabbdomPrePatchCount shouldBe 0
-      onSnabbdomPostPatchCount shouldBe 0
-      onSnabbdomUpdateCount shouldBe 0
-      onSnabbdomDestroyCount shouldBe 0
-      onDomMountList shouldBe List(1)
-      onDomUnmountList shouldBe Nil
-      onDomUpdateList shouldBe Nil
+      _ <- handler.onNextIO(("key", "heinz")) *> IO.cede
+      _ = element.innerHTML shouldBe "<div>heinz</div>"
+      _ = onSnabbdomInsertCount shouldBe 1
+      _ = onSnabbdomPrePatchCount shouldBe 0
+      _ = onSnabbdomPostPatchCount shouldBe 0
+      _ = onSnabbdomUpdateCount shouldBe 0
+      _ = onSnabbdomDestroyCount shouldBe 0
+      _ = onDomMountList shouldBe List(1)
+      _ = onDomUnmountList shouldBe Nil
+      _ = onDomUpdateList shouldBe Nil
 
-      handler.unsafeOnNext(("key", "golum"))
-      element.innerHTML shouldBe "<div>golum</div>"
-      onSnabbdomInsertCount shouldBe 1
-      onSnabbdomPrePatchCount shouldBe 1
-      onSnabbdomPostPatchCount shouldBe 1
-      onSnabbdomUpdateCount shouldBe 1
-      onSnabbdomDestroyCount shouldBe 0
-      onDomMountList shouldBe List(1, 2)
-      onDomUnmountList shouldBe List(1)
-      onDomUpdateList shouldBe Nil
+      _ <- handler.onNextIO(("key", "golum")) *> IO.cede
+      _ = element.innerHTML shouldBe "<div>golum</div>"
+      _ = onSnabbdomInsertCount shouldBe 1
+      _ = onSnabbdomPrePatchCount shouldBe 1
+      _ = onSnabbdomPostPatchCount shouldBe 1
+      _ = onSnabbdomUpdateCount shouldBe 1
+      _ = onSnabbdomDestroyCount shouldBe 0
+      _ = onDomMountList shouldBe List(1, 2)
+      _ = onDomUnmountList shouldBe List(1)
+      _ = onDomUpdateList shouldBe Nil
 
-      handler.unsafeOnNext(("key", "dieter"))
-      element.innerHTML shouldBe "<div>dieter</div>"
-      onSnabbdomInsertCount shouldBe 1
-      onSnabbdomPrePatchCount shouldBe 2
-      onSnabbdomPostPatchCount shouldBe 2
-      onSnabbdomUpdateCount shouldBe 2
-      onSnabbdomDestroyCount shouldBe 0
-      onDomMountList shouldBe List(1, 2, 3)
-      onDomUnmountList shouldBe List(1,2)
-      onDomUpdateList shouldBe Nil
+      _ <- handler.onNextIO(("key", "dieter")) *> IO.cede
+      _ = element.innerHTML shouldBe "<div>dieter</div>"
+      _ = onSnabbdomInsertCount shouldBe 1
+      _ = onSnabbdomPrePatchCount shouldBe 2
+      _ = onSnabbdomPostPatchCount shouldBe 2
+      _ = onSnabbdomUpdateCount shouldBe 2
+      _ = onSnabbdomDestroyCount shouldBe 0
+      _ = onDomMountList shouldBe List(1, 2, 3)
+      _ = onDomUnmountList shouldBe List(1,2)
+      _ = onDomUpdateList shouldBe Nil
 
-      handler.unsafeOnNext(("nope", "dieter"))
-      element.innerHTML shouldBe "<div>dieter</div>"
-      onSnabbdomInsertCount shouldBe 2
-      onSnabbdomPrePatchCount shouldBe 2
-      onSnabbdomPostPatchCount shouldBe 2
-      onSnabbdomUpdateCount shouldBe 2
-      onSnabbdomDestroyCount shouldBe 1
-      onDomMountList shouldBe List(1, 2 ,3, 4)
-      onDomUnmountList shouldBe List(1,2,3)
-      onDomUpdateList shouldBe Nil
+      _ <- handler.onNextIO(("nope", "dieter")) *> IO.cede
+      _ = element.innerHTML shouldBe "<div>dieter</div>"
+      _ = onSnabbdomInsertCount shouldBe 2
+      _ = onSnabbdomPrePatchCount shouldBe 2
+      _ = onSnabbdomPostPatchCount shouldBe 2
+      _ = onSnabbdomUpdateCount shouldBe 2
+      _ = onSnabbdomDestroyCount shouldBe 1
+      _ = onDomMountList shouldBe List(1, 2 ,3, 4)
+      _ = onDomUnmountList shouldBe List(1,2,3)
+      _ = onDomUpdateList shouldBe Nil
 
-      handler.unsafeOnNext(("yes", "peter"))
-      element.innerHTML shouldBe "<div>peter</div>"
-      onSnabbdomInsertCount shouldBe 3
-      onSnabbdomPrePatchCount shouldBe 2
-      onSnabbdomPostPatchCount shouldBe 2
-      onSnabbdomUpdateCount shouldBe 2
-      onSnabbdomDestroyCount shouldBe 2
-      onDomMountList shouldBe List(1, 2, 3, 4, 5)
-      onDomUnmountList shouldBe List(1, 2, 3, 4)
-      onDomUpdateList shouldBe Nil
+      _ <- handler.onNextIO(("yes", "peter")) *> IO.cede
+      _ = element.innerHTML shouldBe "<div>peter</div>"
+      _ = onSnabbdomInsertCount shouldBe 3
+      _ = onSnabbdomPrePatchCount shouldBe 2
+      _ = onSnabbdomPostPatchCount shouldBe 2
+      _ = onSnabbdomUpdateCount shouldBe 2
+      _ = onSnabbdomDestroyCount shouldBe 2
+      _ = onDomMountList shouldBe List(1, 2, 3, 4, 5)
+      _ = onDomUnmountList shouldBe List(1, 2, 3, 4)
+      _ = onDomUpdateList shouldBe Nil
 
-      otherHandler.unsafeOnNext("hi")
-      element.innerHTML shouldBe "<div>hi</div><div>peter</div>"
-      onSnabbdomInsertCount shouldBe 3
-      onSnabbdomPrePatchCount shouldBe 2
-      onSnabbdomPostPatchCount shouldBe 2
-      onSnabbdomUpdateCount shouldBe 2
-      onSnabbdomDestroyCount shouldBe 2
-      onDomMountList shouldBe List(1, 2, 3, 4, 5)
-      onDomUnmountList shouldBe List(1, 2, 3, 4)
-      onDomUpdateList shouldBe Nil
+      _ <- otherHandler.onNextIO("hi") *> IO.cede
+      _ = element.innerHTML shouldBe "<div>hi</div><div>peter</div>"
+      _ = onSnabbdomInsertCount shouldBe 3
+      _ = onSnabbdomPrePatchCount shouldBe 2
+      _ = onSnabbdomPostPatchCount shouldBe 2
+      _ = onSnabbdomUpdateCount shouldBe 2
+      _ = onSnabbdomDestroyCount shouldBe 2
+      _ = onDomMountList shouldBe List(1, 2, 3, 4, 5)
+      _ = onDomUnmountList shouldBe List(1, 2, 3, 4)
+      _ = onDomUpdateList shouldBe Nil
 
-      innerHandlerCount shouldBe 0
+      _ = innerHandlerCount shouldBe 0
 
-      innerHandler.unsafeOnNext(0)
-      element.innerHTML shouldBe "<div>hi</div><div>peter0</div>"
-      onSnabbdomInsertCount shouldBe 3
-      onSnabbdomPrePatchCount shouldBe 3
-      onSnabbdomPostPatchCount shouldBe 3
-      onSnabbdomUpdateCount shouldBe 3
-      onSnabbdomDestroyCount shouldBe 2
-      onDomMountList shouldBe List(1, 2, 3, 4, 5)
-      onDomUnmountList shouldBe List(1, 2, 3, 4)
-      onDomUpdateList shouldBe List(5)
+      _ <- innerHandler.onNextIO(0) *> IO.cede
+      _ = element.innerHTML shouldBe "<div>hi</div><div>peter0</div>"
+      _ = onSnabbdomInsertCount shouldBe 3
+      _ = onSnabbdomPrePatchCount shouldBe 3
+      _ = onSnabbdomPostPatchCount shouldBe 3
+      _ = onSnabbdomUpdateCount shouldBe 3
+      _ = onSnabbdomDestroyCount shouldBe 2
+      _ = onDomMountList shouldBe List(1, 2, 3, 4, 5)
+      _ = onDomUnmountList shouldBe List(1, 2, 3, 4)
+      _ = onDomUpdateList shouldBe List(5)
 
-      innerHandlerCount shouldBe 1
-    }
+      _ = innerHandlerCount shouldBe 1
+    } yield succeed
   }
 
   it should "without a custom key" in {
@@ -796,99 +821,100 @@ class LifecycleHookSpec extends JSDomAsyncSpec {
       }
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      val element = document.getElementById("strings")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      element = document.getElementById("strings")
 
-      element.innerHTML shouldBe ""
-      onSnabbdomInsertCount shouldBe 0
-      onSnabbdomPrePatchCount shouldBe 0
-      onSnabbdomPostPatchCount shouldBe 0
-      onSnabbdomUpdateCount shouldBe 0
-      onSnabbdomDestroyCount shouldBe 0
-      onDomMountList shouldBe Nil
-      onDomUnmountList shouldBe Nil
-      onDomUpdateList shouldBe Nil
+      _ = element.innerHTML shouldBe ""
+      _ = onSnabbdomInsertCount shouldBe 0
+      _ = onSnabbdomPrePatchCount shouldBe 0
+      _ = onSnabbdomPostPatchCount shouldBe 0
+      _ = onSnabbdomUpdateCount shouldBe 0
+      _ = onSnabbdomDestroyCount shouldBe 0
+      _ = onDomMountList shouldBe Nil
+      _ = onDomUnmountList shouldBe Nil
+      _ = onDomUpdateList shouldBe Nil
 
-      handler.unsafeOnNext("heinz")
-      element.innerHTML shouldBe "<div>heinz</div>"
-      onSnabbdomInsertCount shouldBe 1
-      onSnabbdomPrePatchCount shouldBe 0
-      onSnabbdomPostPatchCount shouldBe 0
-      onSnabbdomUpdateCount shouldBe 0
-      onSnabbdomDestroyCount shouldBe 0
-      onDomMountList shouldBe List(1)
-      onDomUnmountList shouldBe Nil
-      onDomUpdateList shouldBe Nil
+      _ <- handler.onNextIO("heinz") *> IO.cede
+      _ = element.innerHTML shouldBe "<div>heinz</div>"
+      _ = onSnabbdomInsertCount shouldBe 1
+      _ = onSnabbdomPrePatchCount shouldBe 0
+      _ = onSnabbdomPostPatchCount shouldBe 0
+      _ = onSnabbdomUpdateCount shouldBe 0
+      _ = onSnabbdomDestroyCount shouldBe 0
+      _ = onDomMountList shouldBe List(1)
+      _ = onDomUnmountList shouldBe Nil
+      _ = onDomUpdateList shouldBe Nil
 
-      handler.unsafeOnNext("golum")
-      element.innerHTML shouldBe "<div>golum</div>"
-      onSnabbdomInsertCount shouldBe 1
-      onSnabbdomPrePatchCount shouldBe 1
-      onSnabbdomPostPatchCount shouldBe 1
-      onSnabbdomUpdateCount shouldBe 1
-      onSnabbdomDestroyCount shouldBe 0
-      onDomMountList shouldBe List(1, 2)
-      onDomUnmountList shouldBe List(1)
-      onDomUpdateList shouldBe Nil
+      _ <- handler.onNextIO("golum") *> IO.cede
+      _ = element.innerHTML shouldBe "<div>golum</div>"
+      _ = onSnabbdomInsertCount shouldBe 1
+      _ = onSnabbdomPrePatchCount shouldBe 1
+      _ = onSnabbdomPostPatchCount shouldBe 1
+      _ = onSnabbdomUpdateCount shouldBe 1
+      _ = onSnabbdomDestroyCount shouldBe 0
+      _ = onDomMountList shouldBe List(1, 2)
+      _ = onDomUnmountList shouldBe List(1)
+      _ = onDomUpdateList shouldBe Nil
 
-      handler.unsafeOnNext("dieter")
-      element.innerHTML shouldBe "<div>dieter</div>"
-      onSnabbdomInsertCount shouldBe 1
-      onSnabbdomPrePatchCount shouldBe 2
-      onSnabbdomPostPatchCount shouldBe 2
-      onSnabbdomUpdateCount shouldBe 2
-      onSnabbdomDestroyCount shouldBe 0
-      onDomMountList shouldBe List(1, 2, 3)
-      onDomUnmountList shouldBe List(1,2)
-      onDomUpdateList shouldBe Nil
+      _ <- handler.onNextIO("dieter") *> IO.cede
+      _ = element.innerHTML shouldBe "<div>dieter</div>"
+      _ = onSnabbdomInsertCount shouldBe 1
+      _ = onSnabbdomPrePatchCount shouldBe 2
+      _ = onSnabbdomPostPatchCount shouldBe 2
+      _ = onSnabbdomUpdateCount shouldBe 2
+      _ = onSnabbdomDestroyCount shouldBe 0
+      _ = onDomMountList shouldBe List(1, 2, 3)
+      _ = onDomUnmountList shouldBe List(1,2)
+      _ = onDomUpdateList shouldBe Nil
 
-      handler.unsafeOnNext("dieter")
-      element.innerHTML shouldBe "<div>dieter</div>"
-      onSnabbdomInsertCount shouldBe 1
-      onSnabbdomPrePatchCount shouldBe 3
-      onSnabbdomPostPatchCount shouldBe 3
-      onSnabbdomUpdateCount shouldBe 3
-      onSnabbdomDestroyCount shouldBe 0
-      onDomMountList shouldBe List(1, 2 ,3, 4)
-      onDomUnmountList shouldBe List(1,2,3)
-      onDomUpdateList shouldBe Nil
+      _ <- handler.onNextIO("dieter") *> IO.cede
+      _ = element.innerHTML shouldBe "<div>dieter</div>"
+      _ = onSnabbdomInsertCount shouldBe 1
+      _ = onSnabbdomPrePatchCount shouldBe 3
+      _ = onSnabbdomPostPatchCount shouldBe 3
+      _ = onSnabbdomUpdateCount shouldBe 3
+      _ = onSnabbdomDestroyCount shouldBe 0
+      _ = onDomMountList shouldBe List(1, 2 ,3, 4)
+      _ = onDomUnmountList shouldBe List(1,2,3)
+      _ = onDomUpdateList shouldBe Nil
 
-      handler.unsafeOnNext("peter")
-      element.innerHTML shouldBe "<div>peter</div>"
-      onSnabbdomInsertCount shouldBe 1
-      onSnabbdomPrePatchCount shouldBe 4
-      onSnabbdomPostPatchCount shouldBe 4
-      onSnabbdomUpdateCount shouldBe 4
-      onSnabbdomDestroyCount shouldBe 0
-      onDomMountList shouldBe List(1, 2, 3, 4, 5)
-      onDomUnmountList shouldBe List(1, 2, 3, 4)
-      onDomUpdateList shouldBe Nil
+      _ <- handler.onNextIO("peter") *> IO.cede
+      _ = element.innerHTML shouldBe "<div>peter</div>"
+      _ = onSnabbdomInsertCount shouldBe 1
+      _ = onSnabbdomPrePatchCount shouldBe 4
+      _ = onSnabbdomPostPatchCount shouldBe 4
+      _ = onSnabbdomUpdateCount shouldBe 4
+      _ = onSnabbdomDestroyCount shouldBe 0
+      _ = onDomMountList shouldBe List(1, 2, 3, 4, 5)
+      _ = onDomUnmountList shouldBe List(1, 2, 3, 4)
+      _ = onDomUpdateList shouldBe Nil
 
-      otherHandler.unsafeOnNext("hi")
-      element.innerHTML shouldBe "<div>hi</div><div>peter</div>"
-      onSnabbdomInsertCount shouldBe 1
-      onSnabbdomPrePatchCount shouldBe 4
-      onSnabbdomPostPatchCount shouldBe 4
-      onSnabbdomUpdateCount shouldBe 4
-      onSnabbdomDestroyCount shouldBe 0
-      onDomMountList shouldBe List(1, 2, 3, 4, 5)
-      onDomUnmountList shouldBe List(1, 2, 3, 4)
-      onDomUpdateList shouldBe Nil
+      _ <- otherHandler.onNextIO("hi") *> IO.cede
+      _ = element.innerHTML shouldBe "<div>hi</div><div>peter</div>"
+      _ = onSnabbdomInsertCount shouldBe 1
+      _ = onSnabbdomPrePatchCount shouldBe 4
+      _ = onSnabbdomPostPatchCount shouldBe 4
+      _ = onSnabbdomUpdateCount shouldBe 4
+      _ = onSnabbdomDestroyCount shouldBe 0
+      _ = onDomMountList shouldBe List(1, 2, 3, 4, 5)
+      _ = onDomUnmountList shouldBe List(1, 2, 3, 4)
+      _ = onDomUpdateList shouldBe Nil
 
-      innerHandlerCount shouldBe 0
+      _ = innerHandlerCount shouldBe 0
 
-      innerHandler.unsafeOnNext(0)
-      element.innerHTML shouldBe "<div>hi</div><div>peter0</div>"
-      onSnabbdomInsertCount shouldBe 1
-      onSnabbdomPrePatchCount shouldBe 5
-      onSnabbdomPostPatchCount shouldBe 5
-      onSnabbdomUpdateCount shouldBe 5
-      onSnabbdomDestroyCount shouldBe 0
-      onDomMountList shouldBe List(1, 2, 3, 4, 5)
-      onDomUnmountList shouldBe List(1, 2, 3, 4)
-      onDomUpdateList shouldBe List(5)
+      _ <- innerHandler.onNextIO(0) *> IO.cede
+      _ = element.innerHTML shouldBe "<div>hi</div><div>peter0</div>"
+      _ = onSnabbdomInsertCount shouldBe 1
+      _ = onSnabbdomPrePatchCount shouldBe 5
+      _ = onSnabbdomPostPatchCount shouldBe 5
+      _ = onSnabbdomUpdateCount shouldBe 5
+      _ = onSnabbdomDestroyCount shouldBe 0
+      _ = onDomMountList shouldBe List(1, 2, 3, 4, 5)
+      _ = onDomUnmountList shouldBe List(1, 2, 3, 4)
+      _ = onDomUpdateList shouldBe List(5)
 
-      innerHandlerCount shouldBe 1
-    }
+      _ = innerHandlerCount shouldBe 1
+    } yield succeed
   }
 }

--- a/tests/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/tests/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -8,7 +8,6 @@ import org.scalajs.dom.{Element, Event, document, html}
 import outwatch.helpers._
 import outwatch.dsl._
 import snabbdom.{DataObject, Hooks, VNodeProxy}
-import org.scalatest.Assertion
 import outwatch.interpreter._
 import colibri._
 import org.scalajs.dom.EventInit
@@ -262,7 +261,7 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       )
     )
 
-    val test = for {
+    for {
 
       node <- IO {
         val node = document.createElement("div")
@@ -272,15 +271,11 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
 
       _ <- IO(list.isEmpty shouldBe true)
       _ <- Outwatch.renderInto[IO](node, vtree)
-    } yield {
-
-      list should contain theSameElementsAs List(
+      _ = list should contain theSameElementsAs List(
         "child1", "child2", "child3", "children1", "children2", "attr1", "attr2"
       )
 
-    }
-
-    test
+    } yield succeed
   }
 
   it should "not provide unique key for child nodes" in {
@@ -389,79 +384,77 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
 
 
   it should "run its effect modifiers once!" in {
-    IO(Subject.replayLatest[String]()).flatMap { stringHandler =>
+    val stringHandler = Subject.replayLatest[String]()
 
-      var ioCounter = 0
-      var handlerCounter = 0
-      stringHandler { _ =>
-        handlerCounter += 1
-      }
-
-      val vtree = div(
-        div(
-          IO {
-            ioCounter += 1
-            BasicAttr("hans", "")
-          }
-        ),
-        stringHandler
-      )
-
-      val node = document.createElement("div")
-      document.body.appendChild(node)
-
-      ioCounter shouldBe 0
-      handlerCounter shouldBe 0
-
-
-      Outwatch.renderInto[IO](node, vtree).map { _ =>
-
-        ioCounter shouldBe 1
-        handlerCounter shouldBe 0
-        stringHandler.unsafeOnNext("pups")
-        ioCounter shouldBe 1
-        handlerCounter shouldBe 1
-
-      }
+    var ioCounter = 0
+    var handlerCounter = 0
+    stringHandler.unsafeForeach { _ =>
+      handlerCounter += 1
     }
+
+    val vtree = div(
+      div(
+        IO {
+          ioCounter += 1
+          BasicAttr("hans", "")
+        }
+      ),
+      stringHandler
+    )
+
+    val node = document.createElement("div")
+    document.body.appendChild(node)
+
+    ioCounter shouldBe 0
+    handlerCounter shouldBe 0
+
+
+    for {
+      _ <- Outwatch.renderInto[IO](node, vtree)
+
+      _ = ioCounter shouldBe 1
+      _ = handlerCounter shouldBe 0
+      _ <- stringHandler.onNextIO("pups") *> IO.cede
+      _ = ioCounter shouldBe 1
+      _ = handlerCounter shouldBe 1
+    } yield succeed
   }
 
   it should "run its effect modifiers once in CompositeModifier!" in {
-    IO(Subject.replayLatest[String]()).flatMap { stringHandler =>
+    val stringHandler = Subject.replayLatest[String]()
 
-      var ioCounter = 0
-      var handlerCounter = 0
-      stringHandler { _ =>
-        handlerCounter += 1
-      }
-
-      val vtree = div(
-        div(Seq(
-          IO {
-            ioCounter += 1
-            BasicAttr("hans", "")
-          }
-        )),
-        stringHandler
-      )
-
-      val node = document.createElement("div")
-      document.body.appendChild(node)
-
-      ioCounter shouldBe 0
-      handlerCounter shouldBe 0
-
-      Outwatch.renderInto[IO](node, vtree).map { _ =>
-
-        ioCounter shouldBe 1
-        handlerCounter shouldBe 0
-        stringHandler.unsafeOnNext("pups")
-        ioCounter shouldBe 1
-        handlerCounter shouldBe 1
-
-      }
-
+    var ioCounter = 0
+    var handlerCounter = 0
+    stringHandler.unsafeForeach { _ =>
+      handlerCounter += 1
     }
+
+    val vtree = div(
+      div(Seq(
+        IO {
+          ioCounter += 1
+          BasicAttr("hans", "")
+        }
+      )),
+      stringHandler
+    )
+
+    val node = document.createElement("div")
+    document.body.appendChild(node)
+
+    ioCounter shouldBe 0
+    handlerCounter shouldBe 0
+
+    for {
+      _ <- Outwatch.renderInto[IO](node, vtree)
+
+      _ = ioCounter shouldBe 1
+      _ = handlerCounter shouldBe 0
+      _ <- stringHandler.onNextIO("pups") *> IO.cede
+      _ = ioCounter shouldBe 1
+      _ = handlerCounter shouldBe 1
+
+    } yield succeed
   }
 
   it should "be correctly patched into the DOM" in {
@@ -473,24 +466,20 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     val child = span(message)
     val vtree = div(attributes.head, attributes(1), child)
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, vtree)
 
-      Outwatch.renderInto[IO](n, vtree).map { _ =>
-
-          val patchedNode = document.getElementById(id)
-          patchedNode.childElementCount shouldBe 1
-          patchedNode.classList.contains(cls) shouldBe true
-          patchedNode.children(0).innerHTML shouldBe message
-      }
-
-    }
-
+      patchedNode = document.getElementById(id)
+      _ = patchedNode.childElementCount shouldBe 1
+      _ = patchedNode.classList.contains(cls) shouldBe true
+      _ = patchedNode.children(0).innerHTML shouldBe message
+    } yield succeed
   }
 
   it should "be replaced if they contain changeables (SyncIO)" in {
@@ -513,19 +502,18 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       div(pageHandler.map(page))
     )
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
     for {
-      n <- node
-      _ <- Outwatch.renderInto[IO](n, vtree)
-      _ <- pageHandler.onNextIO(1)
+      _ <- Outwatch.renderInto[IO](node, vtree)
+      _ <- pageHandler.onNextIO(1) *> IO.cede
       domNode = document.getElementById("page")
       _ = domNode.textContent shouldBe "1"
-      _ <- pageHandler.onNextIO(2)
+      _ <- pageHandler.onNextIO(2) *> IO.cede
       _ = domNode.textContent shouldBe "2"
     } yield succeed
   }
@@ -550,7 +538,7 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       div(pageHandler.map(page))
     )
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
@@ -559,12 +547,11 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     // import scala.concurrent.duration._
 
     for {
-      n <- node
-      _ <- Outwatch.renderInto[IO](n, vtree)
-      _ <- pageHandler.onNextIO(1)
+      _ <- Outwatch.renderInto[IO](node, vtree)
+      _ <- pageHandler.onNextIO(1) *> IO.cede
       domNode = document.getElementById("page")
       _ = domNode.textContent shouldBe "1"
-      _ <- pageHandler.onNextIO(2)
+      _ <- pageHandler.onNextIO(2) *> IO.cede
       domNode2 = document.getElementById("page")
       _ = domNode2.textContent shouldBe "2"
     } yield succeed
@@ -625,24 +612,20 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       )
     )
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap {n =>
+    Outwatch.renderInto[IO](node, vtree).map {_ =>
 
-      Outwatch.renderInto[IO](n, vtree).map {_ =>
+      val patchedNode = document.getElementById("test")
 
-        val patchedNode = document.getElementById("test")
-
-        patchedNode.childElementCount shouldBe 2
-        patchedNode.classList.contains("blue") shouldBe true
-        patchedNode.children(0).innerHTML shouldBe message
-        document.getElementById("list").childElementCount shouldBe 3
-      }
-
+      patchedNode.childElementCount shouldBe 2
+      patchedNode.classList.contains("blue") shouldBe true
+      patchedNode.children(0).innerHTML shouldBe message
+      document.getElementById("list").childElementCount shouldBe 3
     }
   }
 
@@ -653,32 +636,29 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       input(attributes.value <-- messages, idAttr := "input")
     )
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, vtree)
 
-      Outwatch.renderInto[IO](n, vtree).map { _ =>
+      field = document.getElementById("input").asInstanceOf[html.Input]
 
-        val field = document.getElementById("input").asInstanceOf[html.Input]
+      _ = field.value shouldBe ""
 
-        field.value shouldBe ""
+      message = "Hello"
+      _ <- messages.onNextIO(message) *> IO.cede
 
-        val message = "Hello"
-        messages.unsafeOnNext(message)
+      _ = field.value shouldBe message
 
-        field.value shouldBe message
+      message2 = "World"
+      _ <- messages.onNextIO(message2) *> IO.cede
 
-        val message2 = "World"
-        messages.unsafeOnNext(message2)
-
-        field.value shouldBe message2
-      }
-
-    }
+      _ = field.value shouldBe message2
+    } yield succeed
   }
 
   it should "render child nodes in correct order" in {
@@ -693,23 +673,20 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       messagesB.map(span(_))
     )
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, vNode)
 
-      Outwatch.renderInto[IO](n, vNode).map { _ =>
+      _ <- messagesA.onNextIO("1") *> IO.cede
+      _ <- messagesB.onNextIO("2") *> IO.cede
 
-        messagesA.unsafeOnNext("1")
-        messagesB.unsafeOnNext("2")
-
-        n.innerHTML shouldBe "<div><span>A</span><span>1</span><span>B</span><span>2</span></div>"
-      }
-
-    }
+      _ = node.innerHTML shouldBe "<div><span>A</span><span>1</span><span>B</span><span>2</span></div>"
+    } yield succeed
   }
 
   it should "render child string-nodes in correct order" in {
@@ -723,26 +700,23 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       messagesB
     )
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, vNode)
 
-      Outwatch.renderInto[IO](n, vNode).map { _ =>
+      _ = node.innerHTML shouldBe "<div>AB</div>"
 
-        n.innerHTML shouldBe "<div>AB</div>"
+      _ <- messagesA.onNextIO("1") *> IO.cede
+      _ = node.innerHTML shouldBe "<div>A1B</div>"
 
-        messagesA.unsafeOnNext("1")
-        n.innerHTML shouldBe "<div>A1B</div>"
-
-        messagesB.unsafeOnNext("2")
-        n.innerHTML shouldBe "<div>A1B2</div>"
-      }
-
-    }
+      _ <- messagesB.onNextIO("2") *> IO.cede
+      _ = node.innerHTML shouldBe "<div>A1B2</div>"
+    } yield succeed
   }
 
   it should "render child string-nodes in correct order, mixed with children" in {
@@ -759,29 +733,26 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       messagesB
     )
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, vNode)
 
-      Outwatch.renderInto[IO](n, vNode).map { _ =>
+      _ = node.innerHTML shouldBe "<div>AB</div>"
 
-        n.innerHTML shouldBe "<div>AB</div>"
+      _ <- messagesA.onNextIO("1") *> IO.cede
+      _ = node.innerHTML shouldBe "<div>A1B</div>"
 
-        messagesA.unsafeOnNext("1")
-        n.innerHTML shouldBe "<div>A1B</div>"
+      _ <- messagesB.onNextIO("2") *> IO.cede
+      _ = node.innerHTML shouldBe "<div>A1B2</div>"
 
-        messagesB.unsafeOnNext("2")
-        n.innerHTML shouldBe "<div>A1B2</div>"
-
-        messagesC.unsafeOnNext(Seq(div("5"), div("7")))
-        n.innerHTML shouldBe "<div>A1<div>5</div><div>7</div>B2</div>"
-      }
-
-    }
+      _ <- messagesC.onNextIO(Seq(div("5"), div("7"))) *> IO.cede
+      _ = node.innerHTML shouldBe "<div>A1<div>5</div><div>7</div>B2</div>"
+    } yield succeed
   }
 
   it should "update merged nodes children correctly" in {
@@ -791,27 +762,24 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     val vNode = div(messages)(otherMessages)
 
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, vNode)
 
-      Outwatch.renderInto[IO](n, vNode).map { _ =>
+      _ <- otherMessages.onNextIO(Seq(div("otherMessage"))) *> IO.cede
+      _ = node.children(0).innerHTML shouldBe "<div>otherMessage</div>"
 
-        otherMessages.unsafeOnNext(Seq(div("otherMessage")))
-        n.children(0).innerHTML shouldBe "<div>otherMessage</div>"
+      _ <- messages.onNextIO(Seq(div("message"))) *> IO.cede
+      _ = node.children(0).innerHTML shouldBe "<div>message</div><div>otherMessage</div>"
 
-        messages.unsafeOnNext(Seq(div("message")))
-        n.children(0).innerHTML shouldBe "<div>message</div><div>otherMessage</div>"
-
-        otherMessages.unsafeOnNext(Seq(div("genus")))
-        n.children(0).innerHTML shouldBe "<div>message</div><div>genus</div>"
-      }
-
-    }
+      _ <- otherMessages.onNextIO(Seq(div("genus"))) *> IO.cede
+      _ = node.children(0).innerHTML shouldBe "<div>message</div><div>genus</div>"
+    } yield succeed
   }
 
   it should "update merged nodes separate children correctly" in {
@@ -820,29 +788,27 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     val otherMessages = Subject.publish[String]()
     val vNode = div(messages)(otherMessages)
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, vNode)
 
-      Outwatch.renderInto[IO](n, vNode).map { _ =>
+      _ = node.children(0).innerHTML shouldBe ""
 
-        n.children(0).innerHTML shouldBe ""
+      _ <- otherMessages.onNextIO("otherMessage") *> IO.cede
+      _ = node.children(0).innerHTML shouldBe "otherMessage"
 
-        otherMessages.unsafeOnNext("otherMessage")
-        n.children(0).innerHTML shouldBe "otherMessage"
+      _ <- messages.onNextIO("message") *> IO.cede
+      _ = node.children(0).innerHTML shouldBe "messageotherMessage"
 
-        messages.unsafeOnNext("message")
-        n.children(0).innerHTML shouldBe "messageotherMessage"
+      _ <- otherMessages.onNextIO("genus") *> IO.cede
+      _ = node.children(0).innerHTML shouldBe "messagegenus"
+    } yield succeed
 
-        otherMessages.unsafeOnNext("genus")
-        n.children(0).innerHTML shouldBe "messagegenus"
-      }
-
-    }
   }
 
   it should "partially render component even if parts not present" in {
@@ -857,40 +823,38 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       childString
     )
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, vNode)
 
-      Outwatch.renderInto[IO](n, vNode).map { _ =>
+      inner = document.getElementById("inner").asInstanceOf[html.Div]
 
-        val inner = document.getElementById("inner").asInstanceOf[html.Div]
+      _ = inner.innerHTML shouldBe ""
+      _ = inner.style.color shouldBe ""
+      _ = inner.style.backgroundColor shouldBe ""
 
-        inner.innerHTML shouldBe ""
-        inner.style.color shouldBe ""
-        inner.style.backgroundColor shouldBe ""
+      _ <- childString.onNextIO("fish") *> IO.cede
+      _ = inner.innerHTML shouldBe "fish"
+      _ = inner.style.color shouldBe ""
+      _ = inner.style.backgroundColor shouldBe ""
 
-        childString.unsafeOnNext("fish")
-        inner.innerHTML shouldBe "fish"
-        inner.style.color shouldBe ""
-        inner.style.backgroundColor shouldBe ""
+      _ <- messagesColor.onNextIO("red") *> IO.cede
+      _ = inner.innerHTML shouldBe "fish"
+      _ = inner.style.color shouldBe "red"
+      _ = inner.style.backgroundColor shouldBe ""
 
-        messagesColor.unsafeOnNext("red")
-        inner.innerHTML shouldBe "fish"
-        inner.style.color shouldBe "red"
-        inner.style.backgroundColor shouldBe ""
+      _ <- messagesBgColor.onNextIO("blue") *> IO.cede
+      _ = inner.innerHTML shouldBe "fish"
+      _ = inner.style.color shouldBe "red"
+      _ = inner.style.backgroundColor shouldBe "blue"
 
-        messagesBgColor.unsafeOnNext("blue")
-        inner.innerHTML shouldBe "fish"
-        inner.style.color shouldBe "red"
-        inner.style.backgroundColor shouldBe "blue"
+    } yield succeed
 
-      }
-
-    }
   }
 
   it should "partially render component even if parts not present2" in {
@@ -903,31 +867,29 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       childString
     )
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, vNode)
 
-      Outwatch.renderInto[IO](n, vNode).map { _ =>
+      inner = document.getElementById("inner").asInstanceOf[html.Div]
 
-        val inner = document.getElementById("inner").asInstanceOf[html.Div]
+      _ = inner.innerHTML shouldBe ""
+      _ = inner.style.color shouldBe ""
 
-        inner.innerHTML shouldBe ""
-        inner.style.color shouldBe ""
+      _ <- childString.onNextIO("fish") *> IO.cede
+      _ = inner.innerHTML shouldBe "fish"
+      _ = inner.style.color shouldBe ""
 
-        childString.unsafeOnNext("fish")
-        inner.innerHTML shouldBe "fish"
-        inner.style.color shouldBe ""
+      _ <- messagesColor.onNextIO("red") *> IO.cede
+      _ = inner.innerHTML shouldBe "fish"
+      _ = inner.style.color shouldBe "red"
+    } yield succeed
 
-        messagesColor.unsafeOnNext("red")
-        inner.innerHTML shouldBe "fish"
-        inner.style.color shouldBe "red"
-      }
-
-    }
   }
 
   it should "update reused vnodes correctly" in {
@@ -936,26 +898,24 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     val vNode = div(data.ralf := true, messages)
     val container = div(vNode, vNode)
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, container)
 
-      Outwatch.renderInto[IO](n, container).map { _ =>
+      _ <- messages.onNextIO("message") *> IO.cede
+      _ = node.children(0).children(0).innerHTML shouldBe "message"
+      _ = node.children(0).children(1).innerHTML shouldBe "message"
 
-        messages.unsafeOnNext("message")
-        n.children(0).children(0).innerHTML shouldBe "message"
-        n.children(0).children(1).innerHTML shouldBe "message"
+      _ <- messages.onNextIO("bumo") *> IO.cede
+      _ = node.children(0).children(0).innerHTML shouldBe "bumo"
+      _ = node.children(0).children(1).innerHTML shouldBe "bumo"
+    } yield succeed
 
-        messages.unsafeOnNext("bumo")
-        n.children(0).children(0).innerHTML shouldBe "bumo"
-        n.children(0).children(1).innerHTML shouldBe "bumo"
-      }
-
-    }
   }
 
   it should "update merged nodes correctly (render reuse)" in {
@@ -971,31 +931,26 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       node
     }
 
-    val test = for {
-
+    for {
       node1 <- node
-       _ <- Outwatch.renderInto[IO](node1, vNodeTemplate)
+      _ <- Outwatch.renderInto[IO](node1, vNodeTemplate)
 
       node2 <- node
-       _ <- Outwatch.renderInto[IO](node2, vNode)
+      _ <- Outwatch.renderInto[IO](node2, vNode)
 
-    } yield {
+      _ <- messages.onNextIO("gurkon") *> IO.cede
+      _ <- otherMessages.onNextIO("otherMessage") *> IO.cede
+      _ = node1.children(0).innerHTML shouldBe "gurkon"
+      _ = node2.children(0).innerHTML shouldBe "gurkonotherMessage"
 
-      messages.unsafeOnNext("gurkon")
-      otherMessages.unsafeOnNext("otherMessage")
-      node1.children(0).innerHTML shouldBe "gurkon"
-      node2.children(0).innerHTML shouldBe "gurkonotherMessage"
+      _ <- messages.onNextIO("message") *> IO.cede
+      _ = node1.children(0).innerHTML shouldBe "message"
+      _ = node2.children(0).innerHTML shouldBe "messageotherMessage"
 
-      messages.unsafeOnNext("message")
-      node1.children(0).innerHTML shouldBe "message"
-      node2.children(0).innerHTML shouldBe "messageotherMessage"
-
-      otherMessages.unsafeOnNext("genus")
-      node1.children(0).innerHTML shouldBe "message"
-      node2.children(0).innerHTML shouldBe "messagegenus"
-    }
-
-    test
+      _ <- otherMessages.onNextIO("genus") *> IO.cede
+      _ = node1.children(0).innerHTML shouldBe "message"
+      _ = node2.children(0).innerHTML shouldBe "messagegenus"
+    } yield succeed
   }
 
   it should "update merged node attributes correctly" in {
@@ -1004,27 +959,24 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     val otherMessages = Subject.publish[String]()
     val vNode = div(data.noise <-- messages)(data.noise <-- otherMessages)
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, vNode)
 
-      Outwatch.renderInto[IO](n, vNode).map { _ =>
+      _ <- otherMessages.onNextIO("otherMessage") *> IO.cede
+      _ = node.children(0).getAttribute("data-noise") shouldBe "otherMessage"
 
-        otherMessages.unsafeOnNext("otherMessage")
-        n.children(0).getAttribute("data-noise") shouldBe "otherMessage"
+      _ <- messages.onNextIO("message") // should be ignored *> IO.cede
+      _ = node.children(0).getAttribute("data-noise") shouldBe "otherMessage"
 
-        messages.unsafeOnNext("message") // should be ignored
-        n.children(0).getAttribute("data-noise") shouldBe "otherMessage"
-
-        otherMessages.unsafeOnNext("genus")
-        n.children(0).getAttribute("data-noise") shouldBe "genus"
-      }
-
-    }
+      _ <- otherMessages.onNextIO("genus") *> IO.cede
+      _ = node.children(0).getAttribute("data-noise") shouldBe "genus"
+    } yield succeed
   }
 
   it should "update merged node styles written with style() correctly" in {
@@ -1033,27 +985,25 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     val otherMessages = Subject.publish[String]()
     val vNode = div(VModifier.style("color") <-- messages)(VModifier.style("color") <-- otherMessages)
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, vNode)
 
-      Outwatch.renderInto[IO](n, vNode).map { _ =>
+      _ <- otherMessages.onNextIO("red") *> IO.cede
+      _ = node.children(0).asInstanceOf[html.Element].style.color shouldBe "red"
 
-        otherMessages.unsafeOnNext("red")
-        n.children(0).asInstanceOf[html.Element].style.color shouldBe "red"
+      _ <- messages.onNextIO("blue") // should be ignored *> IO.cede
+      _ = node.children(0).asInstanceOf[html.Element].style.color shouldBe "red"
 
-        messages.unsafeOnNext("blue") // should be ignored
-        n.children(0).asInstanceOf[html.Element].style.color shouldBe "red"
+      _ <- otherMessages.onNextIO("green") *> IO.cede
+      _ = node.children(0).asInstanceOf[html.Element].style.color shouldBe "green"
+    } yield succeed
 
-        otherMessages.unsafeOnNext("green")
-        n.children(0).asInstanceOf[html.Element].style.color shouldBe "green"
-      }
-
-    }
   }
 
   it should "update merged node styles correctly" in {
@@ -1062,49 +1012,43 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     val otherMessages = Subject.publish[String]()
     val vNode = div(color <-- messages)(color <-- otherMessages)
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, vNode)
 
-      Outwatch.renderInto[IO](n, vNode).map { _ =>
+      _ <- otherMessages.onNextIO("red") *> IO.cede
+      _ = node.children(0).asInstanceOf[html.Element].style.color shouldBe "red"
 
-        otherMessages.unsafeOnNext("red")
-        n.children(0).asInstanceOf[html.Element].style.color shouldBe "red"
+      _ <- messages.onNextIO("blue") // should be ignored *> IO.cede
+      _ = node.children(0).asInstanceOf[html.Element].style.color shouldBe "red"
 
-        messages.unsafeOnNext("blue") // should be ignored
-        n.children(0).asInstanceOf[html.Element].style.color shouldBe "red"
+      _ <- otherMessages.onNextIO("green") *> IO.cede
+      _ = node.children(0).asInstanceOf[html.Element].style.color shouldBe "green"
+    } yield succeed
 
-        otherMessages.unsafeOnNext("green")
-        n.children(0).asInstanceOf[html.Element].style.color shouldBe "green"
-      }
-
-    }
   }
-
 
   it should "render composite VNodes properly" in {
 
     val items = Seq("one", "two", "three")
     val vNode = div(items.map(item => span(item)))
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, vNode)
 
-      Outwatch.renderInto[IO](n, vNode).map { _ =>
-
-        n.innerHTML shouldBe "<div><span>one</span><span>two</span><span>three</span></div>"
-      }
-
-    }
+      _ = node.innerHTML shouldBe "<div><span>one</span><span>two</span><span>three</span></div>"
+    } yield succeed
   }
 
   it should "render nodes with only attribute receivers properly" in {
@@ -1112,71 +1056,61 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     val classes = Subject.publish[String]()
     val vNode = button( className <-- classes, "Submit")
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, vNode)
 
-      Outwatch.renderInto[IO](n, vNode).map { _ =>
+      _ <- classes.onNextIO("active") *> IO.cede
 
-        classes.unsafeOnNext("active")
-
-        n.innerHTML shouldBe """<button class="active">Submit</button>"""
-      }
-
-    }
+      _ = node.innerHTML shouldBe """<button class="active">Submit</button>"""
+    } yield succeed
   }
 
   it should "work with custom tags" in {
 
     val vNode = div(VNode.html("main")())
 
-    val node = IO {
+    val node = {
       val node = document.createElement("div")
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    for {
+      _ <- Outwatch.renderInto[IO](node, vNode)
 
-      Outwatch.renderInto[IO](n, vNode).map { _ =>
-
-        n.innerHTML shouldBe "<div><main></main></div>"
-      }
-
-    }
+      _ = node.innerHTML shouldBe "<div><main></main></div>"
+    } yield succeed
   }
 
   it should "work with un-assigned booleans attributes and props" in {
 
     val vNode = option(selected, disabled)
 
-    val node = IO {
+    val node = {
       val node = document.createElement("option").asInstanceOf[html.Option]
       document.body.appendChild(node)
       node
     }
 
-    node.flatMap { n =>
+    node.selected shouldBe false
+    node.disabled shouldBe false
 
-      n.selected shouldBe false
-      n.disabled shouldBe false
+    Outwatch.renderReplace[IO](node, vNode).map {_ =>
 
-      Outwatch.renderReplace[IO](n, vNode).map {_ =>
-
-        n.selected shouldBe true
-        n.disabled shouldBe true
-      }
-
+      node.selected shouldBe true
+      node.disabled shouldBe true
     }
   }
 
   it should "correctly work with Render conversions" in {
 
-    val test: IO[Assertion] = for {
+    for {
       n1 <- IO(document.createElement("div"))
 
        _ <- Outwatch.renderReplace[IO](n1, div("one"))
@@ -1206,8 +1140,6 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       _ = n1.innerHTML shouldBe "12"
 
     } yield succeed
-
-    test
   }
 
   "Children stream" should "work for string sequences" in {
@@ -1215,12 +1147,12 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     val myStrings: Observable[Seq[String]] = Observable(Seq("a", "b"))
     val node = div(idAttr := "strings", myStrings)
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      val element = document.getElementById("strings")
-      element.innerHTML shouldBe "ab"
-
-    }
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe "ab"
+    } yield succeed
   }
 
   it should "work for string sequences non empty" in {
@@ -1228,12 +1160,12 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     val myStrings: Observable[Seq[String]] = nonEmptyObservable(Seq("a", "b"))
     val node = div(idAttr := "strings", myStrings)
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      val element = document.getElementById("strings")
-      element.innerHTML shouldBe "ab"
-
-    }
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe "ab"
+    } yield succeed
   }
 
 
@@ -1243,12 +1175,12 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       1.1, true, 133L, 7
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      val element = document.getElementById("strings")
-      element.innerHTML shouldBe "1.1true1337"
-
-    }
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe "1.1true1337"
+    } yield succeed
   }
 
   it should "work for string options" in {
@@ -1257,16 +1189,15 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
 
       val node = div(idAttr := "strings", myOption)
 
-      Outwatch.renderInto[IO]("#app", node).map { _ =>
+      for {
+        _ <- Outwatch.renderInto[IO]("#app", node)
 
-        val element = document.getElementById("strings")
-        element.innerHTML shouldBe "a"
+        element = document.getElementById("strings")
+        _ = element.innerHTML shouldBe "a"
 
-        myOption.unsafeOnNext(None)
-        element.innerHTML shouldBe ""
-
-      }
-
+        _ <- myOption.onNextIO(None) *> IO.cede
+        _ = element.innerHTML shouldBe ""
+      } yield succeed
     }
   }
 
@@ -1276,238 +1207,214 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
 
       val node = div(idAttr := "strings", myOption)
 
-      Outwatch.renderInto[IO]("#app", node).map { _ =>
+      for {
+        _ <- Outwatch.renderInto[IO]("#app", node)
 
-        val element = document.getElementById("strings")
-        element.innerHTML shouldBe "<div>a</div>"
+        element = document.getElementById("strings")
+        _ = element.innerHTML shouldBe "<div>a</div>"
 
-        myOption.unsafeOnNext(None)
-        element.innerHTML shouldBe ""
+        _ <- myOption.onNextIO(None) *> IO.cede
+        _ = element.innerHTML shouldBe ""
 
-      }
-
+      } yield succeed
     }
   }
 
   "Modifier stream" should "work for modifier" in {
 
-    IO(Subject.behavior[VModifier](Seq(cls := "hans", b("stark")))).flatMap { myHandler =>
+    val myHandler = Subject.behavior[VModifier](Seq(cls := "hans", b("stark")))
+    val node = div(idAttr := "strings",
+      div(VModifier(myHandler))
+    )
 
-      val node = div(idAttr := "strings",
-        div(VModifier(myHandler))
-      )
-
-      Outwatch.renderInto[IO]("#app", node).map { _ =>
-
-        val element = document.getElementById("strings")
-        element.innerHTML shouldBe """<div class="hans"><b>stark</b></div>"""
-
-        myHandler.unsafeOnNext(Option(idAttr := "fair"))
-        element.innerHTML shouldBe """<div id="fair"></div>"""
-
-      }
-
-    }
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe """<div class="hans"><b>stark</b></div>"""
+      _ <- myHandler.onNextIO(Option(idAttr := "fair")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div id="fair"></div>"""
+    } yield succeed
   }
 
   it should "work for multiple mods" in {
 
-    val test: IO[Assertion] = IO(Subject.replayLatest[VModifier]()).flatMap { myHandler =>
+    val myHandler = Subject.replayLatest[VModifier]()
+    val node = div(idAttr := "strings",
+      div(myHandler, "bla")
+    )
 
-      val node = div(idAttr := "strings",
-        div(myHandler, "bla")
-      )
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      Outwatch.renderInto[IO]("#app", node).flatMap { _ =>
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe "<div>bla</div>"
 
-        val element = document.getElementById("strings")
-        element.innerHTML shouldBe "<div>bla</div>"
+      _ <- myHandler.onNextIO(cls := "hans") *> IO.cede
+      _ = element.innerHTML shouldBe """<div class="hans">bla</div>"""
 
-        myHandler.unsafeOnNext(cls := "hans")
-        element.innerHTML shouldBe """<div class="hans">bla</div>"""
+      innerHandler = Subject.replayLatest[VModifier]()
 
-        IO(Subject.replayLatest[VModifier]()).map { innerHandler =>
+      _ <- myHandler.onNextIO(div(
+        innerHandler,
+        cls := "no?",
+        "yes?"
+      )) *> IO.cede
+      _ = element.innerHTML shouldBe """<div><div class="no?">yes?</div>bla</div>"""
 
-          myHandler.unsafeOnNext(div(
-            innerHandler,
-            cls := "no?",
-            "yes?"
-          ))
-          element.innerHTML shouldBe """<div><div class="no?">yes?</div>bla</div>"""
+      _ <- innerHandler.onNextIO(Seq(span("question:"), idAttr := "heidi")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div><div class="no?" id="heidi"><span>question:</span>yes?</div>bla</div>"""
 
-          innerHandler.unsafeOnNext(Seq(span("question:"), idAttr := "heidi"))
-          element.innerHTML shouldBe """<div><div class="no?" id="heidi"><span>question:</span>yes?</div>bla</div>"""
+      _ <- myHandler.onNextIO(div(
+        innerHandler,
+        cls := "no?",
+        "yes?",
+        b("go!")
+      )) *> IO.cede
+      _ = element.innerHTML shouldBe """<div><div class="no?" id="heidi"><span>question:</span>yes?<b>go!</b></div>bla</div>"""
 
-          myHandler.unsafeOnNext(div(
-            innerHandler,
-            cls := "no?",
-            "yes?",
-            b("go!")
-          ))
+      _ <- innerHandler.onNextIO(Seq(span("question and answer:"), idAttr := "heidi")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div><div class="no?" id="heidi"><span>question and answer:</span>yes?<b>go!</b></div>bla</div>"""
 
-          element.innerHTML shouldBe """<div><div class="no?" id="heidi"><span>question:</span>yes?<b>go!</b></div>bla</div>"""
+      _ <- myHandler.onNextIO(Seq(span("nope"))) *> IO.cede
+      _ = element.innerHTML shouldBe """<div><span>nope</span>bla</div>"""
 
-          innerHandler.unsafeOnNext(Seq(span("question and answer:"), idAttr := "heidi"))
-          element.innerHTML shouldBe """<div><div class="no?" id="heidi"><span>question and answer:</span>yes?<b>go!</b></div>bla</div>"""
-
-          myHandler.unsafeOnNext(Seq(span("nope")))
-          element.innerHTML shouldBe """<div><span>nope</span>bla</div>"""
-
-          innerHandler.unsafeOnNext(b("me?"))
-          element.innerHTML shouldBe """<div><span>nope</span>bla</div>"""
-
-        }
-      }
-
-    }
-
-    test
+      _ <- innerHandler.onNextIO(b("me?")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div><span>nope</span>bla</div>"""
+    } yield succeed
   }
 
   it should "work for nested stream modifier" in {
 
-    IO(Subject.replayLatest[VModifier]()).flatMap { myHandler =>
+    val myHandler = Subject.replayLatest[VModifier]()
+    val node = div(idAttr := "strings",
+      div(myHandler)
+    )
 
-      val node = div(idAttr := "strings",
-        div(myHandler)
-      )
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe "<div></div>"
 
-      Outwatch.renderInto[IO]("#app", node).flatMap { _ =>
+      innerHandler = Subject.replayLatest[VModifier]()
 
-        val element = document.getElementById("strings")
-        element.innerHTML shouldBe "<div></div>"
+      _ <- myHandler.onNextIO(innerHandler) *> IO.cede
+      _ = element.innerHTML shouldBe """<div></div>"""
 
-        IO(Subject.replayLatest[VModifier]()).flatMap { innerHandler =>
+      _ <- innerHandler.onNextIO(VModifier(cls := "hans", "1")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div class="hans">1</div>"""
 
-          myHandler.unsafeOnNext(innerHandler)
-          element.innerHTML shouldBe """<div></div>"""
+      innerHandler2 = Subject.replayLatest[VModifier]()
 
-          innerHandler.unsafeOnNext(VModifier(cls := "hans", "1"))
-          element.innerHTML shouldBe """<div class="hans">1</div>"""
+      _ <- myHandler.onNextIO(innerHandler2) *> IO.cede
+      _ = element.innerHTML shouldBe """<div></div>"""
 
-          IO(Subject.replayLatest[VModifier]()).map { innerHandler2 =>
+      _ <- myHandler.onNextIO(CompositeModifier(VModifier(innerHandler2) :: Nil)) *> IO.cede
+      _ = element.innerHTML shouldBe """<div></div>"""
 
-          myHandler.unsafeOnNext(innerHandler2)
-          element.innerHTML shouldBe """<div></div>"""
+      _ <- myHandler.onNextIO(CompositeModifier(VModifier(innerHandler2) :: Nil)) *> IO.cede
+      _ = element.innerHTML shouldBe """<div></div>"""
 
-          myHandler.unsafeOnNext(CompositeModifier(VModifier(innerHandler2) :: Nil))
-          element.innerHTML shouldBe """<div></div>"""
+      _ <- myHandler.onNextIO(CompositeModifier(StringVNode("pete") :: VModifier(innerHandler2) :: Nil)) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>pete</div>"""
 
-          myHandler.unsafeOnNext(CompositeModifier(VModifier(innerHandler2) :: Nil))
+      _ <- innerHandler2.onNextIO(VModifier(idAttr := "dieter", "r")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div id="dieter">peter</div>"""
 
-          myHandler.unsafeOnNext(CompositeModifier(StringVNode("pete") :: VModifier(innerHandler2) :: Nil))
-          element.innerHTML shouldBe """<div>pete</div>"""
+      _ <- innerHandler.onNextIO(b("me?")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div id="dieter">peter</div>"""
 
-          innerHandler2.unsafeOnNext(VModifier(idAttr := "dieter", "r"))
-          element.innerHTML shouldBe """<div id="dieter">peter</div>"""
-
-          innerHandler.unsafeOnNext(b("me?"))
-          element.innerHTML shouldBe """<div id="dieter">peter</div>"""
-
-          myHandler.unsafeOnNext(span("the end"))
-          element.innerHTML shouldBe """<div><span>the end</span></div>"""
-
-          }
-        }
-      }
-
-    }
+      _ <- myHandler.onNextIO(span("the end")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div><span>the end</span></div>"""
+    } yield succeed
   }
 
   it should "work for nested stream modifier and default value" in {
 
     var numPatches = 0
 
-    IO(Subject.replayLatest[VModifier]()).flatMap { myHandler =>
-
-      val node: VNode = div(idAttr := "strings",
-        div(
-          onSnabbdomPrePatch doAction { numPatches += 1 },
-          myHandler.prepend(VModifier("initial"))
-        )
+    val myHandler = Subject.replayLatest[VModifier]()
+    val node: VNode = div(idAttr := "strings",
+      div(
+        onSnabbdomPrePatch doAction { numPatches += 1 },
+        myHandler.prepend(VModifier("initial"))
       )
+    )
 
-      Outwatch.renderInto[IO]("#app", node).flatMap { _ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-        val element = document.getElementById("strings")
-        element.innerHTML shouldBe "<div>initial</div>"
-        numPatches shouldBe 0
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe "<div>initial</div>"
+      _ = numPatches shouldBe 0
 
-      IO(Subject.replayLatest[VModifier]()).flatMap { innerHandler =>
+      innerHandler = Subject.replayLatest[VModifier]()
 
-        numPatches shouldBe 0
+      _ <- myHandler.onNextIO(innerHandler.prepend(BasicAttr("initial", "2"))) *> IO.cede
+      _ = element.innerHTML shouldBe """<div initial="2"></div>"""
+      _ = numPatches shouldBe 1
 
-        myHandler.unsafeOnNext(innerHandler.prepend(BasicAttr("initial", "2")))
-        element.innerHTML shouldBe """<div initial="2"></div>"""
-        numPatches shouldBe 2
+      _ <- innerHandler.onNextIO(BasicAttr("attr", "3")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div attr="3"></div>"""
+      _ = numPatches shouldBe 2
 
-        innerHandler.unsafeOnNext(BasicAttr("attr", "3"))
-        element.innerHTML shouldBe """<div attr="3"></div>"""
-        numPatches shouldBe 3
+      innerHandler2 = Subject.replayLatest[VModifier]()
+      _ <- myHandler.onNextIO(innerHandler2.prepend(VModifier("initial3"))) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>initial3</div>"""
+      _ = numPatches shouldBe 3
 
-        IO(Subject.replayLatest[VModifier]()).map {innerHandler2 =>
-          myHandler.unsafeOnNext(innerHandler2.prepend(VModifier("initial3")))
-          element.innerHTML shouldBe """<div>initial3</div>"""
-          numPatches shouldBe 5
+      _ <- myHandler.onNextIO(CompositeModifier(VModifier(innerHandler2.prepend(VModifier("initial4"))) :: Nil)) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>initial4</div>"""
+      _ = numPatches shouldBe 4
 
-          myHandler.unsafeOnNext(CompositeModifier(VModifier(innerHandler2.prepend(VModifier("initial4"))) :: Nil))
-          element.innerHTML shouldBe """<div>initial4</div>"""
-          numPatches shouldBe 7
+      _ <- myHandler.onNextIO(CompositeModifier(StringVNode("pete") :: VModifier(innerHandler2) :: Nil)) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>pete</div>"""
+      _ = numPatches shouldBe 5
 
-          myHandler.unsafeOnNext(CompositeModifier(StringVNode("pete") :: VModifier(innerHandler2) :: Nil))
-          element.innerHTML shouldBe """<div>pete</div>"""
-          numPatches shouldBe 8
+      _ <- innerHandler2.onNextIO(VModifier(idAttr := "dieter", "r")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div id="dieter">peter</div>"""
+      _ = numPatches shouldBe 6
 
-          innerHandler2.unsafeOnNext(VModifier(idAttr := "dieter", "r"))
-          element.innerHTML shouldBe """<div id="dieter">peter</div>"""
-          numPatches shouldBe 9
+      _ <- innerHandler.onNextIO("me?") *> IO.cede
+      _ = element.innerHTML shouldBe """<div id="dieter">peter</div>"""
+      _ = numPatches shouldBe 6
 
-          innerHandler.unsafeOnNext("me?")
-          element.innerHTML shouldBe """<div id="dieter">peter</div>"""
-          numPatches shouldBe 9
-
-          myHandler.unsafeOnNext(span("the end"))
-          element.innerHTML shouldBe """<div><span>the end</span></div>"""
-          numPatches shouldBe 10
-      }}}}
+      _ <- myHandler.onNextIO(span("the end")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div><span>the end</span></div>"""
+      _ = numPatches shouldBe 7
+    } yield succeed
   }
 
   it should "work for deeply nested handlers" in {
 
-    val test: IO[Assertion] = IO(Subject.behavior(0)).flatMap { a =>
-
-      val b = a.map(_.toString)
-      val node =
-        div(
-          a.map(_ =>
-              div(
-                b.map(b =>
-                  div(b)
-                )
+    val a = Subject.behavior(0)
+    val b = a.map(_.toString)
+    val node =
+      div(
+        a.map(_ =>
+            div(
+              b.map(b =>
+                div(b)
               )
-          )
+            )
         )
+      )
 
-      Outwatch.renderInto[IO]("#app", node).map {_ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-        val element = document.getElementById("app")
-        element.innerHTML shouldBe "<div><div><div>0</div></div></div>"
+      element = document.getElementById("app")
+      _ = element.innerHTML shouldBe "<div><div><div>0</div></div></div>"
 
-        a.unsafeOnNext(1)
-        element.innerHTML shouldBe "<div><div><div>1</div></div></div>"
-
-      }
-    }
-
-    test
+      _ <- a.onNextIO(1) *> IO.cede
+      _ = element.innerHTML shouldBe "<div><div><div>1</div></div></div>"
+    } yield succeed
   }
 
   it should "work for nested stream modifier and empty default and start with" in {
 
     var numPatches = 0
 
-    IO(Subject.behavior[VModifier]("initial")).flatMap { myHandler =>
-
+    val myHandler = Subject.behavior[VModifier]("initial")
     val node = div(idAttr := "strings",
       div(
         onSnabbdomPrePatch doAction { numPatches += 1 },
@@ -1515,156 +1422,157 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       )
     )
 
-    Outwatch.renderInto[IO]("#app", node).flatMap { _ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      val element = document.getElementById("strings")
-      element.innerHTML shouldBe "<div>initial</div>"
-      numPatches shouldBe 0
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe "<div>initial</div>"
+      _ = numPatches shouldBe 0
 
-      IO(Subject.replayLatest[VModifier]()).flatMap { innerHandler =>
-      myHandler.unsafeOnNext(innerHandler.startWith(BasicAttr("initial", "2") :: Nil))
-      element.innerHTML shouldBe """<div initial="2"></div>"""
-      numPatches shouldBe 2
+      innerHandler = Subject.replayLatest[VModifier]()
+      _ <- myHandler.onNextIO(innerHandler.startWith(BasicAttr("initial", "2") :: Nil)) *> IO.cede
+      _ = element.innerHTML shouldBe """<div initial="2"></div>"""
+      _ = numPatches shouldBe 1
 
-      innerHandler.unsafeOnNext(BasicAttr("attr", "3"))
-      element.innerHTML shouldBe """<div attr="3"></div>"""
-      numPatches shouldBe 3
+      _ <- innerHandler.onNextIO(BasicAttr("attr", "3")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div attr="3"></div>"""
+      _ = numPatches shouldBe 2
 
-        IO(Subject.replayLatest[VModifier]()).map { innerHandler2 =>
-        myHandler.unsafeOnNext(innerHandler2.startWith(VModifier("initial3") :: Nil))
-        element.innerHTML shouldBe """<div>initial3</div>"""
-        numPatches shouldBe 5
+      innerHandler2 = Subject.replayLatest[VModifier]()
+      _ <- myHandler.onNextIO(innerHandler2.startWith(VModifier("initial3") :: Nil)) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>initial3</div>"""
+      _ = numPatches shouldBe 3
 
-        myHandler.unsafeOnNext(CompositeModifier(VModifier(innerHandler2.prepend(VModifier("initial4"))) :: Nil))
-        element.innerHTML shouldBe """<div>initial4</div>"""
-        numPatches shouldBe 7
+      _ <- myHandler.onNextIO(CompositeModifier(VModifier(innerHandler2.prepend(VModifier("initial4"))) :: Nil)) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>initial4</div>"""
+      _ = numPatches shouldBe 4
 
-        myHandler.unsafeOnNext(CompositeModifier(StringVNode("pete") :: VModifier(innerHandler2) :: Nil))
-        element.innerHTML shouldBe """<div>pete</div>"""
-        numPatches shouldBe 8
+      _ <- myHandler.onNextIO(CompositeModifier(StringVNode("pete") :: VModifier(innerHandler2) :: Nil)) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>pete</div>"""
+      _ = numPatches shouldBe 5
 
-        innerHandler2.unsafeOnNext(VModifier(idAttr := "dieter", "r"))
-        element.innerHTML shouldBe """<div id="dieter">peter</div>"""
-        numPatches shouldBe 9
+      _ <- innerHandler2.onNextIO(VModifier(idAttr := "dieter", "r")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div id="dieter">peter</div>"""
+      _ = numPatches shouldBe 6
 
-        innerHandler.unsafeOnNext("me?")
-        element.innerHTML shouldBe """<div id="dieter">peter</div>"""
-        numPatches shouldBe 9
+      _ <- innerHandler.onNextIO("me?") *> IO.cede
+      _ = element.innerHTML shouldBe """<div id="dieter">peter</div>"""
+      _ = numPatches shouldBe 6
 
-        myHandler.unsafeOnNext(span("the end"))
-        element.innerHTML shouldBe """<div><span>the end</span></div>"""
-        numPatches shouldBe 10
-
-    }}}}
+      _ <- myHandler.onNextIO(span("the end")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div><span>the end</span></div>"""
+      _ = numPatches shouldBe 7
+    } yield succeed
   }
 
   it should "work for stream modifier and streaming default value (subscriptions are canceled properly)" in {
 
-    IO(Subject.replayLatest[VModifier]()).flatMap { myHandler =>
-    IO(Subject.replayLatest[VModifier]()).flatMap { innerHandler =>
+    val myHandler = Subject.replayLatest[VModifier]()
+    val innerHandler = Subject.replayLatest[VModifier]()
 
-      val outerTriggers = new scala.collection.mutable.ArrayBuffer[VModifier]
-      val innerTriggers = new scala.collection.mutable.ArrayBuffer[VModifier]
+    val outerTriggers = new scala.collection.mutable.ArrayBuffer[VModifier]
+    val innerTriggers = new scala.collection.mutable.ArrayBuffer[VModifier]
 
-      val node = div(idAttr := "strings",
-        div(
-          myHandler.map { x => outerTriggers += x; x }.prepend(VModifier(innerHandler.map { x => innerTriggers += x; x }.prepend(VModifier("initial"))))
-        )
+    val node = div(idAttr := "strings",
+      div(
+        myHandler.map { x => outerTriggers += x; x }.prepend(VModifier(innerHandler.map { x => innerTriggers += x; x }.prepend(VModifier("initial"))))
       )
+    )
 
-      Outwatch.renderInto[IO]("#app", node).flatMap {_ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-        val element = document.getElementById("strings")
-        element.innerHTML shouldBe "<div>initial</div>"
-        outerTriggers.size shouldBe 0
-        innerTriggers.size shouldBe 0
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe "<div>initial</div>"
+      _ = outerTriggers.size shouldBe 0
+      _ = innerTriggers.size shouldBe 0
 
-        innerHandler.unsafeOnNext(VModifier("hi!"))
-        element.innerHTML shouldBe """<div>hi!</div>"""
-        outerTriggers.size shouldBe 0
-        innerTriggers.size shouldBe 1
+      _ <- innerHandler.onNextIO(VModifier("hi!")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>hi!</div>"""
+      _ = outerTriggers.size shouldBe 0
+      _ = innerTriggers.size shouldBe 1
 
-        myHandler.unsafeOnNext(VModifier("test"))
-        element.innerHTML shouldBe """<div>test</div>"""
-        outerTriggers.size shouldBe 1
-        innerTriggers.size shouldBe 1
+      _ <- myHandler.onNextIO(VModifier("test")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>test</div>"""
+      _ = outerTriggers.size shouldBe 1
+      _ = innerTriggers.size shouldBe 1
 
-        myHandler.unsafeOnNext(nonEmptyObservable(BasicAttr("initial", "2")))
-        element.innerHTML shouldBe """<div initial="2"></div>"""
-        outerTriggers.size shouldBe 2
-        innerTriggers.size shouldBe 1
+      _ <- myHandler.onNextIO(nonEmptyObservable(BasicAttr("initial", "2"))) *> IO.cede
+      _ = element.innerHTML shouldBe """<div initial="2"></div>"""
+      _ = outerTriggers.size shouldBe 2
+      _ = innerTriggers.size shouldBe 1
 
-        innerHandler.unsafeOnNext(VModifier("me?"))
-        element.innerHTML shouldBe """<div initial="2"></div>"""
-        outerTriggers.size shouldBe 2
-        innerTriggers.size shouldBe 1
+      _ <- innerHandler.onNextIO(VModifier("me?")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div initial="2"></div>"""
+      _ = outerTriggers.size shouldBe 2
+      _ = innerTriggers.size shouldBe 1
 
-        myHandler.unsafeOnNext(innerHandler.map { x => innerTriggers += x; x }.prepend(VModifier.empty))
-        element.innerHTML shouldBe """<div>me?</div>"""
-        outerTriggers.size shouldBe 3
-        innerTriggers.size shouldBe 2
+      _ <- myHandler.onNextIO(innerHandler.map { x => innerTriggers += x; x }.prepend(VModifier.empty)) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>me?</div>"""
+      _ = outerTriggers.size shouldBe 3
+      _ = innerTriggers.size shouldBe 2
 
-        innerHandler.unsafeOnNext(BasicAttr("attr", "3"))
-        element.innerHTML shouldBe """<div attr="3"></div>"""
-        outerTriggers.size shouldBe 3
-        innerTriggers.size shouldBe 3
+      _ <- innerHandler.onNextIO(BasicAttr("attr", "3")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div attr="3"></div>"""
+      _ = outerTriggers.size shouldBe 3
+      _ = innerTriggers.size shouldBe 3
 
-        val innerTriggers2 = new scala.collection.mutable.ArrayBuffer[VModifier]
-        val innerTriggers3 = new scala.collection.mutable.ArrayBuffer[VModifier]
+      innerTriggers2 = new scala.collection.mutable.ArrayBuffer[VModifier]
+      innerTriggers3 = new scala.collection.mutable.ArrayBuffer[VModifier]
 
-        IO(Subject.replayLatest[VModifier]()).flatMap { innerHandler2 =>
-        IO(Subject.replayLatest[VModifier]()).map { innerHandler3 =>
+      innerHandler2 = Subject.replayLatest[VModifier]()
+      innerHandler3 = Subject.replayLatest[VModifier]()
 
-            innerHandler.unsafeOnNext(innerHandler2.map { x => innerTriggers2 += x; x }.prepend(VModifier(innerHandler3.map { x => innerTriggers3 += x; x })))
-            element.innerHTML shouldBe """<div></div>"""
-            outerTriggers.size shouldBe 3
-            innerTriggers.size shouldBe 4
-            innerTriggers2.size shouldBe 0
-            innerTriggers3.size shouldBe 0
+      _ <- innerHandler.onNextIO(innerHandler2.map { x => innerTriggers2 += x; x }.prepend(VModifier(innerHandler3.map { x => innerTriggers3 += x; x }))) *> IO.cede
+      _ = element.innerHTML shouldBe """<div></div>"""
+      _ = outerTriggers.size shouldBe 3
+      _ = innerTriggers.size shouldBe 4
+      _ = innerTriggers2.size shouldBe 0
+      _ = innerTriggers3.size shouldBe 0
 
-            innerHandler2.unsafeOnNext(VModifier("2"))
-            element.innerHTML shouldBe """<div>2</div>"""
-            outerTriggers.size shouldBe 3
-            innerTriggers.size shouldBe 4
-            innerTriggers2.size shouldBe 1
-            innerTriggers3.size shouldBe 0
+      _ <- innerHandler2.onNextIO(VModifier("2")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>2</div>"""
+      _ = outerTriggers.size shouldBe 3
+      _ = innerTriggers.size shouldBe 4
+      _ = innerTriggers2.size shouldBe 1
+      _ = innerTriggers3.size shouldBe 0
 
-            innerHandler.unsafeOnNext(EmptyModifier)
-            element.innerHTML shouldBe """<div></div>"""
-            outerTriggers.size shouldBe 3
-            innerTriggers.size shouldBe 5
-            innerTriggers2.size shouldBe 1
-            innerTriggers3.size shouldBe 0
+      _ <- innerHandler.onNextIO(EmptyModifier) *> IO.cede
+      _ = element.innerHTML shouldBe """<div></div>"""
+      _ = outerTriggers.size shouldBe 3
+      _ = innerTriggers.size shouldBe 5
+      _ = innerTriggers2.size shouldBe 1
+      _ = innerTriggers3.size shouldBe 0
 
-            innerHandler2.unsafeOnNext(VModifier("me?"))
-            element.innerHTML shouldBe """<div></div>"""
-            outerTriggers.size shouldBe 3
-            innerTriggers.size shouldBe 5
-            innerTriggers2.size shouldBe 1
-            innerTriggers3.size shouldBe 0
+      _ <- innerHandler2.onNextIO(VModifier("me?")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div></div>"""
+      _ = outerTriggers.size shouldBe 3
+      _ = innerTriggers.size shouldBe 5
+      _ = innerTriggers2.size shouldBe 1
+      _ = innerTriggers3.size shouldBe 0
 
-            innerHandler3.unsafeOnNext(VModifier("me?"))
-            element.innerHTML shouldBe """<div></div>"""
-            outerTriggers.size shouldBe 3
-            innerTriggers.size shouldBe 5
-            innerTriggers2.size shouldBe 1
-            innerTriggers3.size shouldBe 0
+      _ <- innerHandler3.onNextIO(VModifier("me?")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div></div>"""
+      _ = outerTriggers.size shouldBe 3
+      _ = innerTriggers.size shouldBe 5
+      _ = innerTriggers2.size shouldBe 1
+      _ = innerTriggers3.size shouldBe 0
 
-            myHandler.unsafeOnNext(VModifier("go away"))
-            element.innerHTML shouldBe """<div>go away</div>"""
-            outerTriggers.size shouldBe 4
-            innerTriggers.size shouldBe 5
-            innerTriggers2.size shouldBe 1
-            innerTriggers3.size shouldBe 0
+      _ <- myHandler.onNextIO(VModifier("go away")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>go away</div>"""
+      _ = outerTriggers.size shouldBe 4
+      _ = innerTriggers.size shouldBe 5
+      _ = innerTriggers2.size shouldBe 1
+      _ = innerTriggers3.size shouldBe 0
 
-            innerHandler.unsafeOnNext(VModifier("me?"))
-            element.innerHTML shouldBe """<div>go away</div>"""
-            outerTriggers.size shouldBe 4
-            innerTriggers.size shouldBe 5
-            innerTriggers2.size shouldBe 1
-            innerTriggers3.size shouldBe 0
+      _ <- innerHandler.onNextIO(VModifier("me?")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>go away</div>"""
+      _ = outerTriggers.size shouldBe 4
+      _ = innerTriggers.size shouldBe 5
+      _ = innerTriggers2.size shouldBe 1
+      _ = innerTriggers3.size shouldBe 0
 
-      }}}}}
+    } yield succeed
   }
 
   it should "be able to render basic handler" in {
@@ -1677,17 +1585,18 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
 
     val vtree = div(counter)
 
-    Outwatch.renderInto[IO]("#app", vtree).map { _ =>
-      val element = document.getElementById("click")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", vtree)
+      element = document.getElementById("click")
 
-      element.innerHTML shouldBe "0"
+      _ = element.innerHTML shouldBe "0"
 
-      sendEvent(element, "click")
-      element.innerHTML shouldBe "1"
+      _ <- IO(sendEvent(element, "click")) *> IO.cede
+      _ = element.innerHTML shouldBe "1"
 
-      sendEvent(element, "click")
-      element.innerHTML shouldBe "2"
-    }
+      _ <- IO(sendEvent(element, "click")) *> IO.cede
+      _ = element.innerHTML shouldBe "2"
+    } yield succeed
   }
 
   it should "be able to render basic handler with scan" in {
@@ -1700,17 +1609,18 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
 
     val vtree = div(counter)
 
-    Outwatch.renderInto[IO]("#app", vtree).map { _ =>
-      val element = document.getElementById("click")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", vtree)
+      element = document.getElementById("click")
 
-      element.innerHTML shouldBe "0"
+      _ = element.innerHTML shouldBe "0"
 
-      sendEvent(element, "click")
-      element.innerHTML shouldBe "1"
+      _ <- IO(sendEvent(element, "click")) *> IO.cede
+      _ = element.innerHTML shouldBe "1"
 
-      sendEvent(element, "click")
-      element.innerHTML shouldBe "2"
-    }
+      _ <- IO(sendEvent(element, "click")) *> IO.cede
+      _ = element.innerHTML shouldBe "2"
+    } yield succeed
   }
 
   it should "to render basic handler with scan directly from EmitterBuilder" in {
@@ -1721,17 +1631,18 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
 
     val vtree = div(counter)
 
-    Outwatch.renderInto[IO]("#app", vtree).map { _ =>
-      val element = document.getElementById("click")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", vtree)
+      element = document.getElementById("click")
 
-      element.innerHTML shouldBe "0"
+      _ = element.innerHTML shouldBe "0"
 
-      sendEvent(element, "click")
-      element.innerHTML shouldBe "1"
+      _ <- IO(sendEvent(element, "click")) *> IO.cede
+      _ = element.innerHTML shouldBe "1"
 
-      sendEvent(element, "click")
-      element.innerHTML shouldBe "2"
-    }
+      _ <- IO(sendEvent(element, "click")) *> IO.cede
+      _ = element.innerHTML shouldBe "2"
+    } yield succeed
   }
 
   it should "work for not overpatching keep proxy from previous patch" in {
@@ -1759,345 +1670,339 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       div("klara", onSnabbdomPostPatch.doAction { patchedKlara += 1 }, onSnabbdomInsert.doAction { insertedKlara += 1 }, onSnabbdomDestroy.doAction{  uninsertedKlara += 1 }),
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      val element = document.getElementById("strings")
+      element = document.getElementById("strings")
 
-      element.innerHTML shouldBe """<div>heinz</div><div>klara</div>"""
-      inserted shouldBe 0
-      destroyed shouldBe 0
-      patched shouldBe 0
-      inserted2 shouldBe 0
-      uninserted2 shouldBe 0
-      patched2 shouldBe 0
-      insertedHeinz shouldBe 1
-      uninsertedHeinz shouldBe 0
-      patchedHeinz shouldBe 0
-      insertedKlara shouldBe 1
-      uninsertedKlara shouldBe 0
-      patchedKlara shouldBe 0
+      _ = element.innerHTML shouldBe """<div>heinz</div><div>klara</div>"""
+      _ = inserted shouldBe 0
+      _ = destroyed shouldBe 0
+      _ = patched shouldBe 0
+      _ = inserted2 shouldBe 0
+      _ = uninserted2 shouldBe 0
+      _ = patched2 shouldBe 0
+      _ = insertedHeinz shouldBe 1
+      _ = uninsertedHeinz shouldBe 0
+      _ = patchedHeinz shouldBe 0
+      _ = insertedKlara shouldBe 1
+      _ = uninsertedKlara shouldBe 0
+      _ = patchedKlara shouldBe 0
 
-      handler.unsafeOnNext(1)
-      element.innerHTML shouldBe """<div>1</div><div>heinz</div><div>klara</div>"""
-      inserted shouldBe 1
-      destroyed shouldBe 0
-      patched shouldBe 0
-      inserted2 shouldBe 0
-      uninserted2 shouldBe 0
-      patched2 shouldBe 0
-      insertedHeinz shouldBe 1
-      uninsertedHeinz shouldBe 0
-      patchedHeinz shouldBe 0
-      insertedKlara shouldBe 1
-      uninsertedKlara shouldBe 0
-      patchedKlara shouldBe 0
+      _ <- handler.onNextIO(1) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>1</div><div>heinz</div><div>klara</div>"""
+      _ = inserted shouldBe 1
+      _ = destroyed shouldBe 0
+      _ = patched shouldBe 0
+      _ = inserted2 shouldBe 0
+      _ = uninserted2 shouldBe 0
+      _ = patched2 shouldBe 0
+      _ = insertedHeinz shouldBe 1
+      _ = uninsertedHeinz shouldBe 0
+      _ = patchedHeinz shouldBe 0
+      _ = insertedKlara shouldBe 1
+      _ = uninsertedKlara shouldBe 0
+      _ = patchedKlara shouldBe 0
 
-      handler2.unsafeOnNext(99)
-      element.innerHTML shouldBe """<div>1</div><div>heinz</div><div>99</div><div>klara</div>"""
-      inserted shouldBe 1
-      destroyed shouldBe 0
-      patched shouldBe 0
-      inserted2 shouldBe 1
-      uninserted2 shouldBe 0
-      patched2 shouldBe 0
-      insertedHeinz shouldBe 1
-      uninsertedHeinz shouldBe 0
-      patchedHeinz shouldBe 0
-      insertedKlara shouldBe 1
-      uninsertedKlara shouldBe 0
-      patchedKlara shouldBe 0
+      _ <- handler2.onNextIO(99) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>1</div><div>heinz</div><div>99</div><div>klara</div>"""
+      _ = inserted shouldBe 1
+      _ = destroyed shouldBe 0
+      _ = patched shouldBe 0
+      _ = inserted2 shouldBe 1
+      _ = uninserted2 shouldBe 0
+      _ = patched2 shouldBe 0
+      _ = insertedHeinz shouldBe 1
+      _ = uninsertedHeinz shouldBe 0
+      _ = patchedHeinz shouldBe 0
+      _ = insertedKlara shouldBe 1
+      _ = uninsertedKlara shouldBe 0
+      _ = patchedKlara shouldBe 0
 
-      handler2.unsafeOnNext(0)
-      element.innerHTML shouldBe """<div>1</div><div>heinz</div><div>klara</div>"""
-      inserted shouldBe 1
-      destroyed shouldBe 0
-      patched shouldBe 0
-      inserted2 shouldBe 1
-      uninserted2 shouldBe 1
-      patched2 shouldBe 0
-      insertedHeinz shouldBe 1
-      uninsertedHeinz shouldBe 0
-      patchedHeinz shouldBe 0
-      insertedKlara shouldBe 1
-      uninsertedKlara shouldBe 0
-      patchedKlara shouldBe 0
+      _ <- handler2.onNextIO(0) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>1</div><div>heinz</div><div>klara</div>"""
+      _ = inserted shouldBe 1
+      _ = destroyed shouldBe 0
+      _ = patched shouldBe 0
+      _ = inserted2 shouldBe 1
+      _ = uninserted2 shouldBe 1
+      _ = patched2 shouldBe 0
+      _ = insertedHeinz shouldBe 1
+      _ = uninsertedHeinz shouldBe 0
+      _ = patchedHeinz shouldBe 0
+      _ = insertedKlara shouldBe 1
+      _ = uninsertedKlara shouldBe 0
+      _ = patchedKlara shouldBe 0
 
-      handler.unsafeOnNext(0)
-      element.innerHTML shouldBe """<div>heinz</div><div>klara</div>"""
-      inserted shouldBe 1
-      destroyed shouldBe 1
-      patched shouldBe 0
-      inserted2 shouldBe 1
-      uninserted2 shouldBe 1
-      patched2 shouldBe 0
-      insertedHeinz shouldBe 1
-      uninsertedHeinz shouldBe 0
-      patchedHeinz shouldBe 0
-      insertedKlara shouldBe 1
-      uninsertedKlara shouldBe 0
-      patchedKlara shouldBe 0
+      _ <- handler.onNextIO(0) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>heinz</div><div>klara</div>"""
+      _ = inserted shouldBe 1
+      _ = destroyed shouldBe 1
+      _ = patched shouldBe 0
+      _ = inserted2 shouldBe 1
+      _ = uninserted2 shouldBe 1
+      _ = patched2 shouldBe 0
+      _ = insertedHeinz shouldBe 1
+      _ = uninsertedHeinz shouldBe 0
+      _ = patchedHeinz shouldBe 0
+      _ = insertedKlara shouldBe 1
+      _ = uninsertedKlara shouldBe 0
+      _ = patchedKlara shouldBe 0
 
-      handler2.unsafeOnNext(3)
-      element.innerHTML shouldBe """<div>heinz</div><div>3</div><div>klara</div>"""
-      inserted shouldBe 1
-      destroyed shouldBe 1
-      patched shouldBe 0
-      inserted2 shouldBe 2
-      uninserted2 shouldBe 1
-      patched2 shouldBe 0
-      insertedHeinz shouldBe 1
-      uninsertedHeinz shouldBe 0
-      patchedHeinz shouldBe 0
-      insertedKlara shouldBe 1
-      uninsertedKlara shouldBe 0
-      patchedKlara shouldBe 0
+      _ <- handler2.onNextIO(3) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>heinz</div><div>3</div><div>klara</div>"""
+      _ = inserted shouldBe 1
+      _ = destroyed shouldBe 1
+      _ = patched shouldBe 0
+      _ = inserted2 shouldBe 2
+      _ = uninserted2 shouldBe 1
+      _ = patched2 shouldBe 0
+      _ = insertedHeinz shouldBe 1
+      _ = uninsertedHeinz shouldBe 0
+      _ = patchedHeinz shouldBe 0
+      _ = insertedKlara shouldBe 1
+      _ = uninsertedKlara shouldBe 0
+      _ = patchedKlara shouldBe 0
 
-      handler.unsafeOnNext(2)
-      element.innerHTML shouldBe """<div>2</div><div>heinz</div><div>3</div><div>klara</div>"""
-      inserted shouldBe 2
-      destroyed shouldBe 1
-      patched shouldBe 0
-      inserted2 shouldBe 2
-      uninserted2 shouldBe 1
-      patched2 shouldBe 0
-      insertedHeinz shouldBe 1
-      uninsertedHeinz shouldBe 0
-      patchedHeinz shouldBe 0
-      insertedKlara shouldBe 1
-      uninsertedKlara shouldBe 0
-      patchedKlara shouldBe 0
+      _ <- handler.onNextIO(2) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>2</div><div>heinz</div><div>3</div><div>klara</div>"""
+      _ = inserted shouldBe 2
+      _ = destroyed shouldBe 1
+      _ = patched shouldBe 0
+      _ = inserted2 shouldBe 2
+      _ = uninserted2 shouldBe 1
+      _ = patched2 shouldBe 0
+      _ = insertedHeinz shouldBe 1
+      _ = uninsertedHeinz shouldBe 0
+      _ = patchedHeinz shouldBe 0
+      _ = insertedKlara shouldBe 1
+      _ = uninsertedKlara shouldBe 0
+      _ = patchedKlara shouldBe 0
 
-      handler.unsafeOnNext(18)
-      element.innerHTML shouldBe """<div>18</div><div>heinz</div><div>3</div><div>klara</div>"""
-      inserted shouldBe 2
-      destroyed shouldBe 1
-      patched shouldBe 1
-      inserted2 shouldBe 2
-      uninserted2 shouldBe 1
-      patched2 shouldBe 0
-      insertedHeinz shouldBe 1
-      uninsertedHeinz shouldBe 0
-      patchedHeinz shouldBe 0
-      insertedKlara shouldBe 1
-      uninsertedKlara shouldBe 0
-      patchedKlara shouldBe 0
+      _ <- handler.onNextIO(18) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>18</div><div>heinz</div><div>3</div><div>klara</div>"""
+      _ = inserted shouldBe 2
+      _ = destroyed shouldBe 1
+      _ = patched shouldBe 1
+      _ = inserted2 shouldBe 2
+      _ = uninserted2 shouldBe 1
+      _ = patched2 shouldBe 0
+      _ = insertedHeinz shouldBe 1
+      _ = uninsertedHeinz shouldBe 0
+      _ = patchedHeinz shouldBe 0
+      _ = insertedKlara shouldBe 1
+      _ = uninsertedKlara shouldBe 0
+      _ = patchedKlara shouldBe 0
 
-      handler2.unsafeOnNext(19)
-      element.innerHTML shouldBe """<div>18</div><div>heinz</div><div>19</div><div>klara</div>"""
-      inserted shouldBe 2
-      destroyed shouldBe 1
-      patched shouldBe 1
-      inserted2 shouldBe 2
-      uninserted2 shouldBe 1
-      patched2 shouldBe 1
-      insertedHeinz shouldBe 1
-      uninsertedHeinz shouldBe 0
-      patchedHeinz shouldBe 0
-      insertedKlara shouldBe 1
-      uninsertedKlara shouldBe 0
-      patchedKlara shouldBe 0
-    }
+      _ <- handler2.onNextIO(19) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>18</div><div>heinz</div><div>19</div><div>klara</div>"""
+      _ = inserted shouldBe 2
+      _ = destroyed shouldBe 1
+      _ = patched shouldBe 1
+      _ = inserted2 shouldBe 2
+      _ = uninserted2 shouldBe 1
+      _ = patched2 shouldBe 1
+      _ = insertedHeinz shouldBe 1
+      _ = uninsertedHeinz shouldBe 0
+      _ = patchedHeinz shouldBe 0
+      _ = insertedKlara shouldBe 1
+      _ = uninsertedKlara shouldBe 0
+      _ = patchedKlara shouldBe 0
+    } yield succeed
   }
 
   it should "work for nested observables with seq modifiers " in {
 
-    IO(Subject.behavior("b")).flatMap { innerHandler =>
-    IO(Subject.behavior(Seq[VModifier]("a", data.test := "v", innerHandler))).flatMap { outerHandler =>
+    val innerHandler = Subject.behavior("b")
+    val outerHandler = Subject.behavior(Seq[VModifier]("a", data.test := "v", innerHandler))
 
-      val node = div(
-        idAttr := "strings",
-        outerHandler
-      )
+    val node = div(
+      idAttr := "strings",
+      outerHandler
+    )
 
-      Outwatch.renderInto[IO]("#app", node).map { _ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-        val element = document.getElementById("strings")
-        element.outerHTML shouldBe """<div id="strings" data-test="v">ab</div>"""
+      element = document.getElementById("strings")
+      _ = element.outerHTML shouldBe """<div id="strings" data-test="v">ab</div>"""
 
-        innerHandler.unsafeOnNext("c")
-        element.outerHTML shouldBe """<div id="strings" data-test="v">ac</div>"""
+      _ <- innerHandler.onNextIO("c") *> IO.cede
+      _ = element.outerHTML shouldBe """<div id="strings" data-test="v">ac</div>"""
 
-        outerHandler.unsafeOnNext(Seq[VModifier]("meh"))
-        element.outerHTML shouldBe """<div id="strings">meh</div>"""
-      }
-
-    }}
+      _ <- outerHandler.onNextIO(Seq[VModifier]("meh")) *> IO.cede
+      _ = element.outerHTML shouldBe """<div id="strings">meh</div>"""
+    } yield succeed
   }
 
   it should "work for nested observables with seq modifiers and attribute stream" in {
+    val innerHandler = Subject.replayLatest[String]()
+    val outerHandler = Subject.behavior(Seq[VModifier]("a", data.test := "v", href <-- innerHandler))
 
-    IO(Subject.replayLatest[String]()).flatMap { innerHandler =>
-    IO(Subject.behavior(Seq[VModifier]("a", data.test := "v", href <-- innerHandler))).flatMap { outerHandler =>
+    val node = div(
+      idAttr := "strings",
+      outerHandler
+    )
 
-      val node = div(
-        idAttr := "strings",
-        outerHandler
-      )
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      Outwatch.renderInto[IO]("#app", node).map { _ =>
+      element = document.getElementById("strings")
+      _ = element.outerHTML shouldBe """<div id="strings" data-test="v">a</div>"""
 
-        val element = document.getElementById("strings")
-        element.outerHTML shouldBe """<div id="strings" data-test="v">a</div>"""
+      _ <- innerHandler.onNextIO("c") *> IO.cede
+      _ = element.outerHTML shouldBe """<div id="strings" data-test="v" href="c">a</div>"""
 
-        innerHandler.unsafeOnNext("c")
-        element.outerHTML shouldBe """<div id="strings" data-test="v" href="c">a</div>"""
+      _ <- innerHandler.onNextIO("d") *> IO.cede
+      _ = element.outerHTML shouldBe """<div id="strings" data-test="v" href="d">a</div>"""
 
-        innerHandler.unsafeOnNext("d")
-        element.outerHTML shouldBe """<div id="strings" data-test="v" href="d">a</div>"""
-
-        outerHandler.unsafeOnNext(Seq[VModifier]("meh"))
-        element.outerHTML shouldBe """<div id="strings">meh</div>"""
-      }
-
-    }}
+      _ <- outerHandler.onNextIO(Seq[VModifier]("meh")) *> IO.cede
+      _ = element.outerHTML shouldBe """<div id="strings">meh</div>"""
+    } yield succeed
   }
 
   it should "work for double nested stream modifier" in {
 
-    IO(Subject.replayLatest[VModifier]()).flatMap { myHandler =>
+    val myHandler = Subject.replayLatest[VModifier]()
 
-      val node = div(idAttr := "strings",
-        div(myHandler)
-      )
+    val node = div(idAttr := "strings",
+      div(myHandler)
+    )
 
-      Outwatch.renderInto[IO]("#app", node).map { _ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-        val element = document.getElementById("strings")
-        element.innerHTML shouldBe "<div></div>"
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe "<div></div>"
 
-        myHandler.unsafeOnNext(nonEmptyObservable[VModifier](nonEmptyObservable[VModifier](cls := "hans")))
-        element.innerHTML shouldBe """<div class="hans"></div>"""
-      }
-
-    }
+      _ <- myHandler.onNextIO(nonEmptyObservable[VModifier](nonEmptyObservable[VModifier](cls := "hans"))) *> IO.cede
+      _ = element.innerHTML shouldBe """<div class="hans"></div>"""
+    } yield succeed
   }
 
   it should "work for triple nested stream modifier" in {
 
-    IO(Subject.replayLatest[VModifier]()).flatMap { myHandler =>
+    val myHandler = Subject.replayLatest[VModifier]()
 
-      val node = div(idAttr := "strings",
-        div(myHandler)
-      )
+    val node = div(idAttr := "strings",
+      div(myHandler)
+    )
 
-      Outwatch.renderInto[IO]("#app", node).map { _ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-        val element = document.getElementById("strings")
-        element.innerHTML shouldBe "<div></div>"
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe "<div></div>"
 
-        myHandler.unsafeOnNext(nonEmptyObservable[VModifier](nonEmptyObservable[VModifier](nonEmptyObservable(cls := "hans"))))
-        element.innerHTML shouldBe """<div class="hans"></div>"""
-      }
-
-    }
+      _ <- myHandler.onNextIO(nonEmptyObservable[VModifier](nonEmptyObservable[VModifier](nonEmptyObservable(cls := "hans")))) *> IO.cede
+      _ = element.innerHTML shouldBe """<div class="hans"></div>"""
+    } yield succeed
   }
 
   it should "work for multiple nested stream modifier" in {
 
-    IO(Subject.replayLatest[VModifier]()).flatMap { myHandler =>
+    val myHandler = Subject.replayLatest[VModifier]()
 
-      val node = div(idAttr := "strings",
-        div(myHandler)
-      )
+    val node = div(idAttr := "strings",
+      div(myHandler)
+    )
 
-      Outwatch.renderInto[IO]("#app", node).map { _ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-        val element = document.getElementById("strings")
-        element.innerHTML shouldBe "<div></div>"
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe "<div></div>"
 
-        myHandler.unsafeOnNext(nonEmptyObservable[VModifier](VModifier(nonEmptyObservable[VModifier]("a"), nonEmptyObservable(span("b")))))
-        element.innerHTML shouldBe """<div>a<span>b</span></div>"""
-      }
-
-    }
+      _ <- myHandler.onNextIO(nonEmptyObservable[VModifier](VModifier(nonEmptyObservable[VModifier]("a"), nonEmptyObservable(span("b"))))) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>a<span>b</span></div>"""
+    } yield succeed
   }
 
   it should "work for nested attribute stream receiver" in {
 
-    IO(Subject.replayLatest[VModifier]()).flatMap { myHandler =>
+    val myHandler = Subject.replayLatest[VModifier]()
 
-      val node = div(idAttr := "strings",
-        div(myHandler)
-      )
+    val node = div(idAttr := "strings",
+      div(myHandler)
+    )
 
-      Outwatch.renderInto[IO]("#app", node).map { _ =>
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-        val element = document.getElementById("strings")
-        element.innerHTML shouldBe "<div></div>"
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe "<div></div>"
 
-        myHandler.unsafeOnNext(cls <-- nonEmptyObservable("hans"))
-        element.innerHTML shouldBe """<div class="hans"></div>"""
-      }
-
-    }
+      _ <- myHandler.onNextIO(cls <-- nonEmptyObservable("hans")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div class="hans"></div>"""
+    } yield succeed
   }
 
   it should "work for nested emitter" in {
 
-    IO(Subject.replayLatest[VModifier]()).flatMap { myHandler =>
+    val myHandler = Subject.replayLatest[VModifier]()
 
-      val node = div(idAttr := "strings",
-        div(idAttr := "click", myHandler)
-      )
+    val node = div(idAttr := "strings",
+      div(idAttr := "click", myHandler)
+    )
 
-      Outwatch.renderInto[IO]("#app", node).map { _ =>
+    var clickCounter = 0
 
-        val element = document.getElementById("strings")
-        element.innerHTML shouldBe """<div id="click"></div>"""
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-        var clickCounter = 0
-        myHandler.unsafeOnNext(onClick doAction (clickCounter += 1))
-        element.innerHTML shouldBe """<div id="click"></div>"""
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe """<div id="click"></div>"""
 
-        clickCounter shouldBe 0
-        sendEvent(document.getElementById("click"), "click")
-        clickCounter shouldBe 1
+      _ <- myHandler.onNextIO(onClick doAction (clickCounter += 1)) *> IO.cede
+      _ = element.innerHTML shouldBe """<div id="click"></div>"""
 
-        sendEvent(document.getElementById("click"), "click")
-        clickCounter shouldBe 2
+      _ = clickCounter shouldBe 0
+      _ <- IO(sendEvent(document.getElementById("click"), "click")) *> IO.cede
+      _ = clickCounter shouldBe 1
 
-        myHandler.unsafeOnNext(VModifier.empty)
-        element.innerHTML shouldBe """<div id="click"></div>"""
+      _ <- IO(sendEvent(document.getElementById("click"), "click")) *> IO.cede
+      _ = clickCounter shouldBe 2
 
-        sendEvent(document.getElementById("click"), "click")
-        clickCounter shouldBe 2
-      }
+      _ <- myHandler.onNextIO(VModifier.empty) *> IO.cede
+      _ = element.innerHTML shouldBe """<div id="click"></div>"""
 
-    }
+      _ <- IO(sendEvent(document.getElementById("click"), "click")) *> IO.cede
+      _ = clickCounter shouldBe 2
+    } yield succeed
   }
 
   it should "work for streaming accum attributes" in {
 
-    IO(Subject.behavior("second")).flatMap { myClasses =>
-    IO(Subject.replayLatest[String]()).flatMap { myClasses2 =>
+    val myClasses = Subject.behavior("second")
+    val myClasses2 = Subject.replayLatest[String]()
 
-      val node = div(
-        idAttr := "strings",
-        div(
-          cls := "first",
-          myClasses.map { cls := _ },
-          Seq[VModifier](
-            cls <-- myClasses2
-          )
+    val node = div(
+      idAttr := "strings",
+      div(
+        cls := "first",
+        myClasses.map { cls := _ },
+        Seq[VModifier](
+          cls <-- myClasses2
         )
       )
+    )
 
-      Outwatch.renderInto[IO]("#app", node).map {_ =>
-        val element = document.getElementById("strings")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-        element.innerHTML shouldBe """<div class="first second"></div>"""
+      element = document.getElementById("strings")
 
-        myClasses2.unsafeOnNext("third")
-        element.innerHTML shouldBe """<div class="first second third"></div>"""
+      _ = element.innerHTML shouldBe """<div class="first second"></div>"""
 
-        myClasses2.unsafeOnNext("more")
-        element.innerHTML shouldBe """<div class="first second more"></div>"""
+      _ <- myClasses2.onNextIO("third") *> IO.cede
+      _ = element.innerHTML shouldBe """<div class="first second third"></div>"""
 
-        myClasses.unsafeOnNext("yeah")
-        element.innerHTML shouldBe """<div class="first yeah more"></div>"""
-      }
+      _ <- myClasses2.onNextIO("more") *> IO.cede
+      _ = element.innerHTML shouldBe """<div class="first second more"></div>"""
 
-    }}
+      _ <- myClasses.onNextIO("yeah") *> IO.cede
+      _ = element.innerHTML shouldBe """<div class="first yeah more"></div>"""
+    } yield succeed
   }
 
   "LocalStorage" should "provide a handler" in {
@@ -2174,33 +2079,32 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
                       onDomUpdate doAction  { updates += 1 }
                     )
           _ <- Outwatch.renderInto[IO]("#app", node)
-    } yield {
 
-      val element = document.getElementById("strings")
-      element.outerHTML shouldBe """<div id="strings" class="one">-1</div>"""
-      mounts shouldBe 1
-      unmounts shouldBe 0
-      updates shouldBe 0
+      element = document.getElementById("strings")
+      _ = element.outerHTML shouldBe """<div id="strings" class="one">-1</div>"""
+      _ = mounts shouldBe 1
+      _ = unmounts shouldBe 0
+      _ = updates shouldBe 0
 
-      myHandler.unsafeOnNext(1)
-      element.outerHTML shouldBe """<div id="strings" class="one">1</div>"""
-      mounts shouldBe 1
-      unmounts shouldBe 0
-      updates shouldBe 1
+      _ <- myHandler.onNextIO(1) *> IO.cede
+      _ = element.outerHTML shouldBe """<div id="strings" class="one">1</div>"""
+      _ = mounts shouldBe 1
+      _ = unmounts shouldBe 0
+      _ = updates shouldBe 1
 
-      sendEvent(document.getElementById("strings"), "click")
+      _ <- IO(sendEvent(document.getElementById("strings"), "click")) *> IO.cede
 
-      element.outerHTML shouldBe """<div id="strings" class="one">0</div>"""
-      mounts shouldBe 1
-      unmounts shouldBe 0
-      updates shouldBe 2
+      _ = element.outerHTML shouldBe """<div id="strings" class="one">0</div>"""
+      _ = mounts shouldBe 1
+      _ = unmounts shouldBe 0
+      _ = updates shouldBe 2
 
-      clsHandler.unsafeOnNext("two")
-      element.outerHTML shouldBe """<div id="strings" class="two">0</div>"""
-      mounts shouldBe 1
-      unmounts shouldBe 0
-      updates shouldBe 3
-    }
+      _ <- clsHandler.onNextIO("two") *> IO.cede
+      _ = element.outerHTML shouldBe """<div id="strings" class="two">0</div>"""
+      _ = mounts shouldBe 1
+      _ = unmounts shouldBe 0
+      _ = updates shouldBe 3
+    } yield succeed
   }
 
   it should "work for empty publish Subject" in {
@@ -2222,45 +2126,44 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
                       onDomUpdate doAction  { updates += 1 }
                     )
           _ <- Outwatch.renderInto[IO]("#app", node)
-    } yield {
 
-      val element = document.getElementById("strings")
-      element.outerHTML shouldBe """<div id="strings"></div>"""
-      mounts shouldBe 1
-      unmounts shouldBe 0
-      updates shouldBe 0
+      element = document.getElementById("strings")
+      _ = element.outerHTML shouldBe """<div id="strings"></div>"""
+      _ = mounts shouldBe 1
+      _ = unmounts shouldBe 0
+      _ = updates shouldBe 0
 
-      myHandler.unsafeOnNext(-1)
-      element.outerHTML shouldBe """<div id="strings">-1</div>"""
-      mounts shouldBe 1
-      unmounts shouldBe 0
-      updates shouldBe 1
+      _ <- myHandler.onNextIO(-1) *> IO.cede
+      _ = element.outerHTML shouldBe """<div id="strings">-1</div>"""
+      _ = mounts shouldBe 1
+      _ = unmounts shouldBe 0
+      _ = updates shouldBe 1
 
-      clsHandler.unsafeOnNext("one")
-      element.outerHTML shouldBe """<div id="strings" class="one">-1</div>"""
-      mounts shouldBe 1
-      unmounts shouldBe 0
-      updates shouldBe 2
+      _ <- clsHandler.onNextIO("one") *> IO.cede
+      _ = element.outerHTML shouldBe """<div id="strings" class="one">-1</div>"""
+      _ = mounts shouldBe 1
+      _ = unmounts shouldBe 0
+      _ = updates shouldBe 2
 
-      myHandler.unsafeOnNext(1)
-      element.outerHTML shouldBe """<div id="strings" class="one">1</div>"""
-      mounts shouldBe 1
-      unmounts shouldBe 0
-      updates shouldBe 3
+      _ <- myHandler.onNextIO(1) *> IO.cede
+      _ = element.outerHTML shouldBe """<div id="strings" class="one">1</div>"""
+      _ = mounts shouldBe 1
+      _ = unmounts shouldBe 0
+      _ = updates shouldBe 3
 
-      sendEvent(document.getElementById("strings"), "click")
+      _ <- IO(sendEvent(document.getElementById("strings"), "click")) *> IO.cede
 
-      element.outerHTML shouldBe """<div id="strings" class="one">0</div>"""
-      mounts shouldBe 1
-      unmounts shouldBe 0
-      updates shouldBe 4
+      _ = element.outerHTML shouldBe """<div id="strings" class="one">0</div>"""
+      _ = mounts shouldBe 1
+      _ = unmounts shouldBe 0
+      _ = updates shouldBe 4
 
-      clsHandler.unsafeOnNext("two")
-      element.outerHTML shouldBe """<div id="strings" class="two">0</div>"""
-      mounts shouldBe 1
-      unmounts shouldBe 0
-      updates shouldBe 5
-    }
+      _ <- clsHandler.onNextIO("two") *> IO.cede
+      _ = element.outerHTML shouldBe """<div id="strings" class="two">0</div>"""
+      _ = mounts shouldBe 1
+      _ = unmounts shouldBe 0
+      _ = updates shouldBe 5
+    } yield succeed
   }
 
   "ChildCommand" should "work in handler" in {
@@ -2271,25 +2174,27 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       cmds
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      val element = document.getElementById("strings")
-      element.innerHTML shouldBe ""
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      cmds.unsafeOnNext(ChildCommand.ReplaceAll(b("Hello World") :: span("!") :: Nil))
-      element.innerHTML shouldBe """<b>Hello World</b><span>!</span>"""
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe ""
 
-      cmds.unsafeOnNext(ChildCommand.Insert(1, p("and friends", dsl.key := 42)))
-      element.innerHTML shouldBe """<b>Hello World</b><p>and friends</p><span>!</span>"""
+      _ <- cmds.onNextIO(ChildCommand.ReplaceAll(b("Hello World") :: span("!") :: Nil)) *> IO.cede
+      _ = element.innerHTML shouldBe """<b>Hello World</b><span>!</span>"""
 
-      cmds.unsafeOnNext(ChildCommand.Move(1, 2))
-      element.innerHTML shouldBe """<b>Hello World</b><span>!</span><p>and friends</p>"""
+      _ <- cmds.onNextIO(ChildCommand.Insert(1, p("and friends", dsl.key := 42))) *> IO.cede
+      _ = element.innerHTML shouldBe """<b>Hello World</b><p>and friends</p><span>!</span>"""
 
-      cmds.unsafeOnNext(ChildCommand.MoveId(ChildCommand.ChildId.Key(42), 1))
-      element.innerHTML shouldBe """<b>Hello World</b><p>and friends</p><span>!</span>"""
+      _ <- cmds.onNextIO(ChildCommand.Move(1, 2)) *> IO.cede
+      _ = element.innerHTML shouldBe """<b>Hello World</b><span>!</span><p>and friends</p>"""
 
-      cmds.unsafeOnNext(ChildCommand.RemoveId(ChildCommand.ChildId.Key(42)))
-      element.innerHTML shouldBe """<b>Hello World</b><span>!</span>"""
-    }
+      _ <- cmds.onNextIO(ChildCommand.MoveId(ChildCommand.ChildId.Key(42), 1)) *> IO.cede
+      _ = element.innerHTML shouldBe """<b>Hello World</b><p>and friends</p><span>!</span>"""
+
+      _ <- cmds.onNextIO(ChildCommand.RemoveId(ChildCommand.ChildId.Key(42))) *> IO.cede
+      _ = element.innerHTML shouldBe """<b>Hello World</b><span>!</span>"""
+    } yield succeed
   }
 
   it should "work in handler with element reference" in {
@@ -2318,23 +2223,25 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       )
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      val element = document.getElementById("strings")
-      element.innerHTML shouldBe """<p id="id-1">How much?</p><p id="id-2">Why so cheap?</p>"""
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      sendEvent(document.getElementById("id-1"), "click")
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe """<p id="id-1">How much?</p><p id="id-2">Why so cheap?</p>"""
 
-      element.innerHTML shouldBe """<p id="id-2">Why so cheap?</p>"""
+      _ <- IO(sendEvent(document.getElementById("id-1"), "click")) *> IO.cede
 
-      cmds.unsafeOnNext(ChildCommand.InsertBeforeId(ChildCommand.ChildId.Key("question-2"), div("spam")))
-      element.innerHTML shouldBe """<div>spam</div><p id="id-2">Why so cheap?</p>"""
+      _ = element.innerHTML shouldBe """<p id="id-2">Why so cheap?</p>"""
 
-      cmds.unsafeOnNext(ChildCommand.MoveId(ChildCommand.ChildId.Key("question-2"), 0))
-      element.innerHTML shouldBe """<p id="id-2">Why so cheap?</p><div>spam</div>"""
+      _ <- cmds.onNextIO(ChildCommand.InsertBeforeId(ChildCommand.ChildId.Key("question-2"), div("spam"))) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>spam</div><p id="id-2">Why so cheap?</p>"""
 
-      sendEvent(document.getElementById("id-2"), "click")
-      element.innerHTML shouldBe """<div>spam</div>"""
-    }
+      _ <- cmds.onNextIO(ChildCommand.MoveId(ChildCommand.ChildId.Key("question-2"), 0)) *> IO.cede
+      _ = element.innerHTML shouldBe """<p id="id-2">Why so cheap?</p><div>spam</div>"""
+
+      _ <- IO(sendEvent(document.getElementById("id-2"), "click")) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>spam</div>"""
+    } yield succeed
   }
 
   it should "work in value observable" in {
@@ -2345,19 +2252,21 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       cmds.prepend(ChildCommand.ReplaceAll(div("huch") :: Nil))
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      val element = document.getElementById("strings")
-      element.innerHTML shouldBe "<div>huch</div>"
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      cmds.unsafeOnNext(ChildCommand.Prepend(b("nope")))
-      element.innerHTML shouldBe """<b>nope</b><div>huch</div>"""
+      element = document.getElementById("strings")
+      _ = element.innerHTML shouldBe "<div>huch</div>"
 
-      cmds.unsafeOnNext(ChildCommand.Move(0, 1))
-      element.innerHTML shouldBe """<div>huch</div><b>nope</b>"""
+      _ <- cmds.onNextIO(ChildCommand.Prepend(b("nope"))) *> IO.cede
+      _ = element.innerHTML shouldBe """<b>nope</b><div>huch</div>"""
 
-      cmds.unsafeOnNext(ChildCommand.Replace(1, b("yes")))
-      element.innerHTML shouldBe """<div>huch</div><b>yes</b>"""
-    }
+      _ <- cmds.onNextIO(ChildCommand.Move(0, 1)) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>huch</div><b>nope</b>"""
+
+      _ <- cmds.onNextIO(ChildCommand.Replace(1, b("yes"))) *> IO.cede
+      _ = element.innerHTML shouldBe """<div>huch</div><b>yes</b>"""
+    } yield succeed
   }
 
   "Emitter subscription" should "be correctly subscribed" in {
@@ -2366,7 +2275,7 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
 
     var incCounter =  0
     var mapCounter = 0
-    val innerMod  = onClick.transformLift(_ => clicks.map { c => mapCounter += 1; c }) doAction { incCounter += 1 }
+    val innerMod  = onClick.transform(_ => clicks.map { c => mapCounter += 1; c }) doAction { incCounter += 1 }
     val modHandler = Subject.behavior(innerMod)
 
     val innerNode = div(modHandler)
@@ -2380,38 +2289,40 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     incCounter shouldBe 0
     mapCounter shouldBe 0
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      incCounter shouldBe 1
-      mapCounter shouldBe 1
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      clicks.unsafeOnNext(1)
-      incCounter shouldBe 2
-      mapCounter shouldBe 2
+      _ = incCounter shouldBe 1
+      _ = mapCounter shouldBe 1
 
-      modHandler.unsafeOnNext(VModifier.empty)
-      incCounter shouldBe 2
-      mapCounter shouldBe 2
+      _ <- clicks.onNextIO(1) *> IO.cede
+      _ = incCounter shouldBe 2
+      _ = mapCounter shouldBe 2
 
-      clicks.unsafeOnNext(2)
-      incCounter shouldBe 2
-      mapCounter shouldBe 2
+      _ <- modHandler.onNextIO(VModifier.empty) *> IO.cede
+      _ = incCounter shouldBe 2
+      _ = mapCounter shouldBe 2
 
-      modHandler.unsafeOnNext(innerMod)
-      incCounter shouldBe 3
-      mapCounter shouldBe 3
+      _ <- clicks.onNextIO(2) *> IO.cede
+      _ = incCounter shouldBe 2
+      _ = mapCounter shouldBe 2
 
-      clicks.unsafeOnNext(3)
-      incCounter shouldBe 4
-      mapCounter shouldBe 4
+      _ <- modHandler.onNextIO(innerMod) *> IO.cede
+      _ = incCounter shouldBe 3
+      _ = mapCounter shouldBe 3
 
-      nodeHandler.unsafeOnNext(span)
-      incCounter shouldBe 4
-      mapCounter shouldBe 4
+      _ <- clicks.onNextIO(3) *> IO.cede
+      _ = incCounter shouldBe 4
+      _ = mapCounter shouldBe 4
 
-      clicks.unsafeOnNext(4)
-      incCounter shouldBe 4
-      mapCounter shouldBe 4
-    }
+      _ <- nodeHandler.onNextIO(span) *> IO.cede
+      _ = incCounter shouldBe 4
+      _ = mapCounter shouldBe 4
+
+      _ <- clicks.onNextIO(4) *> IO.cede
+      _ = incCounter shouldBe 4
+      _ = mapCounter shouldBe 4
+    } yield succeed
   }
 
   it should "be correctly subscribed for emitterbuilder.asLatestEmitter" in {
@@ -2433,55 +2344,57 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       handler
     )
 
-    aEvent.unsafeOnNext("nope?")
-    bEvent.unsafeOnNext("nope?")
-    aCounter shouldBe 0
-    bCounter shouldBe 0
-    lastValue shouldBe null
+    for {
+      _ <- aEvent.onNextIO("nope?") *> IO.cede
+      _ <- bEvent.onNextIO("nope?") *> IO.cede
+      _ = aCounter shouldBe 0
+      _ = bCounter shouldBe 0
+      _ = lastValue shouldBe null
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      aCounter shouldBe 0
-      bCounter shouldBe 0
-      lastValue shouldBe null
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      aEvent.unsafeOnNext("a")
-      aCounter shouldBe 1
-      bCounter shouldBe 0
-      lastValue shouldBe null
+      _ = aCounter shouldBe 0
+      _ = bCounter shouldBe 0
+      _ = lastValue shouldBe null
 
-      bEvent.unsafeOnNext("b")
-      aCounter shouldBe 1
-      bCounter shouldBe 1
-      lastValue shouldBe null
+      _ <- aEvent.onNextIO("a") *> IO.cede
+      _ = aCounter shouldBe 1
+      _ = bCounter shouldBe 0
+      _ = lastValue shouldBe null
 
-      aEvent.unsafeOnNext("a2")
-      aCounter shouldBe 2
-      bCounter shouldBe 1
-      lastValue shouldBe "b"
+      _ <- bEvent.onNextIO("b") *> IO.cede
+      _ = aCounter shouldBe 1
+      _ = bCounter shouldBe 1
+      _ = lastValue shouldBe null
 
-      bEvent.unsafeOnNext("ahja")
-      aCounter shouldBe 2
-      bCounter shouldBe 2
-      lastValue shouldBe "b"
+      _ <- aEvent.onNextIO("a2") *> IO.cede
+      _ = aCounter shouldBe 2
+      _ = bCounter shouldBe 1
+      _ = lastValue shouldBe "b"
 
-      aEvent.unsafeOnNext("oh")
-      aCounter shouldBe 3
-      bCounter shouldBe 2
-      lastValue shouldBe "ahja"
+      _ <- bEvent.onNextIO("ahja") *> IO.cede
+      _ = aCounter shouldBe 2
+      _ = bCounter shouldBe 2
+      _ = lastValue shouldBe "b"
 
-      handler.unsafeOnNext(VModifier.empty)
+      _ <- aEvent.onNextIO("oh") *> IO.cede
+      _ = aCounter shouldBe 3
+      _ = bCounter shouldBe 2
+      _ = lastValue shouldBe "ahja"
 
-      aEvent.unsafeOnNext("hmm?")
-      aCounter shouldBe 3
-      bCounter shouldBe 2
-      lastValue shouldBe "ahja"
+      _ <- handler.onNextIO(VModifier.empty) *> IO.cede
 
-      bEvent.unsafeOnNext("no?")
-      aCounter shouldBe 3
-      bCounter shouldBe 2
-      lastValue shouldBe "ahja"
+      _ <- aEvent.onNextIO("hmm?") *> IO.cede
+      _ = aCounter shouldBe 3
+      _ = bCounter shouldBe 2
+      _ = lastValue shouldBe "ahja"
 
-    }
+      _ <- bEvent.onNextIO("no?") *> IO.cede
+      _ = aCounter shouldBe 3
+      _ = bCounter shouldBe 2
+      _ = lastValue shouldBe "ahja"
+
+    } yield succeed
   }
 
   "Thunk" should "work" in {
@@ -2503,48 +2416,50 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       b("something else")
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      val element = document.getElementById("strings")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      renderFnCounter shouldBe 0
-      mountCount shouldBe 0
-      preupdateCount shouldBe 0
-      updateCount shouldBe 0
-      unmountCount shouldBe 0
-      element.innerHTML shouldBe "<b>something else</b>"
+      element = document.getElementById("strings")
 
-      myString.unsafeOnNext("wal?")
-      renderFnCounter shouldBe 1
-      mountCount shouldBe 1
-      preupdateCount shouldBe 0
-      updateCount shouldBe 0
-      unmountCount shouldBe 0
-      element.innerHTML shouldBe """<b id="bla" class="b">wal?</b><b>something else</b>"""
+      _ = renderFnCounter shouldBe 0
+      _ = mountCount shouldBe 0
+      _ = preupdateCount shouldBe 0
+      _ = updateCount shouldBe 0
+      _ = unmountCount shouldBe 0
+      _ = element.innerHTML shouldBe "<b>something else</b>"
 
-      myString.unsafeOnNext("wal?")
-      renderFnCounter shouldBe 1
-      mountCount shouldBe 1
-      preupdateCount shouldBe 1
-      updateCount shouldBe 1
-      unmountCount shouldBe 0
-      element.innerHTML shouldBe """<b id="bla" class="b">wal?</b><b>something else</b>"""
+      _ <- myString.onNextIO("wal?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = mountCount shouldBe 1
+      _ = preupdateCount shouldBe 0
+      _ = updateCount shouldBe 0
+      _ = unmountCount shouldBe 0
+      _ = element.innerHTML shouldBe """<b id="bla" class="b">wal?</b><b>something else</b>"""
 
-      myString.unsafeOnNext("hai!")
-      renderFnCounter shouldBe 2
-      mountCount shouldBe 2
-      preupdateCount shouldBe 1
-      updateCount shouldBe 1
-      unmountCount shouldBe 1
-      element.innerHTML shouldBe """<b id="bla" class="b">hai!</b><b>something else</b>"""
+      _ <- myString.onNextIO("wal?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = mountCount shouldBe 1
+      _ = preupdateCount shouldBe 1
+      _ = updateCount shouldBe 1
+      _ = unmountCount shouldBe 0
+      _ = element.innerHTML shouldBe """<b id="bla" class="b">wal?</b><b>something else</b>"""
 
-      myString.unsafeOnNext("fuchs.")
-      renderFnCounter shouldBe 3
-      mountCount shouldBe 3
-      preupdateCount shouldBe 1
-      updateCount shouldBe 1
-      unmountCount shouldBe 2
-      element.innerHTML shouldBe """<b id="bla" class="b">fuchs.</b><b>something else</b>"""
-    }
+      _ <- myString.onNextIO("hai!") *> IO.cede
+      _ = renderFnCounter shouldBe 2
+      _ = mountCount shouldBe 2
+      _ = preupdateCount shouldBe 1
+      _ = updateCount shouldBe 1
+      _ = unmountCount shouldBe 1
+      _ = element.innerHTML shouldBe """<b id="bla" class="b">hai!</b><b>something else</b>"""
+
+      _ <- myString.onNextIO("fuchs.") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mountCount shouldBe 3
+      _ = preupdateCount shouldBe 1
+      _ = updateCount shouldBe 1
+      _ = unmountCount shouldBe 2
+      _ = element.innerHTML shouldBe """<b id="bla" class="b">fuchs.</b><b>something else</b>"""
+    } yield succeed
   }
 
   it should "work with equals" in {
@@ -2573,34 +2488,36 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       b("something else")
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      val element = document.getElementById("strings")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      renderFnCounter shouldBe 0
-      equalsCounter shouldBe 0
-      element.innerHTML shouldBe "<b>something else</b>"
+      element = document.getElementById("strings")
 
-      myString.unsafeOnNext("wal?")
-      renderFnCounter shouldBe 1
-      equalsCounter shouldBe 0
-      element.innerHTML shouldBe """<b id="bla" class="b">wal?</b><b>something else</b>"""
+      _ = renderFnCounter shouldBe 0
+      _ = equalsCounter shouldBe 0
+      _ = element.innerHTML shouldBe "<b>something else</b>"
 
-      myString.unsafeOnNext("wal?")
-      renderFnCounter shouldBe 1
-      equalsCounter shouldBe 1
-      element.innerHTML shouldBe """<b id="bla" class="b">wal?</b><b>something else</b>"""
+      _ <- myString.onNextIO("wal?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = equalsCounter shouldBe 0
+      _ = element.innerHTML shouldBe """<b id="bla" class="b">wal?</b><b>something else</b>"""
 
-      myString.unsafeOnNext("hai!")
-      renderFnCounter shouldBe 2
-      equalsCounter shouldBe 2
-      element.innerHTML shouldBe """<b id="bla" class="b">hai!</b><b>something else</b>"""
-    }
+      _ <- myString.onNextIO("wal?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = equalsCounter shouldBe 1
+      _ = element.innerHTML shouldBe """<b id="bla" class="b">wal?</b><b>something else</b>"""
+
+      _ <- myString.onNextIO("hai!") *> IO.cede
+      _ = renderFnCounter shouldBe 2
+      _ = equalsCounter shouldBe 2
+      _ = element.innerHTML shouldBe """<b id="bla" class="b">hai!</b><b>something else</b>"""
+    } yield succeed
   }
 
   it should "work with inner stream" in {
     val myString: Subject[String] = Subject.replayLatest[String]()
     val myThunk: Subject[Unit] = Subject.replayLatest[Unit]()
-    
+
 
     var renderFnCounter = 0
     val node = div(
@@ -2615,36 +2532,38 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       }
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      val element = document.getElementById("strings")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      renderFnCounter shouldBe 0
-      element.innerHTML shouldBe ""
+      element = document.getElementById("strings")
 
-      myThunk.unsafeOnNext(())
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<b></b>"
+      _ = renderFnCounter shouldBe 0
+      _ = element.innerHTML shouldBe ""
 
-      myThunk.unsafeOnNext(())
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<b></b>"
+      _ <- myThunk.onNextIO(()) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<b></b>"
 
-      myString.unsafeOnNext("ok?")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<b><p>ok?</p></b>"
+      _ <- myThunk.onNextIO(()) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<b></b>"
 
-      myThunk.unsafeOnNext(())
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<b><p>ok?</p></b>"
+      _ <- myString.onNextIO("ok?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<b><p>ok?</p></b>"
 
-      myString.unsafeOnNext("hope so")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<b><p>hope so</p></b>"
+      _ <- myThunk.onNextIO(()) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<b><p>ok?</p></b>"
 
-      myString.unsafeOnNext("ohai")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<b><p>ohai</p></b>"
-    }
+      _ <- myString.onNextIO("hope so") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<b><p>hope so</p></b>"
+
+      _ <- myString.onNextIO("ohai") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<b><p>ohai</p></b>"
+    } yield succeed
   }
 
   it should "work with inner and adjacent stream" in {
@@ -2670,96 +2589,98 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       myOther
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      val element = document.getElementById("strings")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      renderFnCounter shouldBe 0
-      element.innerHTML shouldBe ""
+      element = document.getElementById("strings")
 
-      myThunk.unsafeOnNext(0)
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<b>0</b>"
+      _ = renderFnCounter shouldBe 0
+      _ = element.innerHTML shouldBe ""
 
-      myThunk.unsafeOnNext(0)
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<b>0</b>"
+      _ <- myThunk.onNextIO(0) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<b>0</b>"
 
-      myString.unsafeOnNext("ok?")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<b>0<p>ok?</p></b>"
+      _ <- myThunk.onNextIO(0) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<b>0</b>"
 
-      myString.unsafeOnNext("got it?")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<b>0<p>got it?</p></b>"
+      _ <- myString.onNextIO("ok?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<b>0<p>ok?</p></b>"
 
-      myOther.unsafeOnNext("nope")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<b>0<p>got it?</p></b>nope"
+      _ <- myString.onNextIO("got it?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<b>0<p>got it?</p></b>"
 
-      myThunk.unsafeOnNext(1)
-      renderFnCounter shouldBe 2
-      element.innerHTML shouldBe "<b>1<p>got it?</p></b>nope"
+      _ <- myOther.onNextIO("nope") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<b>0<p>got it?</p></b>nope"
 
-      myThunk.unsafeOnNext(2)
-      renderFnCounter shouldBe 3
-      element.innerHTML shouldBe "<b>2<p>got it?</p></b>nope"
+      _ <- myThunk.onNextIO(1) *> IO.cede
+      _ = renderFnCounter shouldBe 2
+      _ = element.innerHTML shouldBe "<b>1<p>got it?</p></b>nope"
 
-      myOther.unsafeOnNext("yes")
-      renderFnCounter shouldBe 3
-      element.innerHTML shouldBe "<b>2<p>got it?</p></b>yes"
+      _ <- myThunk.onNextIO(2) *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = element.innerHTML shouldBe "<b>2<p>got it?</p></b>nope"
 
-      myString.unsafeOnNext("sad?")
-      renderFnCounter shouldBe 3
-      element.innerHTML shouldBe "<b>2<p>sad?</p></b>yes"
+      _ <- myOther.onNextIO("yes") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = element.innerHTML shouldBe "<b>2<p>got it?</p></b>yes"
 
-      myString.unsafeOnNext("hungry?")
-      renderFnCounter shouldBe 3
-      element.innerHTML shouldBe "<b>2<p>hungry?</p></b>yes"
+      _ <- myString.onNextIO("sad?") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = element.innerHTML shouldBe "<b>2<p>sad?</p></b>yes"
 
-      myString.unsafeOnNext("thursty?")
-      renderFnCounter shouldBe 3
-      element.innerHTML shouldBe "<b>2<p>thursty?</p></b>yes"
+      _ <- myString.onNextIO("hungry?") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = element.innerHTML shouldBe "<b>2<p>hungry?</p></b>yes"
 
-      myOther.unsafeOnNext("maybe")
-      renderFnCounter shouldBe 3
-      element.innerHTML shouldBe "<b>2<p>thursty?</p></b>maybe"
+      _ <- myString.onNextIO("thursty?") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = element.innerHTML shouldBe "<b>2<p>thursty?</p></b>yes"
 
-      myThunk.unsafeOnNext(3)
-      renderFnCounter shouldBe 4
-      element.innerHTML shouldBe "<b>3<p>thursty?</p></b>maybe"
+      _ <- myOther.onNextIO("maybe") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = element.innerHTML shouldBe "<b>2<p>thursty?</p></b>maybe"
 
-      myString.unsafeOnNext("")
-      renderFnCounter shouldBe 4
-      element.innerHTML shouldBe "<b>3<span>nope</span></b>maybe"
+      _ <- myThunk.onNextIO(3) *> IO.cede
+      _ = renderFnCounter shouldBe 4
+      _ = element.innerHTML shouldBe "<b>3<p>thursty?</p></b>maybe"
 
-      myOther.unsafeOnNext("come on")
-      renderFnCounter shouldBe 4
-      element.innerHTML shouldBe "<b>3<span>nope</span></b>come on"
+      _ <- myString.onNextIO("") *> IO.cede
+      _ = renderFnCounter shouldBe 4
+      _ = element.innerHTML shouldBe "<b>3<span>nope</span></b>maybe"
 
-      myThunk.unsafeOnNext(3)
-      renderFnCounter shouldBe 4
-      element.innerHTML shouldBe "<b>3<span>nope</span></b>come on"
+      _ <- myOther.onNextIO("come on") *> IO.cede
+      _ = renderFnCounter shouldBe 4
+      _ = element.innerHTML shouldBe "<b>3<span>nope</span></b>come on"
 
-      myOther.unsafeOnNext("hey?")
-      renderFnCounter shouldBe 4
-      element.innerHTML shouldBe "<b>3<span>nope</span></b>hey?"
+      _ <- myThunk.onNextIO(3) *> IO.cede
+      _ = renderFnCounter shouldBe 4
+      _ = element.innerHTML shouldBe "<b>3<span>nope</span></b>come on"
 
-      myString.unsafeOnNext("oh")
-      renderFnCounter shouldBe 4
-      element.innerHTML shouldBe "<b>3<p>oh</p></b>hey?"
+      _ <- myOther.onNextIO("hey?") *> IO.cede
+      _ = renderFnCounter shouldBe 4
+      _ = element.innerHTML shouldBe "<b>3<span>nope</span></b>hey?"
 
-      myOther.unsafeOnNext("ah")
-      renderFnCounter shouldBe 4
-      element.innerHTML shouldBe "<b>3<p>oh</p></b>ah"
+      _ <- myString.onNextIO("oh") *> IO.cede
+      _ = renderFnCounter shouldBe 4
+      _ = element.innerHTML shouldBe "<b>3<p>oh</p></b>hey?"
 
-      myThunk.unsafeOnNext(3)
-      renderFnCounter shouldBe 4
-      element.innerHTML shouldBe "<b>3<p>oh</p></b>ah"
+      _ <- myOther.onNextIO("ah") *> IO.cede
+      _ = renderFnCounter shouldBe 4
+      _ = element.innerHTML shouldBe "<b>3<p>oh</p></b>ah"
 
-      myThunk.unsafeOnNext(4)
-      renderFnCounter shouldBe 5
-      element.innerHTML shouldBe "<b>4<p>oh</p></b>ah"
-    }
+      _ <- myThunk.onNextIO(3) *> IO.cede
+      _ = renderFnCounter shouldBe 4
+      _ = element.innerHTML shouldBe "<b>3<p>oh</p></b>ah"
+
+      _ <- myThunk.onNextIO(4) *> IO.cede
+      _ = renderFnCounter shouldBe 5
+      _ = element.innerHTML shouldBe "<b>4<p>oh</p></b>ah"
+    } yield succeed
   }
 
   it should "work with nested inner stream" in {
@@ -2768,7 +2689,7 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     val myInnerOther: Subject[String] = Subject.replayLatest[String]()
     val myOther: Subject[String] = Subject.replayLatest[String]()
     val myThunk: Subject[Unit] = Subject.replayLatest[Unit]()
-    
+
 
     var renderFnCounter = 0
     val node = div(
@@ -2789,208 +2710,210 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       }
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      val element = document.getElementById("strings")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      renderFnCounter shouldBe 0
-      element.innerHTML shouldBe ""
+      element = document.getElementById("strings")
 
-      myThunk.unsafeOnNext(())
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b></b></div>"
+      _ = renderFnCounter shouldBe 0
+      _ = element.innerHTML shouldBe ""
 
-      myThunk.unsafeOnNext(())
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b></b></div>"
+      _ <- myThunk.onNextIO(()) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b></b></div>"
 
-      myString.unsafeOnNext("ok?")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>ok?</p></div></b></div>"
+      _ <- myThunk.onNextIO(()) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b></b></div>"
 
-      myString.unsafeOnNext("ok?")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>ok?</p></div></b></div>"
+      _ <- myString.onNextIO("ok?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>ok?</p></div></b></div>"
 
-      myThunk.unsafeOnNext(())
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>ok?</p></div></b></div>"
+      _ <- myString.onNextIO("ok?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>ok?</p></div></b></div>"
 
-      myString.unsafeOnNext("hope so")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>hope so</p></div></b></div>"
+      _ <- myThunk.onNextIO(()) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>ok?</p></div></b></div>"
 
-      myString.unsafeOnNext("ohai")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>ohai</p></div></b></div>"
+      _ <- myString.onNextIO("hope so") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>hope so</p></div></b></div>"
 
-      myString.unsafeOnNext("")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><div>empty</div></div></b></div>"
+      _ <- myString.onNextIO("ohai") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>ohai</p></div></b></div>"
 
-      myInner.unsafeOnNext("!")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><div>empty</div></div></b></div>"
+      _ <- myString.onNextIO("") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><div>empty</div></div></b></div>"
 
-      myString.unsafeOnNext("torst")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>torst!</p></div></b></div>"
+      _ <- myInner.onNextIO("!") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><div>empty</div></div></b></div>"
 
-      myThunk.unsafeOnNext(())
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>torst!</p></div></b></div>"
+      _ <- myString.onNextIO("torst") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>torst!</p></div></b></div>"
 
-      myInner.unsafeOnNext("?")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>torst?</p></div></b></div>"
+      _ <- myThunk.onNextIO(()) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>torst!</p></div></b></div>"
 
-      myString.unsafeOnNext("gandalf")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gandalf?</p></div></b></div>"
+      _ <- myInner.onNextIO("?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>torst?</p></div></b></div>"
 
-      myString.unsafeOnNext("gandalf")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gandalf?</p></div></b></div>"
+      _ <- myString.onNextIO("gandalf") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gandalf?</p></div></b></div>"
 
-      myOther.unsafeOnNext("du")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gandalf?</p></div></b>du</div>"
+      _ <- myString.onNextIO("gandalf") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gandalf?</p></div></b></div>"
 
-      myThunk.unsafeOnNext(())
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gandalf?</p></div></b>du</div>"
+      _ <- myOther.onNextIO("du") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gandalf?</p></div></b>du</div>"
 
-      myInner.unsafeOnNext("!")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gandalf!</p></div></b>du</div>"
+      _ <- myThunk.onNextIO(()) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gandalf?</p></div></b>du</div>"
 
-      myString.unsafeOnNext("fanta")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>fanta!</p></div></b>du</div>"
+      _ <- myInner.onNextIO("!") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gandalf!</p></div></b>du</div>"
 
-      myString.unsafeOnNext("fanta")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>fanta!</p></div></b>du</div>"
+      _ <- myString.onNextIO("fanta") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>fanta!</p></div></b>du</div>"
 
-      myThunk.unsafeOnNext(())
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>fanta!</p></div></b>du</div>"
+      _ <- myString.onNextIO("fanta") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>fanta!</p></div></b>du</div>"
 
-      myOther.unsafeOnNext("nee")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>fanta!</p></div></b>nee</div>"
+      _ <- myThunk.onNextIO(()) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>fanta!</p></div></b>du</div>"
 
-      myInnerOther.unsafeOnNext("muh")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>fanta!</p>muh</div></b>nee</div>"
+      _ <- myOther.onNextIO("nee") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>fanta!</p></div></b>nee</div>"
 
-      myString.unsafeOnNext("ghost")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>nee</div>"
+      _ <- myInnerOther.onNextIO("muh") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>fanta!</p>muh</div></b>nee</div>"
 
-      myString.unsafeOnNext("ghost")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>nee</div>"
+      _ <- myString.onNextIO("ghost") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>nee</div>"
 
-      myThunk.unsafeOnNext(())
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>nee</div>"
+      _ <- myString.onNextIO("ghost") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>nee</div>"
 
-      myOther.unsafeOnNext("life")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>life</div>"
+      _ <- myThunk.onNextIO(()) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>nee</div>"
 
-      myInnerOther.unsafeOnNext("muh")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>life</div>"
+      _ <- myOther.onNextIO("life") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>life</div>"
 
-      myString.unsafeOnNext("ghost")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>life</div>"
+      _ <- myInnerOther.onNextIO("muh") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>life</div>"
 
-      myOther.unsafeOnNext("seen")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>seen</div>"
+      _ <- myString.onNextIO("ghost") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>life</div>"
 
-      myInnerOther.unsafeOnNext("muh")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>seen</div>"
+      _ <- myOther.onNextIO("seen") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>seen</div>"
 
-      myString.unsafeOnNext("")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><div>empty</div>muh</div></b>seen</div>"
+      _ <- myInnerOther.onNextIO("muh") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>ghost!</p>muh</div></b>seen</div>"
 
-      myThunk.unsafeOnNext(())
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><div>empty</div>muh</div></b>seen</div>"
+      _ <- myString.onNextIO("") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><div>empty</div>muh</div></b>seen</div>"
 
-      myString.unsafeOnNext("gott")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gott!</p>muh</div></b>seen</div>"
+      _ <- myThunk.onNextIO(()) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><div>empty</div>muh</div></b>seen</div>"
 
-      myOther.unsafeOnNext("dorf")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gott!</p>muh</div></b>dorf</div>"
+      _ <- myString.onNextIO("gott") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gott!</p>muh</div></b>seen</div>"
 
-      myInnerOther.unsafeOnNext("ach")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gott!</p>ach</div></b>dorf</div>"
+      _ <- myOther.onNextIO("dorf") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gott!</p>muh</div></b>dorf</div>"
 
-      myThunk.unsafeOnNext(())
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gott!</p>ach</div></b>dorf</div>"
+      _ <- myInnerOther.onNextIO("ach") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gott!</p>ach</div></b>dorf</div>"
 
-      myString.unsafeOnNext("gott")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gott!</p>ach</div></b>dorf</div>"
+      _ <- myThunk.onNextIO(()) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gott!</p>ach</div></b>dorf</div>"
 
-      myInner.unsafeOnNext("hans")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gotthans</p>ach</div></b>dorf</div>"
+      _ <- myString.onNextIO("gott") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gott!</p>ach</div></b>dorf</div>"
 
-      myOther.unsafeOnNext("das")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gotthans</p>ach</div></b>das</div>"
+      _ <- myInner.onNextIO("hans") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gotthans</p>ach</div></b>dorf</div>"
 
-      myInnerOther.unsafeOnNext("tank")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gotthans</p>tank</div></b>das</div>"
+      _ <- myOther.onNextIO("das") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gotthans</p>ach</div></b>das</div>"
 
-      myThunk.unsafeOnNext(())
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gotthans</p>tank</div></b>das</div>"
+      _ <- myInnerOther.onNextIO("tank") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gotthans</p>tank</div></b>das</div>"
 
-      myInner.unsafeOnNext("so")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gottso</p>tank</div></b>das</div>"
+      _ <- myThunk.onNextIO(()) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gotthans</p>tank</div></b>das</div>"
 
-      myOther.unsafeOnNext("datt")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gottso</p>tank</div></b>datt</div>"
+      _ <- myInner.onNextIO("so") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gottso</p>tank</div></b>das</div>"
 
-      myInnerOther.unsafeOnNext("ohje")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gottso</p>ohje</div></b>datt</div>"
+      _ <- myOther.onNextIO("datt") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gottso</p>tank</div></b>datt</div>"
 
-      myThunk.unsafeOnNext(())
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>gottso</p>ohje</div></b>datt</div>"
+      _ <- myInnerOther.onNextIO("ohje") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gottso</p>ohje</div></b>datt</div>"
 
-      myString.unsafeOnNext("ende")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>endeso</p>ohje</div></b>datt</div>"
+      _ <- myThunk.onNextIO(()) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>gottso</p>ohje</div></b>datt</div>"
 
-      myString.unsafeOnNext("ende")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>endeso</p>ohje</div></b>datt</div>"
+      _ <- myString.onNextIO("ende") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>endeso</p>ohje</div></b>datt</div>"
 
-      myOther.unsafeOnNext("fin")
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>endeso</p>ohje</div></b>fin</div>"
+      _ <- myString.onNextIO("ende") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>endeso</p>ohje</div></b>datt</div>"
 
-      myThunk.unsafeOnNext(())
-      renderFnCounter shouldBe 1
-      element.innerHTML shouldBe "<div><b><div><p>endeso</p>ohje</div></b>fin</div>"
-    }
+      _ <- myOther.onNextIO("fin") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>endeso</p>ohje</div></b>fin</div>"
+
+      _ <- myThunk.onNextIO(()) *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = element.innerHTML shouldBe "<div><b><div><p>endeso</p>ohje</div></b>fin</div>"
+    } yield succeed
   }
 
   it should "work with streams (switchMap)" in {
@@ -3024,136 +2947,138 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       b("something else")
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      val element = document.getElementById("strings")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      renderFnCounter shouldBe 0
-      mounts shouldBe Nil
-      preupdates shouldBe Nil
-      updates shouldBe Nil
-      unmounts shouldBe Nil
-      element.innerHTML shouldBe "<b>something else</b>"
+      element = document.getElementById("strings")
 
-      myString.unsafeOnNext("wal?")
-      renderFnCounter shouldBe 1
-      mounts shouldBe List(0)
-      preupdates shouldBe Nil
-      updates shouldBe Nil
-      unmounts shouldBe Nil
-      element.innerHTML shouldBe """<b class="b">wal?</b><b>something else</b>"""
+      _ = renderFnCounter shouldBe 0
+      _ = mounts shouldBe Nil
+      _ = preupdates shouldBe Nil
+      _ = updates shouldBe Nil
+      _ = unmounts shouldBe Nil
+      _ = element.innerHTML shouldBe "<b>something else</b>"
 
-      myId.unsafeOnNext("tier")
-      renderFnCounter shouldBe 1
-      mounts shouldBe List(0)
-      preupdates shouldBe List(0)
-      updates shouldBe List(0)
-      unmounts shouldBe Nil
-      element.innerHTML shouldBe """<b class="b" id="tier">wal?</b><b>something else</b>"""
+      _ <- myString.onNextIO("wal?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = mounts shouldBe List(0)
+      _ = preupdates shouldBe Nil
+      _ = updates shouldBe Nil
+      _ = unmounts shouldBe Nil
+      _ = element.innerHTML shouldBe """<b class="b">wal?</b><b>something else</b>"""
 
-      myString.unsafeOnNext("wal?")
-      renderFnCounter shouldBe 1
-      mounts shouldBe List(0)
-      preupdates shouldBe List(0, 0)
-      updates shouldBe List(0, 0)
-      unmounts shouldBe List()
-      element.innerHTML shouldBe """<b class="b" id="tier">wal?</b><b>something else</b>"""
+      _ <- myId.onNextIO("tier") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = mounts shouldBe List(0)
+      _ = preupdates shouldBe List(0)
+      _ = updates shouldBe List(0)
+      _ = unmounts shouldBe Nil
+      _ = element.innerHTML shouldBe """<b class="b" id="tier">wal?</b><b>something else</b>"""
 
-      myString.unsafeOnNext("hai!")
-      renderFnCounter shouldBe 2
-      mounts shouldBe List(0, 1)
-      preupdates shouldBe List(0, 0)
-      updates shouldBe List(0, 0)
-      unmounts shouldBe List(0)
-      element.innerHTML shouldBe """<b class="b" id="tier">hai!</b><b>something else</b>"""
+      _ <- myString.onNextIO("wal?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = mounts shouldBe List(0)
+      _ = preupdates shouldBe List(0, 0)
+      _ = updates shouldBe List(0, 0)
+      _ = unmounts shouldBe List()
+      _ = element.innerHTML shouldBe """<b class="b" id="tier">wal?</b><b>something else</b>"""
 
-      myId.unsafeOnNext("nope")
-      renderFnCounter shouldBe 2
-      mounts shouldBe List(0, 1)
-      preupdates shouldBe List(0, 0, 1)
-      updates shouldBe List(0, 0, 1)
-      unmounts shouldBe List(0)
-      element.innerHTML shouldBe """<b class="b" id="nope">hai!</b><b>something else</b>"""
+      _ <- myString.onNextIO("hai!") *> IO.cede
+      _ = renderFnCounter shouldBe 2
+      _ = mounts shouldBe List(0, 1)
+      _ = preupdates shouldBe List(0, 0)
+      _ = updates shouldBe List(0, 0)
+      _ = unmounts shouldBe List(0)
+      _ = element.innerHTML shouldBe """<b class="b" id="tier">hai!</b><b>something else</b>"""
 
-      myString.unsafeOnNext("empty")
-      renderFnCounter shouldBe 2
-      mounts shouldBe List(0, 1, 2)
-      preupdates shouldBe List(0, 0, 1)
-      updates shouldBe List(0, 0, 1)
-      unmounts shouldBe List(0, 1)
-      element.innerHTML shouldBe """<b>empty</b><b>something else</b>"""
+      _ <- myId.onNextIO("nope") *> IO.cede
+      _ = renderFnCounter shouldBe 2
+      _ = mounts shouldBe List(0, 1)
+      _ = preupdates shouldBe List(0, 0, 1)
+      _ = updates shouldBe List(0, 0, 1)
+      _ = unmounts shouldBe List(0)
+      _ = element.innerHTML shouldBe """<b class="b" id="nope">hai!</b><b>something else</b>"""
 
-      myId.unsafeOnNext("nothing")
-      renderFnCounter shouldBe 2
-      mounts shouldBe List(0, 1, 2)
-      preupdates shouldBe List(0, 0, 1)
-      updates shouldBe List(0, 0, 1)
-      unmounts shouldBe List(0, 1)
-      element.innerHTML shouldBe """<b>empty</b><b>something else</b>"""
+      _ <- myString.onNextIO("empty") *> IO.cede
+      _ = renderFnCounter shouldBe 2
+      _ = mounts shouldBe List(0, 1, 2)
+      _ = preupdates shouldBe List(0, 0, 1)
+      _ = updates shouldBe List(0, 0, 1)
+      _ = unmounts shouldBe List(0, 1)
+      _ = element.innerHTML shouldBe """<b>empty</b><b>something else</b>"""
 
-      myString.unsafeOnNext("hans")
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3)
-      preupdates shouldBe List(0, 0, 1)
-      updates shouldBe List(0, 0, 1)
-      unmounts shouldBe List(0, 1, 2)
-      element.innerHTML shouldBe """<b id="nothing" class="b">hans</b><b>something else</b>"""
+      _ <- myId.onNextIO("nothing") *> IO.cede
+      _ = renderFnCounter shouldBe 2
+      _ = mounts shouldBe List(0, 1, 2)
+      _ = preupdates shouldBe List(0, 0, 1)
+      _ = updates shouldBe List(0, 0, 1)
+      _ = unmounts shouldBe List(0, 1)
+      _ = element.innerHTML shouldBe """<b>empty</b><b>something else</b>"""
 
-      myId.unsafeOnNext("hans")
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3)
-      preupdates shouldBe List(0, 0, 1, 3)
-      updates shouldBe List(0, 0, 1, 3)
-      unmounts shouldBe List(0, 1, 2)
-      element.innerHTML shouldBe """<b id="hans" class="b">hans</b><b>something else</b>"""
+      _ <- myString.onNextIO("hans") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 1)
+      _ = updates shouldBe List(0, 0, 1)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="nothing" class="b">hans</b><b>something else</b>"""
 
-      myString.unsafeOnNext("hans")
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3)
-      preupdates shouldBe List(0, 0, 1, 3, 3)
-      updates shouldBe List(0, 0, 1, 3, 3)
-      unmounts shouldBe List(0, 1, 2)
-      element.innerHTML shouldBe """<b id="hans" class="b">hans</b><b>something else</b>"""
+      _ <- myId.onNextIO("hans") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 1, 3)
+      _ = updates shouldBe List(0, 0, 1, 3)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="hans" class="b">hans</b><b>something else</b>"""
 
-      thunkContent.unsafeOnNext(p(dsl.key := "1", "el dieter"))
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3)
-      preupdates shouldBe List(0, 0, 1, 3, 3, 3)
-      updates shouldBe List(0, 0, 1, 3, 3, 3)
-      unmounts shouldBe List(0, 1, 2)
-      element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter</p></b><b>something else</b>"""
+      _ <- myString.onNextIO("hans") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 1, 3, 3)
+      _ = updates shouldBe List(0, 0, 1, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="hans" class="b">hans</b><b>something else</b>"""
 
-      thunkContent.unsafeOnNext(p(dsl.key := "2", "el dieter II"))
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3)
-      preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      unmounts shouldBe List(0, 1, 2)
-      element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter II</p></b><b>something else</b>"""
+      _ <- thunkContent.onNextIO(p(dsl.key := "1", "el dieter")) *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 1, 3, 3, 3)
+      _ = updates shouldBe List(0, 0, 1, 3, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter</p></b><b>something else</b>"""
 
-      myOther.unsafeOnNext(div("baem!"))
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3)
-      preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      unmounts shouldBe List(0, 1, 2)
-      element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter II</p></b><div>baem!</div><b>something else</b>"""
+      _ <- thunkContent.onNextIO(p(dsl.key := "2", "el dieter II")) *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter II</p></b><b>something else</b>"""
 
-      myInner.unsafeOnNext("meh")
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3, 4)
-      preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      unmounts shouldBe List(0, 1, 2, 3)
-      element.innerHTML shouldBe """<div>meh</div><div>baem!</div><b>something else</b>"""
+      _ <- myOther.onNextIO(div("baem!")) *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter II</p></b><div>baem!</div><b>something else</b>"""
 
-      myOther.unsafeOnNext(div("fini"))
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3, 4)
-      preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      unmounts shouldBe List(0, 1, 2, 3)
-      element.innerHTML shouldBe """<div>meh</div><div>fini</div><b>something else</b>"""
-    }
+      _ <- myInner.onNextIO("meh") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3, 4)
+      _ = preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2, 3)
+      _ = element.innerHTML shouldBe """<div>meh</div><div>baem!</div><b>something else</b>"""
+
+      _ <- myOther.onNextIO(div("fini")) *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3, 4)
+      _ = preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2, 3)
+      _ = element.innerHTML shouldBe """<div>meh</div><div>fini</div><b>something else</b>"""
+    } yield succeed
   }
 
   it should "work with streams (switchMap 2)" in {
@@ -3187,136 +3112,138 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       b("something else")
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      val element = document.getElementById("strings")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      renderFnCounter shouldBe 0
-      mounts shouldBe Nil
-      preupdates shouldBe Nil
-      updates shouldBe Nil
-      unmounts shouldBe Nil
-      element.innerHTML shouldBe "<b>something else</b>"
+      element = document.getElementById("strings")
 
-      myString.unsafeOnNext("wal?")
-      renderFnCounter shouldBe 1
-      mounts shouldBe List(0)
-      preupdates shouldBe Nil
-      updates shouldBe Nil
-      unmounts shouldBe Nil
-      element.innerHTML shouldBe """<b class="b">wal?</b><b>something else</b>"""
+      _ = renderFnCounter shouldBe 0
+      _ = mounts shouldBe Nil
+      _ = preupdates shouldBe Nil
+      _ = updates shouldBe Nil
+      _ = unmounts shouldBe Nil
+      _ = element.innerHTML shouldBe "<b>something else</b>"
 
-      myId.unsafeOnNext("tier")
-      renderFnCounter shouldBe 1
-      mounts shouldBe List(0)
-      preupdates shouldBe List(0)
-      updates shouldBe List(0)
-      unmounts shouldBe Nil
-      element.innerHTML shouldBe """<b class="b" id="tier">wal?</b><b>something else</b>"""
+      _ <- myString.onNextIO("wal?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = mounts shouldBe List(0)
+      _ = preupdates shouldBe Nil
+      _ = updates shouldBe Nil
+      _ = unmounts shouldBe Nil
+      _ = element.innerHTML shouldBe """<b class="b">wal?</b><b>something else</b>"""
 
-      myString.unsafeOnNext("wal?")
-      renderFnCounter shouldBe 1
-      mounts shouldBe List(0)
-      preupdates shouldBe List(0, 0)
-      updates shouldBe List(0, 0)
-      unmounts shouldBe List()
-      element.innerHTML shouldBe """<b class="b" id="tier">wal?</b><b>something else</b>"""
+      _ <- myId.onNextIO("tier") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = mounts shouldBe List(0)
+      _ = preupdates shouldBe List(0)
+      _ = updates shouldBe List(0)
+      _ = unmounts shouldBe Nil
+      _ = element.innerHTML shouldBe """<b class="b" id="tier">wal?</b><b>something else</b>"""
 
-      myString.unsafeOnNext("hai!")
-      renderFnCounter shouldBe 2
-      mounts shouldBe List(0, 1)
-      preupdates shouldBe List(0, 0)
-      updates shouldBe List(0, 0)
-      unmounts shouldBe List(0)
-      element.innerHTML shouldBe """<b class="b" id="tier">hai!</b><b>something else</b>"""
+      _ <- myString.onNextIO("wal?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = mounts shouldBe List(0)
+      _ = preupdates shouldBe List(0, 0)
+      _ = updates shouldBe List(0, 0)
+      _ = unmounts shouldBe List()
+      _ = element.innerHTML shouldBe """<b class="b" id="tier">wal?</b><b>something else</b>"""
 
-      myId.unsafeOnNext("nope")
-      renderFnCounter shouldBe 2
-      mounts shouldBe List(0, 1)
-      preupdates shouldBe List(0, 0, 1)
-      updates shouldBe List(0, 0, 1)
-      unmounts shouldBe List(0)
-      element.innerHTML shouldBe """<b class="b" id="nope">hai!</b><b>something else</b>"""
+      _ <- myString.onNextIO("hai!") *> IO.cede
+      _ = renderFnCounter shouldBe 2
+      _ = mounts shouldBe List(0, 1)
+      _ = preupdates shouldBe List(0, 0)
+      _ = updates shouldBe List(0, 0)
+      _ = unmounts shouldBe List(0)
+      _ = element.innerHTML shouldBe """<b class="b" id="tier">hai!</b><b>something else</b>"""
 
-      myString.unsafeOnNext("empty")
-      renderFnCounter shouldBe 2
-      mounts shouldBe List(0, 1, 2)
-      preupdates shouldBe List(0, 0, 1)
-      updates shouldBe List(0, 0, 1)
-      unmounts shouldBe List(0, 1)
-      element.innerHTML shouldBe """<b>empty</b><b>something else</b>"""
+      _ <- myId.onNextIO("nope") *> IO.cede
+      _ = renderFnCounter shouldBe 2
+      _ = mounts shouldBe List(0, 1)
+      _ = preupdates shouldBe List(0, 0, 1)
+      _ = updates shouldBe List(0, 0, 1)
+      _ = unmounts shouldBe List(0)
+      _ = element.innerHTML shouldBe """<b class="b" id="nope">hai!</b><b>something else</b>"""
 
-      myId.unsafeOnNext("nothing")
-      renderFnCounter shouldBe 2
-      mounts shouldBe List(0, 1, 2)
-      preupdates shouldBe List(0, 0, 1)
-      updates shouldBe List(0, 0, 1)
-      unmounts shouldBe List(0, 1)
-      element.innerHTML shouldBe """<b>empty</b><b>something else</b>"""
+      _ <- myString.onNextIO("empty") *> IO.cede
+      _ = renderFnCounter shouldBe 2
+      _ = mounts shouldBe List(0, 1, 2)
+      _ = preupdates shouldBe List(0, 0, 1)
+      _ = updates shouldBe List(0, 0, 1)
+      _ = unmounts shouldBe List(0, 1)
+      _ = element.innerHTML shouldBe """<b>empty</b><b>something else</b>"""
 
-      myString.unsafeOnNext("hans")
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3)
-      preupdates shouldBe List(0, 0, 1)
-      updates shouldBe List(0, 0, 1)
-      unmounts shouldBe List(0, 1, 2)
-      element.innerHTML shouldBe """<b id="nothing" class="b">hans</b><b>something else</b>"""
+      _ <- myId.onNextIO("nothing") *> IO.cede
+      _ = renderFnCounter shouldBe 2
+      _ = mounts shouldBe List(0, 1, 2)
+      _ = preupdates shouldBe List(0, 0, 1)
+      _ = updates shouldBe List(0, 0, 1)
+      _ = unmounts shouldBe List(0, 1)
+      _ = element.innerHTML shouldBe """<b>empty</b><b>something else</b>"""
 
-      myId.unsafeOnNext("hans")
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3)
-      preupdates shouldBe List(0, 0, 1, 3)
-      updates shouldBe List(0, 0, 1, 3)
-      unmounts shouldBe List(0, 1, 2)
-      element.innerHTML shouldBe """<b id="hans" class="b">hans</b><b>something else</b>"""
+      _ <- myString.onNextIO("hans") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 1)
+      _ = updates shouldBe List(0, 0, 1)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="nothing" class="b">hans</b><b>something else</b>"""
 
-      myString.unsafeOnNext("hans")
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3)
-      preupdates shouldBe List(0, 0, 1, 3, 3)
-      updates shouldBe List(0, 0, 1, 3, 3)
-      unmounts shouldBe List(0, 1, 2)
-      element.innerHTML shouldBe """<b id="hans" class="b">hans</b><b>something else</b>"""
+      _ <- myId.onNextIO("hans") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 1, 3)
+      _ = updates shouldBe List(0, 0, 1, 3)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="hans" class="b">hans</b><b>something else</b>"""
 
-      thunkContent.unsafeOnNext(p(dsl.key := "1", "el dieter"))
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3)
-      preupdates shouldBe List(0, 0, 1, 3, 3, 3)
-      updates shouldBe List(0, 0, 1, 3, 3, 3)
-      unmounts shouldBe List(0, 1, 2)
-      element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter</p></b><b>something else</b>"""
+      _ <- myString.onNextIO("hans") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 1, 3, 3)
+      _ = updates shouldBe List(0, 0, 1, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="hans" class="b">hans</b><b>something else</b>"""
 
-      thunkContent.unsafeOnNext(p(dsl.key := "2", "el dieter II"))
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3)
-      preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      unmounts shouldBe List(0, 1, 2)
-      element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter II</p></b><b>something else</b>"""
+      _ <- thunkContent.onNextIO(p(dsl.key := "1", "el dieter")) *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 1, 3, 3, 3)
+      _ = updates shouldBe List(0, 0, 1, 3, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter</p></b><b>something else</b>"""
 
-      myOther.unsafeOnNext(div("baem!"))
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3)
-      preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      unmounts shouldBe List(0, 1, 2)
-      element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter II</p></b><div>baem!</div><b>something else</b>"""
+      _ <- thunkContent.onNextIO(p(dsl.key := "2", "el dieter II")) *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter II</p></b><b>something else</b>"""
 
-      myInner.unsafeOnNext("meh")
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3, 4)
-      preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      unmounts shouldBe List(0, 1, 2, 3)
-      element.innerHTML shouldBe """<div>meh</div><div>baem!</div><b>something else</b>"""
+      _ <- myOther.onNextIO(div("baem!")) *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter II</p></b><div>baem!</div><b>something else</b>"""
 
-      myOther.unsafeOnNext(div("fini"))
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3, 4)
-      preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
-      unmounts shouldBe List(0, 1, 2, 3)
-      element.innerHTML shouldBe """<div>meh</div><div>fini</div><b>something else</b>"""
-    }
+      _ <- myInner.onNextIO("meh") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3, 4)
+      _ = preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2, 3)
+      _ = element.innerHTML shouldBe """<div>meh</div><div>baem!</div><b>something else</b>"""
+
+      _ <- myOther.onNextIO(div("fini")) *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3, 4)
+      _ = preupdates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = updates shouldBe List(0, 0, 1, 3, 3, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2, 3)
+      _ = element.innerHTML shouldBe """<div>meh</div><div>fini</div><b>something else</b>"""
+    } yield succeed
   }
 
   it should "work with streams" in {
@@ -3350,155 +3277,156 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       b("something else")
     )
 
-    Outwatch.renderInto[IO]("#app", node).map { _ =>
-      val element = document.getElementById("strings")
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-      renderFnCounter shouldBe 0
-      mounts shouldBe Nil
-      preupdates shouldBe Nil
-      updates shouldBe Nil
-      unmounts shouldBe Nil
-      element.innerHTML shouldBe "<b>something else</b>"
+      element = document.getElementById("strings")
 
-      myString.unsafeOnNext("wal?")
-      renderFnCounter shouldBe 1
-      mounts shouldBe List(0)
-      preupdates shouldBe Nil
-      updates shouldBe Nil
-      unmounts shouldBe Nil
-      element.innerHTML shouldBe """<b class="b">wal?</b><b>something else</b>"""
+      _ = renderFnCounter shouldBe 0
+      _ = mounts shouldBe Nil
+      _ = preupdates shouldBe Nil
+      _ = updates shouldBe Nil
+      _ = unmounts shouldBe Nil
+      _ = element.innerHTML shouldBe "<b>something else</b>"
 
-      myId.unsafeOnNext("tier")
-      renderFnCounter shouldBe 1
-      mounts shouldBe List(0)
-      preupdates shouldBe List(0)
-      updates shouldBe List(0)
-      unmounts shouldBe Nil
-      element.innerHTML shouldBe """<b class="b" id="tier">wal?</b><b>something else</b>"""
+      _ <- myString.onNextIO("wal?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = mounts shouldBe List(0)
+      _ = preupdates shouldBe Nil
+      _ = updates shouldBe Nil
+      _ = unmounts shouldBe Nil
+      _ = element.innerHTML shouldBe """<b class="b">wal?</b><b>something else</b>"""
 
-      myId.unsafeOnNext("tier")
-      renderFnCounter shouldBe 1
-      mounts shouldBe List(0)
-      preupdates shouldBe List(0, 0)
-      updates shouldBe List(0, 0)
-      unmounts shouldBe Nil
-      element.innerHTML shouldBe """<b class="b" id="tier">wal?</b><b>something else</b>"""
+      _ <- myId.onNextIO("tier") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = mounts shouldBe List(0)
+      _ = preupdates shouldBe List(0)
+      _ = updates shouldBe List(0)
+      _ = unmounts shouldBe Nil
+      _ = element.innerHTML shouldBe """<b class="b" id="tier">wal?</b><b>something else</b>"""
 
-      myString.unsafeOnNext("wal?")
-      renderFnCounter shouldBe 2
-      mounts shouldBe List(0, 1)
-      preupdates shouldBe List(0, 0)
-      updates shouldBe List(0, 0)
-      unmounts shouldBe List(0)
-      element.innerHTML shouldBe """<b id="tier" class="b">wal?</b><b>something else</b>"""
+      _ <- myId.onNextIO("tier") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = mounts shouldBe List(0)
+      _ = preupdates shouldBe List(0, 0)
+      _ = updates shouldBe List(0, 0)
+      _ = unmounts shouldBe Nil
+      _ = element.innerHTML shouldBe """<b class="b" id="tier">wal?</b><b>something else</b>"""
 
-      myId.unsafeOnNext("tier")
-      renderFnCounter shouldBe 2
-      mounts shouldBe List(0, 1)
-      preupdates shouldBe List(0, 0, 1)
-      updates shouldBe List(0, 0, 1)
-      unmounts shouldBe List(0)
-      element.innerHTML shouldBe """<b id="tier" class="b">wal?</b><b>something else</b>"""
+      _ <- myString.onNextIO("wal?") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = mounts shouldBe List(0)
+      _ = preupdates shouldBe List(0, 0, 0)
+      _ = updates shouldBe List(0, 0, 0)
+      _ = unmounts shouldBe Nil
+      _ = element.innerHTML shouldBe """<b class="b" id="tier">wal?</b><b>something else</b>"""
 
-      myString.unsafeOnNext("hai!")
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2)
-      preupdates shouldBe List(0, 0, 1)
-      updates shouldBe List(0, 0, 1)
-      unmounts shouldBe List(0, 1)
-      element.innerHTML shouldBe """<b id="tier" class="b">hai!</b><b>something else</b>"""
+      _ <- myId.onNextIO("tier") *> IO.cede
+      _ = renderFnCounter shouldBe 1
+      _ = mounts shouldBe List(0)
+      _ = preupdates shouldBe List(0, 0, 0, 0)
+      _ = updates shouldBe List(0, 0, 0, 0)
+      _ = unmounts shouldBe Nil
+      _ = element.innerHTML shouldBe """<b class="b" id="tier">wal?</b><b>something else</b>"""
 
-      myId.unsafeOnNext("nope")
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2)
-      preupdates shouldBe List(0, 0, 1, 2)
-      updates shouldBe List(0, 0, 1, 2)
-      unmounts shouldBe List(0, 1)
-      element.innerHTML shouldBe """<b id="nope" class="b">hai!</b><b>something else</b>"""
+      _ <- myString.onNextIO("hai!") *> IO.cede
+      _ = renderFnCounter shouldBe 2
+      _ = mounts shouldBe List(0, 1)
+      _ = preupdates shouldBe List(0, 0, 0, 0)
+      _ = updates shouldBe List(0, 0, 0, 0)
+      _ = unmounts shouldBe List(0)
+      _ = element.innerHTML shouldBe """<b class="b" id="tier">hai!</b><b>something else</b>"""
 
-      myString.unsafeOnNext("empty")
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3)
-      preupdates shouldBe List(0, 0, 1, 2)
-      updates shouldBe List(0, 0, 1, 2)
-      unmounts shouldBe List(0, 1, 2)
-      element.innerHTML shouldBe """<b>empty</b><b>something else</b>"""
+      _ <- myId.onNextIO("nope") *> IO.cede
+      _ = renderFnCounter shouldBe 2
+      _ = mounts shouldBe List(0, 1)
+      _ = preupdates shouldBe List(0, 0, 0, 0, 1)
+      _ = updates shouldBe List(0, 0, 0, 0, 1)
+      _ = unmounts shouldBe List(0)
+      _ = element.innerHTML shouldBe """<b class="b" id="nope">hai!</b><b>something else</b>"""
 
-      myId.unsafeOnNext("nothing")
-      renderFnCounter shouldBe 3
-      mounts shouldBe List(0, 1, 2, 3)
-      preupdates shouldBe List(0, 0, 1, 2)
-      updates shouldBe List(0, 0, 1, 2)
-      unmounts shouldBe List(0, 1, 2)
-      element.innerHTML shouldBe """<b>empty</b><b>something else</b>"""
+      _ <- myString.onNextIO("empty") *> IO.cede
+      _ = renderFnCounter shouldBe 2
+      _ = mounts shouldBe List(0, 1, 2)
+      _ = preupdates shouldBe List(0, 0, 0, 0, 1)
+      _ = updates shouldBe List(0, 0, 0, 0, 1)
+      _ = unmounts shouldBe List(0, 1)
+      _ = element.innerHTML shouldBe """<b>empty</b><b>something else</b>"""
 
-      myString.unsafeOnNext("hans")
-      renderFnCounter shouldBe 4
-      mounts shouldBe List(0, 1, 2, 3, 4)
-      preupdates shouldBe List(0, 0, 1, 2)
-      updates shouldBe List(0, 0, 1, 2)
-      unmounts shouldBe List(0, 1, 2, 3)
-      element.innerHTML shouldBe """<b id="nothing" class="b">hans</b><b>something else</b>"""
+      _ <- myId.onNextIO("nothing") *> IO.cede
+      _ = renderFnCounter shouldBe 2
+      _ = mounts shouldBe List(0, 1, 2)
+      _ = preupdates shouldBe List(0, 0, 0, 0, 1)
+      _ = updates shouldBe List(0, 0, 0, 0, 1)
+      _ = unmounts shouldBe List(0, 1)
+      _ = element.innerHTML shouldBe """<b>empty</b><b>something else</b>"""
 
-      myId.unsafeOnNext("hans")
-      renderFnCounter shouldBe 4
-      mounts shouldBe List(0, 1, 2, 3, 4)
-      preupdates shouldBe List(0, 0, 1, 2, 4)
-      updates shouldBe List(0, 0, 1, 2, 4)
-      unmounts shouldBe List(0, 1, 2, 3)
-      element.innerHTML shouldBe """<b id="hans" class="b">hans</b><b>something else</b>"""
+      _ <- myString.onNextIO("hans") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 0, 0, 1)
+      _ = updates shouldBe List(0, 0, 0, 0, 1)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="nothing" class="b">hans</b><b>something else</b>"""
 
-      myString.unsafeOnNext("hans")
-      renderFnCounter shouldBe 5
-      mounts shouldBe List(0, 1, 2, 3, 4, 5)
-      preupdates shouldBe List(0, 0, 1, 2, 4)
-      updates shouldBe List(0, 0, 1, 2, 4)
-      unmounts shouldBe List(0, 1, 2, 3, 4)
-      element.innerHTML shouldBe """<b id="hans" class="b">hans</b><b>something else</b>"""
+      _ <- myId.onNextIO("hans") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 0, 0, 1, 3)
+      _ = updates shouldBe List(0, 0, 0, 0, 1, 3)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="hans" class="b">hans</b><b>something else</b>"""
 
-      thunkContent.unsafeOnNext(p(dsl.key := "1", "el dieter"))
-      renderFnCounter shouldBe 5
-      mounts shouldBe List(0, 1, 2, 3, 4, 5)
-      preupdates shouldBe List(0, 0, 1, 2, 4, 5)
-      updates shouldBe List(0, 0, 1, 2, 4, 5)
-      unmounts shouldBe List(0, 1, 2, 3, 4)
-      element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter</p></b><b>something else</b>"""
+      _ <- myString.onNextIO("hans") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 0, 0, 1, 3, 3)
+      _ = updates shouldBe List(0, 0, 0, 0, 1, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="hans" class="b">hans</b><b>something else</b>"""
 
-      thunkContent.unsafeOnNext(p(dsl.key := "2", "el dieter II"))
-      renderFnCounter shouldBe 5
-      mounts shouldBe List(0, 1, 2, 3, 4, 5)
-      preupdates shouldBe List(0, 0, 1, 2, 4, 5, 5)
-      updates shouldBe List(0, 0, 1, 2, 4, 5, 5)
-      unmounts shouldBe List(0, 1, 2, 3, 4)
-      element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter II</p></b><b>something else</b>"""
+      _ <- thunkContent.onNextIO(p(dsl.key := "1", "el dieter")) *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 0, 0, 1, 3, 3, 3)
+      _ = updates shouldBe List(0, 0, 0, 0, 1, 3, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter</p></b><b>something else</b>"""
 
-      myOther.unsafeOnNext(div("baem!"))
-      renderFnCounter shouldBe 5
-      mounts shouldBe List(0, 1, 2, 3, 4, 5)
-      preupdates shouldBe List(0, 0, 1, 2, 4, 5, 5)
-      updates shouldBe List(0, 0, 1, 2, 4, 5, 5)
-      unmounts shouldBe List(0, 1, 2, 3, 4)
-      element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter II</p></b><div>baem!</div><b>something else</b>"""
+      _ <- thunkContent.onNextIO(p(dsl.key := "2", "el dieter II")) *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 0, 0, 1, 3, 3, 3, 3)
+      _ = updates shouldBe List(0, 0, 0, 0, 1, 3, 3, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter II</p></b><b>something else</b>"""
 
-      myInner.unsafeOnNext("meh")
-      renderFnCounter shouldBe 5
-      mounts shouldBe List(0, 1, 2, 3, 4, 5, 6)
-      preupdates shouldBe List(0, 0, 1, 2, 4, 5, 5)
-      updates shouldBe List(0, 0, 1, 2, 4, 5, 5)
-      unmounts shouldBe List(0, 1, 2, 3, 4, 5)
-      element.innerHTML shouldBe """<div>meh</div><div>baem!</div><b>something else</b>"""
+      _ <- myOther.onNextIO(div("baem!")) *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3)
+      _ = preupdates shouldBe List(0, 0, 0, 0, 1, 3, 3, 3, 3)
+      _ = updates shouldBe List(0, 0, 0, 0, 1, 3, 3, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2)
+      _ = element.innerHTML shouldBe """<b id="hans" class="b">hans<p>el dieter II</p></b><div>baem!</div><b>something else</b>"""
 
-      myOther.unsafeOnNext(div("fini"))
-      renderFnCounter shouldBe 5
-      mounts shouldBe List(0, 1, 2, 3, 4, 5, 6)
-      preupdates shouldBe List(0, 0, 1, 2, 4, 5, 5)
-      updates shouldBe List(0, 0, 1, 2, 4, 5, 5)
-      unmounts shouldBe List(0, 1, 2, 3, 4, 5)
-      element.innerHTML shouldBe """<div>meh</div><div>fini</div><b>something else</b>"""
-    }
+      _ <- myInner.onNextIO("meh") *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3, 4)
+      _ = preupdates shouldBe List(0, 0, 0, 0, 1, 3, 3, 3, 3)
+      _ = updates shouldBe List(0, 0, 0, 0, 1, 3, 3, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2, 3)
+      _ = element.innerHTML shouldBe """<div>meh</div><div>baem!</div><b>something else</b>"""
+
+      _ <- myOther.onNextIO(div("fini")) *> IO.cede
+      _ = renderFnCounter shouldBe 3
+      _ = mounts shouldBe List(0, 1, 2, 3, 4)
+      _ = preupdates shouldBe List(0, 0, 0, 0, 1, 3, 3, 3, 3)
+      _ = updates shouldBe List(0, 0, 0, 0, 1, 3, 3, 3, 3)
+      _ = unmounts shouldBe List(0, 1, 2, 3)
+      _ = element.innerHTML shouldBe """<div>meh</div><div>fini</div><b>something else</b>"""
+    } yield succeed
   }
 
-  // TODO: this test does not actually fail if it is wrong, but you just see an error message in the console output. Fix when merging error observable in OutwatchTracing.
   "Nested VNode" should "work without outdated patch" in {
     val myList: Subject[List[String]] = Subject.behavior[List[String]](List("hi"))
     val isSynced: Subject[Int] = Subject.behavior[Int](-1)
@@ -3534,15 +3462,18 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       )
     )
 
+    val errors = mutable.ArrayBuffer[Throwable]()
+    OutwatchTracing.error.unsafeForeach(errors += _)
+
     Outwatch.renderInto[IO]("#app", node).flatMap { _ =>
       val editButton = document.getElementById("edit-button")
 
       for {
-        _ <- IO.unit
-        _ = sendEvent(editButton, "click")
+        _ <- IO(sendEvent(editButton, "click")) *> IO.cede
         _ <- IO.sleep(1.seconds)
-        _ = sendEvent(editButton, "click")
+        _ <- IO(sendEvent(editButton, "click")) *> IO.cede
         _ <- IO.sleep(1.seconds)
+        _ = errors.toList shouldBe List.empty
       } yield succeed
     }
   }
@@ -3756,26 +3687,28 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       )
     )
 
-    Outwatch.renderInto[SyncIO]("#app", node).unsafeRunSync()
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-    insertedFirst shouldBe 0
-    mountedFirst shouldBe 0
-    insertedSecond shouldBe 1
-    mountedSecond shouldBe 1
+      _ = insertedFirst shouldBe 0
+      _ = mountedFirst shouldBe 0
+      _ = insertedSecond shouldBe 1
+      _ = mountedSecond shouldBe 1
 
-    otherDiv.unsafeOnNext(div())
+      _ <- otherDiv.onNextIO(div()) *> IO.cede
 
-    insertedFirst shouldBe 1
-    mountedFirst shouldBe 1
-    insertedSecond shouldBe 1
-    mountedSecond shouldBe 1
+      _ = insertedFirst shouldBe 1
+      _ = mountedFirst shouldBe 1
+      _ = insertedSecond shouldBe 1
+      _ = mountedSecond shouldBe 1
 
-    otherDiv.unsafeOnNext(div("hallo"))
+      _ <- otherDiv.onNextIO(div("hallo")) *> IO.cede
 
-    insertedFirst shouldBe 1
-    mountedFirst shouldBe 2
-    insertedSecond shouldBe 1
-    mountedSecond shouldBe 1
+      _ = insertedFirst shouldBe 1
+      _ = mountedFirst shouldBe 2
+      _ = insertedSecond shouldBe 1
+      _ = mountedSecond shouldBe 1
+    } yield succeed
   }
 
 
@@ -3802,25 +3735,27 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       ))
     )
 
-    Outwatch.renderInto[SyncIO]("#app", node).unsafeRunSync()
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
 
-    insertedFirst shouldBe 0
-    mountedFirst shouldBe 0
-    insertedSecond shouldBe 1
-    mountedSecond shouldBe 1
+      _ = insertedFirst shouldBe 0
+      _ = mountedFirst shouldBe 0
+      _ = insertedSecond shouldBe 1
+      _ = mountedSecond shouldBe 1
 
-    otherDiv.unsafeOnNext(Some(div()))
+      _ <- otherDiv.onNextIO(Some(div())) *> IO.cede
 
-    insertedFirst shouldBe 0
-    mountedFirst shouldBe 1
-    insertedSecond shouldBe 2
-    mountedSecond shouldBe 2
+      _ = insertedFirst shouldBe 0
+      _ = mountedFirst shouldBe 1
+      _ = insertedSecond shouldBe 2
+      _ = mountedSecond shouldBe 2
 
-    otherDiv.unsafeOnNext(Some(div("hallo")))
+      _ <- otherDiv.onNextIO(Some(div("hallo"))) *> IO.cede
 
-    insertedFirst shouldBe 0
-    mountedFirst shouldBe 2
-    insertedSecond shouldBe 2
-    mountedSecond shouldBe 3
+      _ = insertedFirst shouldBe 0
+      _ = mountedFirst shouldBe 2
+      _ = insertedSecond shouldBe 2
+      _ = mountedSecond shouldBe 3
+    } yield succeed
   }
 }

--- a/tests/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/tests/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -100,7 +100,7 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
 
     emitters.get.values.size shouldBe 1
     attrs.get.values.size shouldBe 2
-    streamable.subscribables.calculateLength() shouldBe 0
+    streamable.subscribables.toFlatArray.filterNot(_.isEmpty()).length shouldBe 0
     proxies.get.length shouldBe 3
   }
 
@@ -130,7 +130,7 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
 
     emitters.get.values.size shouldBe 1
     attrs.get.values.size shouldBe 2
-    streamable.subscribables.calculateLength() shouldBe 2
+    streamable.subscribables.toFlatArray.filterNot(_.isEmpty()).length shouldBe 2
     proxies.get.length shouldBe 3
   }
 
@@ -152,7 +152,7 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
 
     emitters.get.values.size shouldBe 3
     attrs.get.values.size shouldBe 1
-    streamable.subscribables.calculateLength() shouldBe 1
+    streamable.subscribables.toFlatArray.filterNot(_.isEmpty()).length shouldBe 1
     proxies.get.length shouldBe 2
   }
 
@@ -175,7 +175,7 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
 
     emitters.get.values.size shouldBe 3
     attrs.get.values.size shouldBe 1
-    streamable.subscribables.calculateLength() shouldBe 1
+    streamable.subscribables.toFlatArray.filterNot(_.isEmpty()).length shouldBe 1
     proxies.get.length shouldBe 2
   }
 
@@ -209,7 +209,7 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     destroyHook.isDefined shouldBe false
     attrs.get.values.size shouldBe 1
     keyOption.isEmpty shouldBe true
-    streamable.subscribables.calculateLength() shouldBe 2
+    streamable.subscribables.toFlatArray.filterNot(_.isEmpty()).length shouldBe 2
     proxies.get.length shouldBe 1
   }
 
@@ -295,7 +295,7 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     import seps._
 
     proxies.get.length shouldBe 4
-    streamable.subscribables.calculateLength() shouldBe 0
+    streamable.subscribables.toFlatArray.filterNot(_.isEmpty()).length shouldBe 0
 
     val proxy = SnabbdomOps.toSnabbdom(div(mods), RenderConfig.ignoreError)
     proxy.key.isDefined shouldBe false
@@ -324,7 +324,7 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     import seps._
 
     proxies.get.length shouldBe 4
-    streamable.subscribables.calculateLength() shouldBe 1
+    streamable.subscribables.toFlatArray.filterNot(_.isEmpty()).length shouldBe 1
 
     val proxy = SnabbdomOps.toSnabbdom(div(mods), RenderConfig.ignoreError)
     proxy.key.isDefined shouldBe false
@@ -352,7 +352,7 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
     import seps._
 
     proxies.get.length shouldBe 1
-    streamable.subscribables.calculateLength() shouldBe 1
+    streamable.subscribables.toFlatArray.filterNot(_.isEmpty()).length shouldBe 1
 
     val proxy = SnabbdomOps.toSnabbdom(div(mods), RenderConfig.ignoreError)
     proxy.key.toOption  shouldBe Some(1234)

--- a/tests/src/test/scala/outwatch/OutwatchSpec.scala
+++ b/tests/src/test/scala/outwatch/OutwatchSpec.scala
@@ -6,16 +6,8 @@ import org.scalajs.dom.{Event, document, window}
 import org.scalatest.{BeforeAndAfterEach, _}
 import org.scalatest.flatspec.{AnyFlatSpec, AsyncFlatSpec}
 import org.scalatest.matchers.should.Matchers
-import colibri._
 
-import scala.concurrent.{ExecutionContext, Future}
-
-trait EasySubscribe {
-
-  implicit class Subscriber[T](obs: Observable[T]) {
-    def apply(next: T => Unit): Cancelable = obs.unsafeForeach(next)
-  }
-}
+import scala.concurrent.Future
 
 trait LocalStorageMock {
   import scala.scalajs.js
@@ -37,7 +29,7 @@ trait LocalStorageMock {
   }
 }
 
-trait OutwatchSpec extends Matchers with BeforeAndAfterEach with EasySubscribe with LocalStorageMock { self: Suite =>
+trait OutwatchSpec extends Matchers with BeforeAndAfterEach with LocalStorageMock { self: Suite =>
   override def beforeEach(): Unit = {
 
     document.body.innerHTML = ""
@@ -59,10 +51,10 @@ abstract class JSDomAsyncSpec extends AsyncFlatSpec with OutwatchSpec {
   // implicit private val ioRuntime: unsafe.IORuntime = unsafe.IORuntime.global
 
   // ExecutionContext.parasitic only exists in scala 2.13. Not 2.12.
-  override val executionContext = new ExecutionContext {
-    override final def execute(runnable: Runnable): Unit = runnable.run()
-    override final def reportFailure(t: Throwable): Unit = ExecutionContext.defaultReporter(t)
-  }
+  override val executionContext = scala.scalajs.concurrent.QueueExecutionContext()
+    // override final def execute(runnable: Runnable): Unit = runnable.run()
+    // override final def reportFailure(t: Throwable): Unit = ExecutionContext.defaultReporter(t)
+  // }
 
   implicit val ioRuntime = unsafe.IORuntime(
     compute = executionContext,

--- a/tests/src/test/scala/outwatch/ScenarioTestSpec.scala
+++ b/tests/src/test/scala/outwatch/ScenarioTestSpec.scala
@@ -7,6 +7,7 @@ import outwatch.dsl._
 import org.scalajs.dom.EventInit
 import colibri._
 import outwatch.util._
+import cats.implicits._
 
 class ScenarioTestSpec extends JSDomAsyncSpec {
 
@@ -16,7 +17,7 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
 
   "A simple counter application" should "work as intended" in {
 
-    val test: IO[Assertion] = for {
+    for {
        handlePlus <- IO(Subject.replayLatest[MouseEvent]())
       handleMinus <- IO(Subject.replayLatest[MouseEvent]())
           plusOne = handlePlus.map(_ => 1)
@@ -43,19 +44,18 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
                 _ <- IO {
                       getCounter.innerHTML shouldBe 0.toString
                       getMinus.dispatchEvent(event)
+                    }
+                _ <- IO.cede
+                _ <- IO {
                       getCounter.innerHTML shouldBe (-1).toString
                     }
-                as <- IO {
-                      (0 to 10).map { _ =>
-                        getPlus.dispatchEvent(event)
-                        getCounter.innerHTML
-                     }}
+
+                as <- (0 to 10).toList.traverse { _ =>
+                      IO(getPlus.dispatchEvent(event)) *> IO.cede *> IO(getCounter.innerHTML)
+                    }
     } yield {
       as should contain theSameElementsInOrderAs (0 to 10).map(_.toString)
     }
-
-    test
-
   }
 
 
@@ -73,7 +73,7 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
       case (state, Plus) => state.copy(state.count + 1, state.iterations + 1)
       case (state, Minus) => state.copy(state.count - 1, state.iterations + 1)
     }
-  
+
     val node: IO[VNode] = for {
       store <- Store.create[IO, CounterAction, CounterModel](Initial, CounterModel(0, 0), reduce)
       state = store.collect { case (action@_, state) => state }
@@ -92,7 +92,7 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
 
     def getIterations: Element = document.getElementById("iterations")
 
-    val test: IO[Assertion] = for {
+    for {
       r <- IO {
             val root = document.createElement("div")
             document.body.appendChild(root)
@@ -109,25 +109,24 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
       _ <- IO {
             getCounter.innerHTML shouldBe 0.toString
             getIterations.innerHTML shouldBe 0.toString
-
+          }
+      _ <- IO {
             getMinus.dispatchEvent(e)
+          }
+      _ <- IO.cede
 
+      _ <- IO {
             getCounter.innerHTML shouldBe (-1).toString
             getIterations.innerHTML shouldBe 1.toString
-      }
-      as <- IO {
-            (0 to 10).map { _ =>
-              getPlus.dispatchEvent(e)
-              getCounter.innerHTML
-           }}
+          }
+      as <- (0 to 10).toList.traverse { _ =>
+            IO(getPlus.dispatchEvent(e)) *> IO.cede *> IO(getCounter.innerHTML)
+          }
 
     } yield {
       as should contain theSameElementsInOrderAs (0 to 10).map(_.toString)
       getIterations.innerHTML shouldBe 12.toString
     }
-
-    test
-
   }
 
   "A simple name application" should "work as intended" in {
@@ -136,10 +135,10 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
     val name1 = "Luka"
     val name2 = "Peter"
 
-    def getGreeting(evt: Event, name: String): IO[String] = IO {
+    def getGreeting(evt: Event, name: String): IO[Unit] = IO {
       document.getElementById("input").asInstanceOf[html.Input].value = name
       document.getElementById("input").dispatchEvent(evt)
-      document.getElementById("greeting").innerHTML
+      ()
     }
 
     def assertGreeting(greeting: String, name: String): Assertion =
@@ -154,7 +153,7 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
       )
     }
 
-    val test: IO[Assertion] = for {
+    for {
           r <- IO {
                 val root = document.createElement("div")
                 document.body.appendChild(root)
@@ -168,14 +167,14 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
                   cancelable = true
                 })
               }
-          g1 <- getGreeting(event, name1)
-          g2 <- getGreeting(event, name2)
+          _ <- getGreeting(event, name1) *> IO.cede
+          g1 <- IO(document.getElementById("greeting").innerHTML)
+          _ <- getGreeting(event, name2) *> IO.cede
+          g2 <- IO(document.getElementById("greeting").innerHTML)
            _ = assertGreeting(g1, name1)
            _ = assertGreeting(g2, name2)
 
     } yield succeed
-
-    test
   }
 
   "A component" should "be referential transparent" in {
@@ -197,7 +196,7 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
     val component1 = div(component(), component())
     val component2 = div(comp, comp)
 
-    val test: IO[Assertion] = for {
+    for {
       evt <- IO {
         new Event("click", new EventInit {
           bubbles = true
@@ -212,11 +211,10 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
              getButton(e1).dispatchEvent(evt)
              getButton(e2).dispatchEvent(evt)
            }
+       _ <- IO.cede
        _ = e1.innerHTML shouldBe e1.innerHTML
 
     } yield succeed
-
-    test
   }
 
   "A todo application" should "work with components" in {
@@ -280,7 +278,7 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
         ul(idAttr := "list", state)
       )
 
-    val test: IO[Assertion] = for {
+    for {
 
       root <- IO {
         val root = document.createElement("div")
@@ -317,6 +315,9 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
         submitBtn.dispatchEvent(clickEvt)
         todo
       }
+
+      _ <- IO.cede
+
       _ = list.childElementCount shouldBe 1
 
       t2 <- IO {
@@ -326,6 +327,9 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
         submitBtn.dispatchEvent(clickEvt)
         todo2
       }
+
+      _ <- IO.cede
+
       _ = list.childElementCount shouldBe 2
 
       t3 <- IO {
@@ -335,20 +339,23 @@ class ScenarioTestSpec extends JSDomAsyncSpec {
         submitBtn.dispatchEvent(clickEvt)
         todo3
       }
+
+      _ <- IO.cede
+
       _ = list.childElementCount shouldBe 3
 
       _ <- IO(document.getElementById(t2).dispatchEvent(clickEvt))
+      _ <- IO.cede
       _ = list.childElementCount shouldBe 2
 
       _ <- IO(document.getElementById(t3).dispatchEvent(clickEvt))
+      _ <- IO.cede
       _ = list.childElementCount shouldBe 1
 
       _ <- IO(document.getElementById(t).dispatchEvent(clickEvt))
+      _ <- IO.cede
       _ = list.childElementCount shouldBe 0
 
     } yield succeed
-
-    test
-
   }
 }

--- a/tests/src/test/scala/outwatch/SnabbdomSpec.scala
+++ b/tests/src/test/scala/outwatch/SnabbdomSpec.scala
@@ -85,12 +85,15 @@ class SnabbdomSpec extends JSDomAsyncSpec {
 
              btn <- IO(document.getElementById("btn"))
 
-              ie <- IO {
+              _  <- IO {
                     inputElement().value = "Something"
                     inputElement().dispatchEvent(inputEvt)
                     btn.dispatchEvent(clickEvt)
-                    inputElement().value
                   }
+
+              _  <- IO.cede
+
+              ie <- IO(inputElement().value)
                _ = ie shouldBe ""
 
       } yield succeed
@@ -117,9 +120,9 @@ class SnabbdomSpec extends JSDomAsyncSpec {
             )
           _ <- Outwatch.renderInto[IO]("#app", vtree)
           c1 <- getContent
-           _ <- a.onNextIO(1)
+          _  <- a.onNextIO(1) *> IO.cede
           c2 <- getContent
-           _ <- b.onNextIO(200)
+          _  <- b.onNextIO(200) *> IO.cede
           c3 <- getContent
     } yield {
       c1 shouldBe """0<div id="meh">100</div>"""


### PR DESCRIPTION
The main change is to move snabbdom patching into a micro task (currently running synchronously). Now it would run async but before any rendering or dom events. See about event loops in javascript: https://javascript.info/event-loop

I owe this idea to @armanbilge. Thank you so much :)

The advantages:
- We will gather all observable triggers (even from nested observables) before the first render -> this circumvents triggering multiple succeeding patch calls inside one transcation.
- Multiple observables inside one node only do one patch call!
- In diamond cases, we will not render invalid state -> no (visible) frp glitches!
- Promise-based modifiers can still be captured inside the initial render and do not need an additional patch.
- When triggering from an emitter builder, we do not render inside the event callback - which becomes potentially long-running.

The disadvantages:
- Had to rewrite a lot of tests 😵‍💫 
