### PR TITLE
remove js.undefined render instances to not render Unit

### DIFF
--- a/outwatch/src/main/scala/outwatch/Render.scala
+++ b/outwatch/src/main/scala/outwatch/Render.scala
@@ -20,15 +20,6 @@ trait Render[-T] {
 trait RenderLowPrio1 {
   import RenderOps._
 
-  @inline implicit def UndefinedModifierAs[T: Render]: Render[js.UndefOr[T]] = new UndefinedRenderAsClass[T]
-  @inline private class UndefinedRenderAsClass[T: Render] extends Render[js.UndefOr[T]] {
-    @inline def render(value: js.UndefOr[T]) = undefinedToModifierRender(value)
-  }
-
-  implicit object UndefinedModifier extends Render[js.UndefOr[VMod]] {
-    @inline def render(value: js.UndefOr[VMod]): VMod = value.getOrElse(VMod.empty)
-  }
-
   implicit object SyncIOUnitRender extends Render[SyncIO[Unit]] {
     @inline def render(effect: SyncIO[Unit]) = VMod.managedSubscribe(Observable.fromEffect(effect))
   }

--- a/outwatch/src/main/scala/outwatch/Render.scala
+++ b/outwatch/src/main/scala/outwatch/Render.scala
@@ -1,13 +1,10 @@
 package outwatch
 
-import colibri.{Cancelable, Observable}
-import cats.effect.{unsafe, IO}
-
 import colibri._
 import colibri.effect._
 import cats.Show
 import cats.data.{Chain, NonEmptyChain, NonEmptyList, NonEmptySeq, NonEmptyVector}
-import cats.effect.{IO, Resource, Sync, SyncIO}
+import cats.effect.{unsafe, IO, Resource, Sync, SyncIO}
 
 import scala.scalajs.js
 import scala.concurrent.Future
@@ -20,19 +17,11 @@ trait Render[-T] {
 trait RenderLowPrio1 {
   import RenderOps._
 
-  implicit object SyncIOUnitRender extends Render[SyncIO[Unit]] {
-    @inline def render(effect: SyncIO[Unit]) = VMod.managedSubscribe(Observable.fromEffect(effect))
-  }
-
-  implicit object IOUnitRender extends Render[IO[Unit]] {
+  implicit val IOUnitRender: Render[IO[Unit]] = new Render[IO[Unit]] {
     @inline def render(effect: IO[Unit]) = VMod.managedSubscribe(Observable.fromEffect(effect))
   }
 
-  implicit object SyncIORender extends Render[SyncIO[VMod]] {
-    @inline def render(future: SyncIO[VMod]) = syncToModifier(future)
-  }
-
-  implicit object IORender extends Render[IO[VMod]] {
+  implicit val IORender: Render[IO[VMod]] = new Render[IO[VMod]] {
     @inline def render(effect: IO[VMod]) = effectToModifier(effect)
   }
 }
@@ -50,6 +39,10 @@ trait RenderLowPrio0 extends RenderLowPrio1 {
     @inline def render(effect: F[T]) = effectToModifierRender(effect)
   }
 
+  implicit val SyncIOUnitRender: Render[SyncIO[Unit]] = new Render[SyncIO[Unit]] {
+    @inline def render(effect: SyncIO[Unit]) = VMod.managedSubscribe(Observable.fromEffect(effect))
+  }
+
   @inline implicit def IOUnitRenderIORuntime(implicit ioRuntime: unsafe.IORuntime): Render[IO[Unit]] =
     new IOUnitRenderIORuntimeClass
   @inline private class IOUnitRenderIORuntimeClass(implicit ioRuntime: unsafe.IORuntime) extends Render[IO[Unit]] {
@@ -61,7 +54,7 @@ trait RenderLowPrio0 extends RenderLowPrio1 {
     @inline def render(source: F[Unit]) = VMod.managedSubscribe(Observable.fromEffect(source))
   }
 
-  implicit object ObservableUnitRender extends Render[Observable[Unit]] {
+  implicit val ObservableUnitRender: Render[Observable[Unit]] = new Render[Observable[Unit]] {
     @inline def render(source: Observable[Unit]) = VMod.managedSubscribe(source)
   }
 
@@ -227,6 +220,10 @@ object Render extends RenderLowPrio {
 
   implicit object BooleanRender extends Render[Boolean] {
     @inline def render(value: Boolean): VMod = StringVNode(value.toString)
+  }
+
+  implicit object SyncIORender extends Render[SyncIO[VMod]] {
+    @inline def render(future: SyncIO[VMod]) = syncToModifier(future)
   }
 
   @inline implicit def IORenderIORuntime(implicit ioRuntime: unsafe.IORuntime): Render[IO[VMod]] =

--- a/tests/src/test/scala/outwatch/AttributeSpec.scala
+++ b/tests/src/test/scala/outwatch/AttributeSpec.scala
@@ -286,8 +286,6 @@ class AttributeSpec extends JSDomSpec {
   }
 
   "emitterbuilder" should "should work as attribute function" in {
-    import outwatch.dsl.svg._
-
     var triggered = 0
     val node = SnabbdomOps.toSnabbdom(
       button(

--- a/tests/src/test/scala/outwatch/OutWatchDomSpec.scala
+++ b/tests/src/test/scala/outwatch/OutWatchDomSpec.scala
@@ -3,7 +3,6 @@ package outwatch
 import cats.{Monoid, Show}
 import cats.implicits._
 import cats.effect.{IO, SyncIO}
-import org.scalajs.dom.window.localStorage
 import org.scalajs.dom.{document, html, Element, Event}
 import outwatch.helpers._
 import outwatch.dsl._
@@ -3962,8 +3961,6 @@ class OutwatchDomSpec extends JSDomAsyncSpec {
   }
 
   "Component" should "render unit observables and effects" in {
-    import scala.concurrent.duration._
-
     case class MyObservable[T](observable: Observable[T])
     object MyObservable {
       implicit object source extends Source[MyObservable] {


### PR DESCRIPTION
I am not sure why, but otherwise this implicit instance allows us to render a `()`, which we do not want. So, currently, you always have to convert a `js.UndefOr` with `toOption` to render it.