### PR TITLE
feat: add implicit to render show instances

### DIFF
--- a/outwatch/src/main/scala/outwatch/Render.scala
+++ b/outwatch/src/main/scala/outwatch/Render.scala
@@ -1,5 +1,6 @@
 package outwatch
 
+import cats.Show
 import colibri._
 import colibri.effect._
 import cats.data.{NonEmptyChain, NonEmptyList, NonEmptySeq, NonEmptyVector}
@@ -42,6 +43,11 @@ trait RenderLowPrio0 extends RenderLowPrio1 {
 
 trait RenderLowPrio extends RenderLowPrio0 {
   import RenderOps._
+
+  @inline implicit def ShowRenderAs[T: Show]: Render[T] = new ShowRenderAsClass[T]
+  @inline private class ShowRenderAsClass[T: Show] extends Render[T] {
+    @inline def render(value: T): VModifier = StringVNode(Show[T].show(value))
+  }
 
   @inline implicit def JsArrayModifierAs[T: Render]: Render[js.Array[T]] = new JsArrayRenderAsClass[T]
   @inline private class JsArrayRenderAsClass[T: Render] extends Render[js.Array[T]] {

--- a/tests/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/tests/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -1,10 +1,10 @@
 package outwatch
 
-import cats.Monoid
+import cats.{Monoid, Show}
 import cats.implicits._
 import cats.effect.{IO, SyncIO}
 import org.scalajs.dom.window.localStorage
-import org.scalajs.dom.{document, html, Element, Event}
+import org.scalajs.dom.{Element, Event, document, html}
 import outwatch.helpers._
 import outwatch.dsl._
 import snabbdom.{DataObject, Hooks, VNodeProxy}
@@ -3992,6 +3992,27 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
       _ <- IO.cede
 
       _ = element.innerHTML shouldBe """<div style="">hallo2</div>"""
+    } yield succeed
+  }
+
+  it should "render types that have a `Render` and a `Show` implementation using `Render`" in {
+    case class Foo(bar: String)
+    object Foo {
+      implicit val renderFoo: Render[Foo] = (foo: Foo) => span(foo.bar)
+      implicit val showFoo: Show[Foo] = (foo: Foo) => foo.bar
+    }
+
+    val node = div(
+      idAttr := "test",
+      Foo("foo"),
+    )
+
+    for {
+      _ <- Outwatch.renderInto[IO]("#app", node)
+
+      element <- IO(document.getElementById("test"))
+
+      _ = element.innerHTML shouldBe """<span>foo</span>"""
     } yield succeed
   }
 }


### PR DESCRIPTION
Also includes a test for the implicit order.  

Unfortunately tests won't run on my machine since `node-gyp` is acting up as per usual, so I may need to make some changes to the implicit order once the github tests are done.